### PR TITLE
add common virtualenv locations to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 logs/*
 !logs/.gitkeep
 core.db
+.venv/
+venv/
+.env


### PR DESCRIPTION
Might make things a little nicer for folks who like the store their venvs in the project directory (folks like me). 