### PR TITLE
virts-493-allowing capitalization of adversary names. 

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -163,7 +163,7 @@ class DataService(BaseService):
         :return: the database id
         """
         identifier = await self.dao.create('core_adversary',
-                                           dict(adversary_id=i, name=name.lower(), description=description))
+                                           dict(adversary_id=i, name=name, description=description))
 
         await self.dao.delete('core_adversary_map', data=dict(adversary_id=i))
         for ability in phases:


### PR DESCRIPTION
for a mixed case adversary name to be passed to data service and stored
in the database as a mixed case string as opposed to an only lower case
string.