### PR TITLE
added config to change bind address for terminal & docker-compose file

### DIFF
--- a/conf/local.yml
+++ b/conf/local.yml
@@ -2,6 +2,7 @@
 
 host: 127.0.0.1
 port: 8888
+terminal_host: 127.0.0.1
 terminal_port: 8880
 debug_level: DEBUG
 planner: plugins.stockpile.app.sequential

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  caldera:
+    image: python:3
+
+    expose:
+    - "8880"
+    - "8888"
+
+    ports:
+      - "8880:8880"
+      - "8888:8888"
+    working_dir: /usr/src/app
+
+    volumes:
+      - $PWD:/usr/src/app
+
+    command: /bin/bash -c "pip install --no-cache-dir -r requirements.txt && python server.py -E local"
+
+
+# docker run -it --name caldera2 -p 8880:8880 -p 8888:8888 -v "$PWD":/usr/src/app -w /usr/src/app python:3 /bin/bash -c "pip install --no-cache-dir -r requirements.txt && python server.py -E local"

--- a/server.py
+++ b/server.py
@@ -59,12 +59,12 @@ async def init(address, port, services, users):
     await web.TCPSite(runner, address, port, ssl_context=context).start()
 
 
-def main(services, host, port, terminal_port, users):
+def main(services, host, port, terminal_host, terminal_port, users):
     loop = asyncio.get_event_loop()
     loop.run_until_complete(init(host, port, services, users))
     try:
         loc = dict(services=services)
-        with aiomonitor.start_monitor(loop=loop, monitor=TerminalApp, port=terminal_port, locals=loc):
+        with aiomonitor.start_monitor(loop=loop, monitor=TerminalApp, host=terminal_host, port=terminal_port, locals=loc):
             logging.debug('Starting CALDERA at %s:%s' % (host, port))
             loop.run_forever()
     except KeyboardInterrupt:
@@ -102,4 +102,4 @@ if __name__ == '__main__':
             data_svc=data_svc, auth_svc=auth_svc, utility_svc=utility_svc, operation_svc=operation_svc,
             logger=Logger('plugin'), plugins=plugin_modules
         )
-        main(services=services, host=config['host'], port=config['port'], terminal_port=config['terminal_port'], users=config['users'])
+        main(services=services, host=config['host'], port=config['port'], terminal_host=config['terminal_host'], terminal_port=config['terminal_port'], users=config['users'])


### PR DESCRIPTION
In order for the API to be publicly accessible, I added a `terminal_host` variable to the conf/local.yml file that is interpreted by server.py. By setting the `terminal_host` variable to `0.0.0.0`, users can access the API remotely.