### PR TITLE
Add IP/Subnet Boundaries for Rules

### DIFF
--- a/app/utility/rule.py
+++ b/app/utility/rule.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum
+import ipaddress
 
 
 class RuleAction(Enum):
@@ -14,11 +15,12 @@ class RuleSet:
     async def is_fact_allowed(self, fact):
         allowed = True
         for rule in self.rules.get(fact['property'], []):
-            if re.match(rule.get('match', '.*'), fact['value']):
-                if rule['action'] == RuleAction.DENY.value:
-                    allowed = False
-                elif rule['action'] == RuleAction.ALLOW.value:
-                    allowed = True
+            if await self._is_ip_rule_match(rule, fact):
+                allowed = await self._rule_judgement(rule['action'])
+                continue
+
+            if await self._is_regex_rule_match(rule, fact):
+                allowed = await self._rule_judgement(rule['action'])
         return allowed
 
     async def apply_rules(self, facts):
@@ -34,3 +36,27 @@ class RuleSet:
     async def _has_rules(self):
         return len(self.rules)
 
+    @staticmethod
+    async def _rule_judgement(action):
+        if action == RuleAction.DENY.value:
+            return False
+        return True
+
+    @staticmethod
+    async def _is_ip_network(value):
+        try:
+            ipaddress.IPv4Network(value)
+            return True
+        except (ValueError, ipaddress.AddressValueError):
+            pass
+        return False
+
+    @staticmethod
+    async def _is_regex_rule_match(rule, fact):
+        return re.match(rule.get('match', '.*'), fact['value'])
+
+    async def _is_ip_rule_match(self, rule, fact):
+        if rule['match'] != '.*' and await self._is_ip_network(rule['match']) and await self._is_ip_network(fact['value']):
+            if ipaddress.IPv4Network(fact['value']).subnet_of(ipaddress.IPv4Network(rule['match'])):
+                return True
+        return False


### PR DESCRIPTION
For an example rule would look like
```
  - action: DENY
    fact: my.host.ip
    match: .*
  - action: ALLOW
    fact: my.host.ip
    match: 10.245.112.0/24
```
this would permit caldera to only operate within the 10.245.112.1 to 10.245.112.254 range