### PR TITLE
force fact parsing in planning_svc.select_links

### DIFF
--- a/app/service/operation_svc.py
+++ b/app/service/operation_svc.py
@@ -53,12 +53,10 @@ class OperationService(BaseService):
             for phase in operation[0]['adversary']['phases']:
                 operation_phase_name = 'Operation %s (%s) phase %s' % (op_id, operation[0]['name'], phase)
                 self.log.debug('%s: started' % operation_phase_name)
-                operation = await self.data_svc.explode_operation(dict(id=op_id))
                 await planner.execute(phase)
                 self.log.debug('%s: completed' % operation_phase_name)
                 await self.data_svc.update('core_operation', key='id', value=op_id,
                                            data=dict(phase=phase))
-                await self.get_service('parsing_svc').parse_facts(operation[0])
             await self.close_operation(operation[0])
         except Exception:
             traceback.print_exc()

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -21,6 +21,9 @@ class PlanningService(BaseService):
         :param phase:
         :return: a list of links
         """
+        await self.get_service('parsing_svc').parse_facts(operation)
+        operation = (await self.get_service('data_svc').explode_operation(criteria=dict(id=operation['id'])))[0]
+
         if (not agent['trusted']) and (not operation['allow_untrusted']):
             self.log.debug('Agent %s untrusted: no link created' % agent['paw'])
             return []


### PR DESCRIPTION
Force fact_parsing to always happen before link generation.  Moving this out of operation service ensures that the last phase of an operation will have the correct links generated for it.  This also makes it easier to write planners that could ask for new links in the middle of a phase. 

Changes:
* operation_svc is no longer responsible for parsing facts
* planning_svc will now always parse facts whenever select_links() is called. 
