### PR TITLE
Allow Pre-Seeded Private Facts

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -160,7 +160,10 @@ class PlanningService(BaseService):
         return score
 
     @staticmethod
-    async def _build_relevant_facts(variables, facts, agent_facts):
+    def _is_fact_bound(fact):
+        return not fact['link_id']
+
+    async def _build_relevant_facts(self, variables, facts, agent_facts):
         """
         Create a list of ([fact, value, score]) tuples for each variable/fact
         """
@@ -170,7 +173,7 @@ class PlanningService(BaseService):
             variable_facts = []
             for fact in [f for f in facts if f['property'] == v]:
                 if fact['property'].startswith('host'):
-                    if fact['id'] in agent_facts or not fact['link_id']:
+                    if fact['id'] in agent_facts or self._is_fact_bound(fact):
                         variable_facts.append(fact)
                 else:
                     variable_facts.append(fact)

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -170,7 +170,7 @@ class PlanningService(BaseService):
             variable_facts = []
             for fact in [f for f in facts if f['property'] == v]:
                 if fact['property'].startswith('host'):
-                    if fact['id'] in agent_facts:
+                    if fact['id'] in agent_facts or not fact['link_id']:
                         variable_facts.append(fact)
                 else:
                     variable_facts.append(fact)

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -8,7 +8,7 @@ CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, 
 CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (ability integer, name text, property text, script text, UNIQUE(ability, property) ON CONFLICT REPLACE);
-CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer);
+CREATE TABLE if not exists core_fact (id integer primary key AUTOINCREMENT, property text, value text, score integer, set_id integer, source_id text, link_id integer DEFAULT 0);
 CREATE TABLE if not exists core_source (id integer primary key AUTOINCREMENT, name text, UNIQUE(name) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_source_map (id integer primary key AUTOINCREMENT, op_id integer, source_id integer, UNIQUE(op_id, source_id) ON CONFLICT IGNORE);
 CREATE TABLE if not exists core_planner (id integer primary key AUTOINCREMENT, name text, module text, params json, UNIQUE(name) ON CONFLICT IGNORE);


### PR DESCRIPTION
Allow use of pre-seeded private facts. Here any host.x.x fact will apply to all agents if specified in the fact sheet