### PR TITLE
 update private facts collection

### DIFF
--- a/app/service/parsing_svc.py
+++ b/app/service/parsing_svc.py
@@ -15,7 +15,7 @@ class ParsingService(BaseService):
         op_source = await data_svc.explode_sources(dict(name=operation['name']))
         for x in [r for r in results if not r['parsed']]:
             parser = await data_svc.explode_parsers(dict(ability=x['link']['ability']))
-            if parser:
+            if parser and x['link']['status']==0:
                 if parser[0]['name'] == 'json':
                     matched_facts = parsers.json(parser[0], b64decode(x['output']).decode('utf-8'), self.log)
                 elif parser[0]['name'] == 'line':

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -31,12 +31,12 @@ class PlanningService(BaseService):
 
     async def wait_for_phase(self, operation):
         for member in operation['host_group']:
-            op = await self.data_svc.explode_operation(dict(id=operation['id']))
-            while next((True for lnk in op[0]['chain'] if lnk['host_id'] == member['id'] and not lnk['finish']),
+            op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+            while next((True for lnk in op[0]['chain'] if lnk['paw'] == member['paw'] and not lnk['finish']),
                        False):
                 await asyncio.sleep(3)
-                op = await self.data_svc.explode_operation(dict(id=operation['id']))
-
+                op = await self.get_service('data_svc').explode_operation(dict(id=operation['id']))
+                
     async def decode(self, encoded_cmd, agent, group):
         decoded_cmd = self.decode_bytes(encoded_cmd)
         decoded_cmd = decoded_cmd.replace('#{server}', agent['server'])

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -28,7 +28,8 @@ class PlanningService(BaseService):
     async def create_cleanup_links(self, operation):
         for member in operation['host_group']:
             links = []
-            for link in await self.get_service('data_svc').explode_chain(criteria=dict(paw=member['paw'])):
+            for link in await self.get_service('data_svc').explode_chain(criteria=dict(paw=member['paw'],
+                                                                     op_id=operation['id'])):
                 ability = (await self.get_service('data_svc').explode_abilities(criteria=dict(id=link['ability'])))[0]
                 if ability['cleanup']:
                     links.append(dict(op_id=operation['id'], paw=member['paw'], ability=ability['id'], cleanup=1,

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -8,7 +8,7 @@ CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT,
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_attack (attack_id text primary key, name text, tactic json, UNIQUE(attack_id));
-CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer, UNIQUE(source_id, property, value) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);


### PR DESCRIPTION
When using private facts, the possibility exists that the same fact (both name and value) is collected by two distinct agents (in multiagent operations).

So:

- when a **"normal" fact** is collected: check that there is not already one collected during the ENTIRE OPERATION with the same name and the same value (_same as before_).
- when a **"private" fact** is collected: check that there is not already one collected FROM THE SAME AGENT during the operation with the same name and the same value.


I had problems of inconsistency when I executed the adversary "Hunter" on multiple agents. For example, it happened that two distinct agents had files with the same name and path (perhaps because of system files), and only the first fact collected was saved.
It took me some time to figure out where the problem was.