### PR TITLE
Updating aiohttp in requirements.txt

### DIFF
--- a/caldera/requirements.txt
+++ b/caldera/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.18.4
 pyyaml==3.12
 pymongo==3.5.1
-aiohttp==2.3.2
+aiohttp==2.3.8
 aiohttp_jinja2==0.14.0
 cryptography==2.1.3
 itsdangerous==0.24


### PR DESCRIPTION
While attempting to install Caldera, I ran into this exact issue with Aiohttp -- it appears to be a very recent change: https://github.com/aio-libs/yarl/issues/161

```
  File "caldera.py", line 16, in <module>
    from app import server
  File "/home/vagrant/caldera/caldera/app/server.py", line 13, in <module>
    from aiohttp import web, WSCloseCode
  File "/usr/local/lib/python3.5/dist-packages/aiohttp/web.py", line 15, in <module>
    from . import (hdrs, web_exceptions, web_fileresponse, web_middlewares,
  File "/usr/local/lib/python3.5/dist-packages/aiohttp/web_middlewares.py", line 5, in <module>
    from aiohttp.web_urldispatcher import SystemRoute
  File "/usr/local/lib/python3.5/dist-packages/aiohttp/web_urldispatcher.py", line 20, in <module>
    from yarl import URL, unquote
```

Updating aiohttp to 2.3.8 fixed the issue for me.