### PR TITLE
introduction of "private" facts

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -95,7 +95,7 @@ class PlanningService:
             variable_facts = []
             for fact in facts:
                 if fact['property'] == v:
-                    if "private" in fact['property']:
+                    if 'private' in fact['property']:
                         if fact['id'] in private_facts:
                             variable_facts.append(fact)
                     else:

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -59,7 +59,8 @@ class PlanningService:
 
             variables = re.findall(r'#{(.*?)}', decoded_test, flags=re.DOTALL)
             if variables:
-                relevant_facts = await self._build_relevant_facts(variables, operation.get('facts', []))
+                private_facts = await self._explode_private_facts(operation['id'], agent['id'])
+                relevant_facts = await self._build_relevant_facts(variables, operation.get('facts', []), private_facts)
                 for combo in list(itertools.product(*relevant_facts)):
                     copy_test = copy.deepcopy(decoded_test)
                     copy_link = copy.deepcopy(link)
@@ -84,7 +85,7 @@ class PlanningService:
         return score
 
     @staticmethod
-    async def _build_relevant_facts(variables, facts):
+    async def _build_relevant_facts(variables, facts, private_facts):
         """
         Create a list of ([fact, value, score]) tuples for each variable/fact
         """
@@ -94,7 +95,11 @@ class PlanningService:
             variable_facts = []
             for fact in facts:
                 if fact['property'] == v:
-                    variable_facts.append(fact)
+                    if "private" in fact['property']:
+                        if fact['id'] in private_facts:
+                            variable_facts.append(fact)
+                    else:
+                        variable_facts.append(fact)
             relevant_facts.append(variable_facts)
         return relevant_facts
 
@@ -123,3 +128,20 @@ class PlanningService:
         if not operation['cleanup']:
             for link in links:
                 link['cleanup'] = None
+
+    async def _explode_private_facts(self, op_id, agent_id):
+        """
+        Only select the id of the agent's collected facts during the operation
+        """
+        sql = """
+        SELECT 
+            b.id 
+        FROM core_chain a 
+            JOIN (SELECT id, link_id FROM core_fact GROUP BY id) b 
+              ON a.id=b.link_id 
+        WHERE 
+            a.op_id = %s AND a.host_id = %s;
+        """ % (op_id, agent_id)
+        private_facts =  await self.data_svc.dao.raw_select(sql)
+        pf_list = [pf['id'] for pf in private_facts]
+        return pf_list


### PR DESCRIPTION
The private facts allow in operations with multiple agents to use, in certain phases of the attack, only the facts previously collected by the specific agent and not by all the agents of the operation.
This is possible using the word "private" (eg  #{host.file.sensitive.private} ) in the name assigned to the fact.

I will update the stockpile plugin with some tests on private facts.