### PR TITLE
Virts 430 encoded payloads

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -8,6 +8,7 @@ from shutil import which
 from hashlib import md5
 
 from app.service.base_service import BaseService
+from app.utility.payload_encoder import xor_file
 
 
 class FileSvc(BaseService):
@@ -19,14 +20,19 @@ class FileSvc(BaseService):
 
     async def download(self, request):
         """
-        Accept a request with a required header, file, and an optional header, platform, and download the file
+        Accept a request with a required header, file, and an optional header, platform, and download the file.
+        If there is not a plaintext version of the file, and there is an encoded version available, then this
+        file will be decoded and returned to the requester.
         :param request:
         :return: a multipart file via HTTP
         """
         name = await self._compile(request.headers.get('file'), request.headers.get('platform'))
+        headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % name)])
         _, file_path = await self.find_file_path(name, 'payloads')
-        if file_path:
-            headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % name)])
+
+        if file_path and file_path.endswith('.xored'):
+            return web.Response(body=xor_file(file_path), headers=headers)
+        elif file_path:
             return web.FileResponse(path=file_path, headers=headers)
         return web.HTTPNotFound(body='File not found')
 
@@ -57,16 +63,23 @@ class FileSvc(BaseService):
 
     async def find_file_path(self, name, location=''):
         """
-        Find the location on disk of a file by name
+        Find the location on disk of a file by name. Will also return the path
+        to an encoded version of the file (e.g. if there is a file of the same name
+        that ends in a '.xored' extension.
         :param name:
         :param location:
         :return: a tuple: the plugin the file is found in & the relative file path
         """
+        encoded_name = '%s.xored' % (name,)
         for plugin in self.plugins:
             for root, dirs, files in os.walk('plugins/%s/%s' % (plugin, location)):
                 if name in files:
                     self.log.debug('Located %s' % name)
                     return plugin, os.path.join(root, name)
+                elif encoded_name in files:
+                    self.log.debug('Located %s' % encoded_name)
+                    return plugin, os.path.join(root, encoded_name)
+
 
     """ PRIVATE """
 

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -64,8 +64,8 @@ class FileSvc(BaseService):
     async def find_file_path(self, name, location=''):
         """
         Find the location on disk of a file by name. Will also return the path
-        to an encoded version of the file (e.g. if there is a file of the same name
-        that ends in a '.xored' extension.
+        to an encoded version of the file (encoded files share the same name
+        but end with the '.xored' extension).
         :param name:
         :param location:
         :return: a tuple: the plugin the file is found in & the relative file path

--- a/app/utility/payload_encoder.py
+++ b/app/utility/payload_encoder.py
@@ -1,0 +1,65 @@
+"""
+This module contains helper functions for encoding and decoding payload files.
+
+If AV is running on the CALDERA server host, then it may sometimes flag, quarantine, or delete
+CALDERA payloads. To help prevent this, encoded payloads can be used to prevent AV
+from breaking CALDERA server-side. The convention expected by the CALDERA server is that
+encoded payloads will be XOR'ed with the DEFAULT_KEY contained in the payload_encoder.py
+module.
+
+Additionally, payload_encoder.py can be used from the command-line to add a new encoded payload.
+
+```
+python /path/to/payload_encoder.py /path/to/plain-text-file /path/to/encoded-file.xored
+```
+
+NOTE: In order for CALDERA to detect the availability of an encoded payload, the payload file's
+name must end in the `.xored` extension.
+"""
+
+import array
+import argparse
+import pathlib
+
+DEFAULT_KEY = [0x32, 0x45, 0x32, 0xca]
+
+
+def xor_bytes(in_bytes, key=None):
+    if not key:
+        key = DEFAULT_KEY
+
+    arr = array.array('B', in_bytes)
+    for i, val in enumerate(arr):
+        cur_key = key[i % len(key)]
+        arr[i] = val ^ cur_key
+
+    return bytes(arr)
+
+
+def xor_file(input_file, output_file=None, key=None):
+    with open(input_file, 'rb') as encoded_stream:
+        buf = encoded_stream.read()
+
+    buf = xor_bytes(buf, key=key)
+
+    if output_file:
+        with open(output_file, 'wb') as decoded_stream:
+            decoded_stream.write(bytes(buf))
+
+    return buf
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-key', default=DEFAULT_KEY)
+    parser.add_argument('input')
+    parser.add_argument('output')
+
+    args = parser.parse_args()
+
+    if args.input == args.output:
+        raise RuntimeError('Input file path and output file path should be different.')
+    elif pathlib.Path(args.output).exists():
+        raise RuntimeError('Output file {} already exists.'.format(args.output))
+
+    xor_file(args.input, output_file=args.output, key=args.key)


### PR DESCRIPTION
Allow caldera payloads to be XOR encoded.  This can help prevent AV running on the CALDERA server from deleting known payloads and breaking abilities that depend on them.  This works purely on the server and does not do anything to obfuscate payloads after they have been downloaded by an agent.

Changes:
* `file_svc`: If CALDERA is unable to find a payload with the exact name an agent requests, it will now also search for the same name with the `.xored` extension.  If it finds a match, it will return the decoded contents to the requester.
* `app/utility/payload_encoder.py` (new module): holds the file XORing utilities and defines the XOR key that is expected to encode files. 

Notes:
* this was adapted from functionality previously in CALDERA (however, back then all payloads were encoded, which made things unnecessarily awkward).   See https://github.com/mitre/caldera/blob/e8a2c0f93c18b23e10413405680ff6c83431e9bb/scripts/encode.py for reference. 
* Most of the module docstring from `payload_encoder.py` can probably be pasted into the relevant portion of our docs wiki if this is merged in so that this functionality is documented in a more obvious way.