### PR TITLE
Compromised agents introduction

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -95,10 +95,11 @@ class DataService(BaseService):
         return identifier
 
     async def create_operation(self, name, group, adversary_id, jitter='2/8', stealth=False, sources=None,
-                               planner=None, state=None):
+                               planner=None, state=None, max_waiting=None):
         op_id = await self.dao.create('core_operation', dict(
             name=name, host_group=group, adversary_id=adversary_id, finish=None, phase=0, jitter=jitter,
-            start=self.get_current_timestamp(), stealth=stealth, planner=planner, state=state))
+            start=self.get_current_timestamp(), stealth=stealth, planner=planner, 
+            state=state, max_waiting=max_waiting))
         source_id = await self.dao.create('core_source', dict(name=name))
         await self.dao.create('core_source_map', dict(op_id=op_id, source_id=source_id))
         for s_id in [s for s in sources if s]:
@@ -117,6 +118,9 @@ class DataService(BaseService):
 
     async def create_agent(self, agent):
         return await self.dao.create('core_agent', agent)
+    
+    async def create_compromised_agents_map(self, op_id, agent_id):
+        return await self.dao.create('core_compromised_agents_map', dict(op_id=op_id, agent_id=agent_id))
 
     """ VIEW """
 
@@ -148,6 +152,8 @@ class DataService(BaseService):
             op['host_group'] = await self.explode_agents(criteria=dict(host_group=op['host_group']))
             sources = await self.dao.get('core_source_map', dict(op_id=op['id']))
             op['facts'] = await self.dao.get_in('core_fact', 'source_id', [s['source_id'] for s in sources])
+            compromised_agents = await self.dao.get('core_compromised_agents_map', dict(op_id=op['id']))
+            op['compromised_agents'] = [c['agent_id'] for c in compromised_agents]
         return operations
 
     async def explode_agents(self, criteria: object = None) -> object:

--- a/app/service/parsing_svc.py
+++ b/app/service/parsing_svc.py
@@ -15,7 +15,7 @@ class ParsingService(BaseService):
         op_source = await data_svc.explode_sources(dict(name=operation['name']))
         for x in [r for r in results if not r['parsed']]:
             parser = await data_svc.explode_parsers(dict(ability=x['link']['ability']))
-            if parser:
+            if parser and x['link']['status']==0:
                 if parser[0]['name'] == 'json':
                     matched_facts = parsers.json(parser[0], b64decode(x['output']).decode('utf-8'), self.log)
                 elif parser[0]['name'] == 'line':

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -31,12 +31,12 @@ class PlanningService(BaseService):
 
     async def wait_for_phase(self, operation):
         for member in operation['host_group']:
-            op = await self.data_svc.explode_operation(dict(id=operation['id']))
-            while next((True for lnk in op[0]['chain'] if lnk['host_id'] == member['id'] and not lnk['finish']),
+            op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+            while next((True for lnk in op[0]['chain'] if lnk['paw'] == member['paw'] and not lnk['finish']),
                        False):
                 await asyncio.sleep(3)
-                op = await self.data_svc.explode_operation(dict(id=operation['id']))
-
+                op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+                
     async def decode(self, encoded_cmd, agent, group):
         decoded_cmd = self.decode_bytes(encoded_cmd)
         decoded_cmd = decoded_cmd.replace('#{server}', agent['server'])

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -4,7 +4,8 @@ CREATE TABLE if not exists core_payload (id integer primary key AUTOINCREMENT, a
 CREATE TABLE if not exists core_adversary (id integer primary key AUTOINCREMENT, adversary_id text, name text, description text, UNIQUE (name));
 CREATE TABLE if not exists core_adversary_map (phase integer, adversary_id text, ability_id text, UNIQUE (adversary_id, phase, ability_id));
 CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, platform text, executor text, server text, host_group text, location text);
-CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text);
+CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text, max_waiting integer);
+CREATE TABLE if not exists core_compromised_agents_map (id integer primary key AUTOINCREMENT, op_id integer, agent_id integer, UNIQUE(op_id, agent_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_attack (attack_id text primary key, name text, tactic json, UNIQUE(attack_id));
@@ -12,4 +13,3 @@ CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, prop
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
-


### PR DESCRIPTION
**Goal**: avoid (optionally) that an operation on multi-agents stops completely if an agent ends unexpectedly


I introduced two new concepts: max_waiting and compromised agents

**max_waiting**: optional parameter for operations at the user's complete discretion. 
If, during wait_for_phase(), an agent does not send an heartbeat signal or a new result to the server for more than max_waiting seconds, the agent will be considered compromised for that operation.
If max_waiting is not specified, the operation will wait infinitely (_default behavior_).

**compromised agent**: agent participating in an operation that does not send an heartbeat signal or a new result to the caldera server from max_waiting seconds.

Once an agent is considered compromised for an operation, it will remain so **until the end of the operation**. Therefore, if the agent were to "reactivate" after it was labeled compromise, no other links would be generated for it and any results sent late would not be considered. 
This choice is to avoid inconsistent situations (eg: an agent is compromised in phase 1 of an attack and is "reactivated" to phase 10. If we reintegrate it in the operation, we could have some anomalies at the level of executed phases and of the execution order of the phases links).
Exception: links related to cleanup commands are also generated for compromised agents. This is because they are generated on the basis of the ONLY links executed and the collection of the results does not compromise in any case the execution of the operation (which is actually terminated). In doing so, the environment is still cleaned up even in the event that the agent "wakes up" after being compromised.


**TIP**: use a value for max_waiting which, when exceeded, gives us the near certainty of the agent being compromised.

**NOTE**: the concept of compromise is linked to the single operation and not directly to the agent. In fact the changes introduced to the db concern the **compromised-agents/operation mapping**.
If we had linked the concept of compromise directly to the agent (eg by introducing a status field in core_agent), we would also have had to develop a system to reintegrate them once they were reactivated/awakened.

**ISSUE**: 
As a wait value I chose the seconds. This solution is simple and provides a fairly high degree of granularity, but does not satisfy me completely.
An alternative, more "solid" in my opinion, would be to use "lost ticks" (where tick = heartbeat) as a measure. But the time between one heartbeat and another (60 seconds) is "in-box" within the agent's code. To solve this problem, and introduce even higher customization, it would be advisable to move this value to the local.yml file (but then we should ensure that the same value is also used in the agent code...).

I will be happy to hear your opinions and criticisms :)
(I pulled a request for the chain plugin to display "max_waiting" in the web interface)