### PR TITLE
set_id and link_id are compared and double the score if they are the same

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -78,7 +78,7 @@ class PlanningService:
             variable_facts = []
             for fact in facts:
                 if fact['property'] == v:
-                    variable_facts.append((fact['property'], fact['value'], fact['score'], fact['id'], fact['set_id'], fact['link_id']))
+                    variable_facts.append(fact)
             relevant_facts.append(variable_facts)
         return relevant_facts
 
@@ -95,12 +95,12 @@ class PlanningService:
         """
         score, rewards, combo_set_id, combo_link_id = 0, [], set(), set()
         for var in combo:
-            score += (score + var[2])
-            combo_set_id.add(var[4])
-            combo_link_id.add(var[5])
-            rewards.append(var[3])
-            copy_test = copy_test.replace('#{%s}' % var[0], var[1])
-            clean_test = clean_test.replace('#{%s}' % var[0], var[1])
+            score += (score + var['score'])
+            combo_set_id.add(var['set_id'])
+            combo_link_id.add(var['link_id'])
+            rewards.append(var['id'])
+            copy_test = copy_test.replace('#{%s}' % var['property'], var['value'])
+            clean_test = clean_test.replace('#{%s}' % var['property'], var['value'])
         score = PlanningService._reward_fact_relationship(combo_set_id, combo_link_id, score)
         return copy_test, clean_test, score, rewards
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -83,6 +83,12 @@ class PlanningService:
         return relevant_facts
 
     @staticmethod
+    def _reward_fact_relationship(combo_set, combo_link, score):
+        if len(combo_set) == 1 and len(combo_link) == 1:
+            score *= 2
+        return score
+
+    @staticmethod
     async def _build_single_test_variant(copy_test, clean_test, combo):
         """
         Replace all variables with facts from the combo to build a single test variant
@@ -95,8 +101,7 @@ class PlanningService:
             rewards.append(var[3])
             copy_test = copy_test.replace('#{%s}' % var[0], var[1])
             clean_test = clean_test.replace('#{%s}' % var[0], var[1])
-        if len(combo_set_id) == 1 and len(combo_link_id) == 1:
-            score*=2
+        score = PlanningService.reward_fact_relationship(combo_set_id, combo_link_id, score)
         return copy_test, clean_test, score, rewards
 
     async def _apply_stealth(self, operation, agent, decoded_test):

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -78,7 +78,7 @@ class PlanningService:
             variable_facts = []
             for fact in facts:
                 if fact['property'] == v:
-                    variable_facts.append((fact['property'], fact['value'], fact['score'], fact['id']))
+                    variable_facts.append((fact['property'], fact['value'], fact['score'], fact['id'], fact['set_id'], fact['link_id']))
             relevant_facts.append(variable_facts)
         return relevant_facts
 
@@ -87,12 +87,16 @@ class PlanningService:
         """
         Replace all variables with facts from the combo to build a single test variant
         """
-        score, rewards = 0, []
+        score, rewards, combo_set_id, combo_link_id = 0, [], set(), set()
         for var in combo:
             score += (score + var[2])
+            combo_set_id.add(var[4])
+            combo_link_id.add(var[5])
             rewards.append(var[3])
             copy_test = copy_test.replace('#{%s}' % var[0], var[1])
             clean_test = clean_test.replace('#{%s}' % var[0], var[1])
+        if len(combo_set_id) == 1 and len(combo_link_id) == 1:
+            score*=2
         return copy_test, clean_test, score, rewards
 
     async def _apply_stealth(self, operation, agent, decoded_test):

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -101,7 +101,7 @@ class PlanningService:
             rewards.append(var[3])
             copy_test = copy_test.replace('#{%s}' % var[0], var[1])
             clean_test = clean_test.replace('#{%s}' % var[0], var[1])
-        score = PlanningService.reward_fact_relationship(combo_set_id, combo_link_id, score)
+        score = PlanningService._reward_fact_relationship(combo_set_id, combo_link_id, score)
         return copy_test, clean_test, score, rewards
 
     async def _apply_stealth(self, operation, agent, decoded_test):


### PR DESCRIPTION
This PR is in regards to supporting multifact relationships and groups. The idea is that facts that are collected together should be prioritized higher by the planner. For example, if fact A and fact B are a possible combination to be grounded into an ability, the planner will check if A.set_id = B.set_id and A.link_id = B.link_id. If so, the score is doubled. 