### PR TITLE
parameters for custom planners

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -175,7 +175,6 @@ class DataService:
 
     async def explode_planners(self, criteria=None):
         planners = await self.dao.get('core_planner', criteria=criteria)
-        # De-serialize json params into a Dict if params are present
         for p in planners:
             if p['params'] == 'null':
                 p['params'] = dict()

--- a/app/service/operation_svc.py
+++ b/app/service/operation_svc.py
@@ -29,9 +29,9 @@ class OperationService:
     async def run(self, op_id):
         self.log.debug('Starting operation: %s' % op_id)
         operation = await self.data_svc.explode_operation(dict(id=op_id))
-        planner = await self._get_planning_module(operation[0]['planner'])
 
         try:
+            planner = await self._get_planning_module(operation[0]['planner'])
             for phase in operation[0]['adversary']['phases']:
                 operation_phase_name = 'Operation %s (%s) phase %s' % (op_id, operation[0]['name'], phase)
                 self.log.debug('%s: started' % operation_phase_name)
@@ -49,4 +49,5 @@ class OperationService:
     async def _get_planning_module(self, planner_id):
         chosen_planner = await self.data_svc.explode_planners(dict(id=planner_id))
         planning_module = import_module(chosen_planner[0]['module'])
-        return getattr(planning_module, 'LogicalPlanner')(self.data_svc, self.planning_svc)
+        return getattr(planning_module, 'LogicalPlanner')(self.data_svc, self.planning_svc,
+                                                          **chosen_planner[0]['params'])

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -11,4 +11,4 @@ CREATE TABLE if not exists core_attack (attack_id text primary key, name text, t
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer, UNIQUE(source_id, property, value) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
-CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, UNIQUE(name) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);


### PR DESCRIPTION
This is one way we could allow defining planner parameters in yml planner definitions.  Would allow passing of configuration options to future planners: 

How this approach works:
Parameters can be written in the planner YAML definitions
```yml
---

id: 788107d5-dc1e-4204-9269-38df0186d3e9
name: mycustomplanner
module: plugins.stockpile.app.mycustomplanner
params:
  first_param: val1
  second_param: 2
  list_param:
    - el1
    - el2
```

Later these param options are passed into the LogicalPlanner constructor's as kwargs: 
```
...
return getattr(planning_module, 'LogicalPlanner')(self.data_svc, self.planning_svc,
                                                          **chosen_planner[0]['params'])
```
Using kwargs here keeps things backwards compatible with the existing planners which don't take params. 