### PR TITLE
introduction of 'private' facts

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -133,6 +133,9 @@ class PlanningService:
         """
         Collect a list of this agent's facts
         """
+        agent_facts = []
         for link in await self.data_svc.dao.get('core_chain', criteria=dict(op_id=op_id, host_id=agent_id)):
             facts = await self.data_svc.dao.get('core_fact', criteria=dict(link_id=link['id']))
-            return [f['id'] for f in facts]
+            for f in facts:
+                agent_facts.append(f['id'])
+        return agent_facts


### PR DESCRIPTION
The private facts allow in operations with multiple agents to use, in certain phases of the attack, only the facts previously collected by the specific agent and not by all the agents of the operation.
This is possible using the word "private" (eg #{host.file.sensitive.private} ) in the name assigned to the fact.

In this process I no longer use the "raw_select" from the data_svc DAO object, but I still use the "get" from the DAO object.
A solution to completely avoid the direct use of the DAO object is to introduce a sort of "explodes_private_facts" method in data_svc.

Note: I also made a pull request for the stockpile plugin in which I replaced the fact name '# {host.file.sensitive}' with '# {host.file.sensitive.private}' in any abilities which are using it. Thus the adversary "File Hunter" is a good example of using private facts.


