### PR TITLE
Parsing and cleanup-links updates

### DIFF
--- a/app/service/parsing_svc.py
+++ b/app/service/parsing_svc.py
@@ -15,7 +15,7 @@ class ParsingService(BaseService):
         op_source = await data_svc.explode_sources(dict(name=operation['name']))
         for x in [r for r in results if not r['parsed']]:
             parser = await data_svc.explode_parsers(dict(ability=x['link']['ability']))
-            if parser:
+            if parser and x['link']['status']==0:
                 if parser[0]['name'] == 'json':
                     matched_facts = parsers.json(parser[0], b64decode(x['output']).decode('utf-8'), self.log)
                 elif parser[0]['name'] == 'line':

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -31,12 +31,12 @@ class PlanningService(BaseService):
 
     async def wait_for_phase(self, operation):
         for member in operation['host_group']:
-            op = await self.data_svc.explode_operation(dict(id=operation['id']))
-            while next((True for lnk in op[0]['chain'] if lnk['host_id'] == member['id'] and not lnk['finish']),
+            op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+            while next((True for lnk in op[0]['chain'] if lnk['paw'] == member['paw'] and not lnk['finish']),
                        False):
                 await asyncio.sleep(3)
-                op = await self.data_svc.explode_operation(dict(id=operation['id']))
-
+                op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+                
     async def decode(self, encoded_cmd, agent, group):
         decoded_cmd = self.decode_bytes(encoded_cmd)
         decoded_cmd = decoded_cmd.replace('#{server}', agent['server'])

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -28,7 +28,8 @@ class PlanningService(BaseService):
     async def create_cleanup_links(self, operation):
         for member in operation['host_group']:
             links = []
-            for link in await self.get_service('data_svc').explode_chain(criteria=dict(paw=member['paw'])):
+            for link in await self.get_service('data_svc').explode_chain(criteria=dict(paw=member['paw'],
+                                                                     op_id=operation['id'])):
                 ability = (await self.get_service('data_svc').explode_abilities(criteria=dict(id=link['ability'])))[0]
                 if ability['cleanup']:
                     links.append(dict(op_id=operation['id'], paw=member['paw'], ability=ability['id'], cleanup=1,


### PR DESCRIPTION
1) Parsing only the links output correctly executed. Avoiding collecting facts even in the event of errors, meaningless and/or unwanted links are not generated.

2) Make sure cleanup links are created for the operation of interest.