### PR TITLE
Virts 413

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 [submodule "plugins/mock"]
 	path = plugins/mock
 	url = https://github.com/mitre/mock.git
-[submodule "plugins/dark"]
-	path = plugins/dark
-	url = https://gitlab.mitre.org/caldera/dark.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "plugins/mock"]
 	path = plugins/mock
 	url = https://github.com/mitre/mock.git
+[submodule "plugins/dark"]
+	path = plugins/dark
+	url = https://gitlab.mitre.org/caldera/dark.git

--- a/app/parsers/standard.py
+++ b/app/parsers/standard.py
@@ -36,3 +36,12 @@ def line(parser, blob, **kwargs):
     property_name = parser['property'][0]['property']
     return [dict(fact=property_name, value=f.strip(), set_id=0) for f in blob.split('\n') if f.strip()]
 
+
+def testing(parser, blob, **kwargs):
+    matched_facts=[]
+    properties = parser['property']
+    for j, line in enumerate(blob.split('\n')):
+        for i, v in enumerate(line.split(',')):
+            if v is not None and v is not '':
+                matched_facts.append(dict(fact=properties[i]['property'], value=v, set_id=j))
+    return matched_facts

--- a/app/parsers/standard.py
+++ b/app/parsers/standard.py
@@ -33,5 +33,6 @@ def regex(parser, blob, **kwargs):
 
 
 def line(parser, blob, **kwargs):
-    return [dict(fact=parser['property'], value=f.strip(), set_id=0) for f in blob.split('\n') if f.strip()]
+    property_name = parser['property'][0]['property']
+    return [dict(fact=property_name, value=f.strip(), set_id=0) for f in blob.split('\n') if f.strip()]
 

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -62,6 +62,16 @@ class DataService(BaseService):
                 for fact in source['facts']:
                     fact['source_id'] = source_id
                     await self.create_fact(**fact)
+                relationships = source.get('relationships')
+                if relationships:
+                    for _, relationship in relationships.items():
+                        await self.create_relationship(relationship)
+
+
+    async def create_relationship(self, values):
+        return await self.dao.create('core_fact_relationships', dict(value1=values['value1'],
+                                                                     relationship=values['relationship'],
+                                                                     value2=values['value2']))
 
     async def load_planner(self, directory):
         """

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -417,7 +417,13 @@ class DataService(BaseService):
             await self.dao.create('core_payload', dict(ability=identifier, payload=payload))
         if parser:
             parser['ability'] = identifier
-            await self.dao.create('core_parser', parser)
+            # Backwards compatibility code
+            if isinstance(parser['property'], str):
+                await self.dao.create('core_parser', parser)
+            else:
+                for prop in parser['property']:
+                    await self.dao.create('core_parser', dict(name=parser['name'], property=prop,
+                                                              script=parser['script'], ability=identifier))
         if requires_fact_relationship:
             requires_fact_relationship['ability_id'] = identifier
             await self.dao.create('core_ability_relationships', requires_fact_relationship)

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -446,6 +446,11 @@ class DataService(BaseService):
             if saved['platform'] not in ability['platforms']:
                 await self.dao.delete('core_ability', dict(id=saved['id']))
 
+    async def _add_adversary_packs(self, pack):
+        _, filename = await self.get_service('file_svc').find_file_path('%s.yml' % pack, location='data')
+        for adv in self.strip_yml(filename):
+            return [dict(phase=k, id=i) for k, v in adv.get('phases').items() for i in v]
+
     async def _create_parser(self, parser):
         parser_copy = parser.copy()
         properties = parser_copy.pop('property', None)

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -367,8 +367,7 @@ class DataService(BaseService):
         """
         parsers = await self.dao.get('core_parser', criteria=criteria)
         for parser in parsers:
-            parsers['property'] = json.laods(await self.dao.get('core_parser_property',
-                                                                criteria=dict(parser_id=parser['id'])))
+            parser['property'] = await self.dao.get('core_parser_property', criteria=dict(parser_id=parser['id']))
         return parsers
 
     """ DELETE """

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -390,14 +390,14 @@ class DataService(BaseService):
                                                               'utf-8')).decode() if info.get(
                                                           'cleanup') else None,
                                                       payload=info.get('payload'), parser=info.get('parser'),
-                                                      requires_fact_relationship=dict(fact1=ab['requires'].split(',')[0],
-                                                                                      relationship=ab['requires'].split(',')[1]
-                                                                                      , fact2=ab['requires'].split(',')[2],
+                                                      requires_fact_relationship=dict(property1=ab['requires'].split(',')[0].strip(),
+                                                                                      relationship=ab['requires'].split(',')[1].strip(),
+                                                                                      property2=ab['requires'].split(',')[2].strip(),
                                                                                       relationship_type='requires')
                                                                             if ab.get('requires') else None,
-                                                      creates_fact_relationship=dict(fact1=ab['creates'].split(',')[0],
-                                                                                      relationship=ab['creates'].split(',')[1]
-                                                                                      , fact2=ab['creates'].split(',')[2],
+                                                      creates_fact_relationship=dict(property1=ab['creates'].split(',')[0].strip(),
+                                                                                      relationship=ab['creates'].split(',')[1].strip(),
+                                                                                      property2=ab['creates'].split(',')[2].strip(),
                                                                                       relationship_type='creates')
                                                                             if ab.get('creates') else None)
                 await self._delete_stale_abilities(ab)

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -2,6 +2,7 @@ import glob
 import json
 from base64 import b64encode
 from collections import defaultdict
+
 import yaml
 
 from app.service.base_service import BaseService

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -380,6 +380,14 @@ class DataService(BaseService):
                     for name, info in executors.items():
                         for e in name.split(','):
                             encoded_test = b64encode(info['command'].strip().encode('utf-8'))
+                            creates_fact_relationship = dict(property1=ab['creates'].split(',')[0].strip(),
+                                                             relationship=ab['creates'].split(',')[1].strip(),
+                                                             property2=ab['creates'].split(',')[2].strip(),
+                                                             relationship_type='creates') if ab.get('creates') else None
+                            requires_fact_relationship = dict(property1=ab['requires'].split(',')[0].strip(),
+                                                              relationship=ab['requires'].split(',')[1].strip(),
+                                                              property2=ab['requires'].split(',')[2].strip(),
+                                                              relationship_type='requires') if ab.get('requires') else None
                             await self.create_ability(ability_id=ab.get('id'), tactic=ab['tactic'].lower(),
                                                       technique_name=ab['technique']['name'],
                                                       technique_id=ab['technique']['attack_id'],
@@ -390,16 +398,8 @@ class DataService(BaseService):
                                                               'utf-8')).decode() if info.get(
                                                           'cleanup') else None,
                                                       payload=info.get('payload'), parser=info.get('parser'),
-                                                      requires_fact_relationship=dict(property1=ab['requires'].split(',')[0].strip(),
-                                                                                      relationship=ab['requires'].split(',')[1].strip(),
-                                                                                      property2=ab['requires'].split(',')[2].strip(),
-                                                                                      relationship_type='requires')
-                                                                            if ab.get('requires') else None,
-                                                      creates_fact_relationship=dict(property1=ab['creates'].split(',')[0].strip(),
-                                                                                      relationship=ab['creates'].split(',')[1].strip(),
-                                                                                      property2=ab['creates'].split(',')[2].strip(),
-                                                                                      relationship_type='creates')
-                                                                            if ab.get('creates') else None)
+                                                      requires_fact_relationship=requires_fact_relationship,
+                                                      creates_fact_relationship=creates_fact_relationship)
                 await self._delete_stale_abilities(ab)
 
     async def _save_ability_extras(self, identifier, payload, parser, requires_fact_relationship, creates_fact_relationship):

--- a/app/service/parsing_svc.py
+++ b/app/service/parsing_svc.py
@@ -24,7 +24,7 @@ class ParsingService(BaseService):
         data_svc = self.get_service('data_svc')
         results = await data_svc.explode_results()
         for result in [r for r in results if not r['parsed']]:
-            parse_info = await data_svc.get('core_parser', dict(ability=result['link']['ability']))
+            parse_info = await data_svc.explode_parsers(criteria=dict(ability=result['link']['ability']))
             if parse_info and result['link']['status'] == 0:
                 blob = b64decode(result['output']).decode('utf-8')
                 parser = self.parsers.get(parse_info[0]['name'], parsers.regex)

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -213,8 +213,8 @@ class PlanningService(BaseService):
 
     async def _enforce_relationship(self, fact_combo, relationship):
         for i in range(len(fact_combo) - 1):
-            if relationship.get('fact1') == fact_combo[i]['property'] \
-                    and relationship.get('fact2') == fact_combo[i + 1]['property']:
+            if relationship.get('property1') == fact_combo[i]['property'] \
+                    and relationship.get('property2') == fact_combo[i + 1]['property']:
                 relationship_found = await self.get_service('data_svc').dao.get('core_fact_relationships',
                                             criteria=dict(value1=fact_combo[i]['value'],
                                             value2=fact_combo[i + 1]['value']))

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -140,7 +140,6 @@ class PlanningService(BaseService):
                         relationship_satisfied = await self._enforce_relationship(combo, requires_relationship[0])
                         if not relationship_satisfied:
                             continue
-
                     copy_test = copy.deepcopy(decoded_test)
                     copy_link = copy.deepcopy(link)
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -131,13 +131,13 @@ class PlanningService(BaseService):
             variables = re.findall(r'#{(.*?)}', decoded_test, flags=re.DOTALL)
             if variables:
                 agent_facts = await self._get_agent_facts(operation['id'], agent['paw'])
-                requires_relationship = (await self.get_service('data_svc').dao.get('core_ability_relationships',
+                requires_relationship = await self.get_service('data_svc').dao.get('core_ability_relationships',
                                                                     criteria=dict(ability_id=link['ability'],
-                                                                    relationship_type='requires')))[0]
+                                                                    relationship_type='requires'))
                 relevant_facts = await self._build_relevant_facts(variables, operation.get('facts', []), agent_facts)
                 for combo in list(itertools.product(*relevant_facts)):
                     if requires_relationship:
-                        relationship_satisfied = await self._enforce_relationship(combo, requires_relationship)
+                        relationship_satisfied = await self._enforce_relationship(combo, requires_relationship[0])
                         if not relationship_satisfied:
                             continue
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -217,7 +217,8 @@ class PlanningService(BaseService):
                     and relationship.get('property2') == fact_combo[i + 1]['property']:
                 relationship_found = await self.get_service('data_svc').dao.get('core_fact_relationships',
                                             criteria=dict(value1=fact_combo[i]['value'],
-                                            value2=fact_combo[i + 1]['value']))
+                                                          relationship=relationship['relationship'],
+                                                          value2=fact_combo[i + 1]['value']))
                 if relationship_found:
                     return True
         return False

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -12,3 +12,4 @@ CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, prop
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_ability_relationships (id integer primary key AUTOINCREMENT, ability_id integer, fact1 text, relationship text, fact2 text, relationship_type text, UNIQUE(ability_id, relationship, relationship_type) ON CONFLICT IGNORE);

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -13,3 +13,4 @@ CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, na
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_ability_relationships (id integer primary key AUTOINCREMENT, ability_id integer, fact1 text, relationship text, fact2 text, relationship_type text, UNIQUE(ability_id, relationship, relationship_type) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_fact_relationships (id integer primary key AUTOINCREMENT, value1 text, relationship text, value2 text, UNIQUE(value1, value2) ON CONFLICT IGNORE);

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -12,5 +12,5 @@ CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, prop
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
-CREATE TABLE if not exists core_ability_relationships (id integer primary key AUTOINCREMENT, ability_id integer, fact1 text, relationship text, fact2 text, relationship_type text, UNIQUE(ability_id, relationship, relationship_type) ON CONFLICT IGNORE);
-CREATE TABLE if not exists core_fact_relationships (id integer primary key AUTOINCREMENT, value1 text, relationship text, value2 text, UNIQUE(value1, value2) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_ability_relationships (id integer primary key AUTOINCREMENT, ability_id integer, property1 text, relationship text, property2 text, relationship_type text, UNIQUE(ability_id, relationship, relationship_type) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_fact_relationships (id integer primary key AUTOINCREMENT, value1 text, relationship text, value2 text, UNIQUE(value1, relationship, value2) ON CONFLICT IGNORE);

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -7,7 +7,7 @@ CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
 CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
-CREATE TABLE if not exists core_parser (ability integer, name text, script text, UNIQUE(ability, script) ON CONFLICT REPLACE);
+CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, name text, script text, UNIQUE(ability, script) ON CONFLICT REPLACE);
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -7,10 +7,11 @@ CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
 CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
-CREATE TABLE if not exists core_parser (ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT REPLACE);
+CREATE TABLE if not exists core_parser (ability integer, name text, script text, UNIQUE(ability, script) ON CONFLICT REPLACE);
 CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_ability_relationships (id integer primary key AUTOINCREMENT, ability_id integer, property1 text, relationship text, property2 text, relationship_type text, UNIQUE(ability_id, relationship, relationship_type) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_fact_relationships (id integer primary key AUTOINCREMENT, value1 text, relationship text, value2 text, UNIQUE(value1, relationship, value2) ON CONFLICT IGNORE);
+CREATE TABLE if not exists core_parser_property (id integer primary key AUTOINCREMENT, parser_id text, property text, UNIQUE(parser_id, property) ON CONFLICT IGNORE);


### PR DESCRIPTION
Accomplishes the following for VIRTS-413 Ticket:
1. Establishes backend additions to support fact relationships. Addition of  core_fact_relationships and core_ability_relationships. 
2. Planning service enforces that facts be related if they have relationship requirements specified in the ability file
3. Ability to load in fact relationships from the fact yaml file
4. Load ability supports loading in fact relationship requirements and fact relationship creation specifications
5. Necessary change of parser table which now must support a one-to-many relationship between parser and properties. Includes the addition of the core_parser_property table

Not yet completed for VIRTS-413:
1. Parser changes for parsing out fact relationships
2. Realistic adversary that uses fact relationships