### PR TITLE
Skipped abilities

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -222,8 +222,7 @@ class PlanningService(BaseService):
                                     if c['ability_id'] not in already_checked])
         capable_abs_id = set([ab_id for (i, ab_id) in capable_abs_tuples])
         links_abs = set([l['ability'] for l in links])
-        links_abs_tuples = set([(i, ab_id) for (i, ab_id) in capable_abs_tuples if i in links_abs])
-        links_abs_id = set([ab_id for (i, ab_id) in links_abs_tuples])
+        links_abs_id = set([ab_id for (i, ab_id) in capable_abs_tuples if i in links_abs])
         for ab_id in (phase_abilities_id - capable_abs_id):
             await data_svc.create('core_skipped_abilities', dict(ability_id=ab_id, paw=agent['paw'], 
                     op_id=operation['id'], phase=phase, reason='incompatible executors'))

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -216,9 +216,8 @@ class PlanningService(BaseService):
         already_ran = set([l['ability'] for l in operation['chain'] if l['paw'] == agent['paw']])
         already_ran_id = set([p['ability_id'] for p in phase_abilities if p['id'] in already_ran])
         already_checked = already_skipped_id.union(already_ran_id)
-        phase_abilities_tuples = set([(p['id'],p['ability_id']) for p in phase_abilities 
+        phase_abilities_id = set([p['ability_id'] for p in phase_abilities 
                                     if p['ability_id'] not in already_checked])
-        phase_abilities_id = set([ab_id for (i, ab_id) in phase_abilities_tuples])
         capable_abs_tuples = set([(c['id'],c['ability_id']) for c in capable_agent_abs 
                                     if c['ability_id'] not in already_checked])
         capable_abs_id = set([ab_id for (i, ab_id) in capable_abs_tuples])

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -3,13 +3,12 @@ CREATE TABLE if not exists core_ability (id integer primary key AUTOINCREMENT, a
 CREATE TABLE if not exists core_payload (id integer primary key AUTOINCREMENT, ability integer, payload text, UNIQUE (ability, payload) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_adversary (id integer primary key AUTOINCREMENT, adversary_id text, name text, description text, UNIQUE (name));
 CREATE TABLE if not exists core_adversary_map (phase integer, adversary_id text, ability_id text, UNIQUE (adversary_id, phase, ability_id));
-CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer, trusted integer, last_trusted_seen date);
+CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer);
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
-CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text, allow_untrusted integer);
+CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
-

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -3,9 +3,9 @@ CREATE TABLE if not exists core_ability (id integer primary key AUTOINCREMENT, a
 CREATE TABLE if not exists core_payload (id integer primary key AUTOINCREMENT, ability integer, payload text, UNIQUE (ability, payload) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_adversary (id integer primary key AUTOINCREMENT, adversary_id text, name text, description text, UNIQUE (name));
 CREATE TABLE if not exists core_adversary_map (phase integer, adversary_id text, ability_id text, UNIQUE (adversary_id, phase, ability_id));
-CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer);
+CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer, trusted integer, last_trusted_seen date);
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
-CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text);
+CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text, allow_untrusted integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -6,6 +6,7 @@ CREATE TABLE if not exists core_adversary_map (phase integer, adversary_id text,
 CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer, trusted integer, last_trusted_seen date);
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
 CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, stealth integer, planner integer, state text, allow_untrusted integer);
+CREATE TABLE if not exists core_skipped_abilities (id integer primary key AUTOINCREMENT, ability_id text, paw text , op_id integer, phase integer, reason text, UNIQUE(ability_id, paw, op_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);

--- a/conf/local.yml
+++ b/conf/local.yml
@@ -4,6 +4,7 @@ host: 127.0.0.1
 port: 8888
 exfil_dir: /tmp
 memory: True
+untrusted_timer: 180
 plugins:
   - stockpile
   - sandcat

--- a/conf/local.yml
+++ b/conf/local.yml
@@ -4,7 +4,6 @@ host: 127.0.0.1
 port: 8888
 exfil_dir: /tmp
 memory: True
-untrusted_timer: 180
 plugins:
   - stockpile
   - sandcat


### PR DESCRIPTION
I tried to find a solution to PR #451 , @wbooth 
Relating **phase_abilities**, **capable_agent_abs** and **links** during the **planning_svc:select_links** function is possible, not only to keep track of abilities not performed, but also other information, like:

- phase in which the ability was skipped
- know if it has been skipped due to reasons of incompatibility of OS/executors
- know if it was skipped due to variables that cannot be replaced in the command section


The information thus collected can be retrieved at any time by querying table **core_skipped_abilities**.

(it was a mess to relate the ids of abilities with the respective UUIDs and to take into account all the abilities id (UUIDs) already skipped or already executed)