### PR TITLE
Virts 460c: solving the state persistence issue for operations and group

### DIFF
--- a/app/service/reporting_svc.py
+++ b/app/service/reporting_svc.py
@@ -100,19 +100,20 @@ class ReportingService(BaseService):
         if ability['ability_id'] in agent_ran:
             return
         elif ability['platform'] != agent['platform']:
-            return dict(reason='Wrong platform', reason_id=self.Reason.PLATFORM.value, ability_id=ability['ability_id'])
+            return dict(reason='Wrong platform', reason_id=self.Reason.PLATFORM.value, ability_id=ability['ability_id'],
+                        ability_name=ability['name'])
         elif ability['executor'] not in agent_executors:
             return dict(reason='Executor not available', reason_id=self.Reason.EXECUTOR.value,
-                        ability_id=ability['ability_id'])
+                        ability_id=ability['ability_id'], ability_name=ability['name'])
         elif variables and not all(op_fact in op_facts for op_fact in variables):
             return dict(reason='Fact dependency not fulfilled', reason_id=self.Reason.FACT_DEPENDENCY.value,
-                        ability_id=ability['ability_id'])
+                        ability_id=ability['ability_id'], ability_name=ability['name'])
         else:
             if (ability['platform'] == agent['platform'] and ability['executor'] in agent_executors
                     and ability['ability_id'] not in agent_ran):
                 if state != 'finished':
                     return dict(reason='Operation not completed', reason_id=self.Reason.OP_RUNNING.value,
-                                ability_id=ability['ability_id'])
+                                ability_id=ability['ability_id'], ability_name=ability['name'])
                 else:
                     return dict(reason='Agent untrusted', reason_id=self.Reason.UNTRUSTED.value,
-                                ability_id=ability['ability_id'])
+                                ability_id=ability['ability_id'], ability_name=ability['name'])

--- a/conf/core.sql
+++ b/conf/core.sql
@@ -5,7 +5,9 @@ CREATE TABLE if not exists core_adversary (id integer primary key AUTOINCREMENT,
 CREATE TABLE if not exists core_adversary_map (id integer primary key AUTOINCREMENT, phase integer, adversary_id text, ability_id text, UNIQUE (adversary_id, phase, ability_id));
 CREATE TABLE if not exists core_agent (id integer primary key AUTOINCREMENT, paw text, last_seen date, architecture text, platform text, server text, host_group text, location text, pid integer, ppid integer, trusted integer, last_trusted_seen date, sleep_min integer, sleep_max integer);
 CREATE TABLE if not exists core_executor (id integer primary key AUTOINCREMENT, agent_id integer, executor text, preferred integer);
-CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
+CREATE TABLE if not exists core_operation (id integer primary key AUTOINCREMENT, name text, group_id integer, host_group text, adversary_id text, jitter text, start date, finish date, phase integer, autonomous integer, planner integer, state text, allow_untrusted integer);
+CREATE TABLE if not exists core_operation_group (id integer primary key AUTOINCREMENT, name integer);
+CREATE TABLE if not exists core_operation_group_map (group_id integer, agent_id integer);
 CREATE TABLE if not exists core_chain (id integer primary key AUTOINCREMENT, op_id integer, paw text, ability integer, jitter integer, command text, executor text, cleanup integer, score integer, status integer, decide date, collect date, finish date, UNIQUE(op_id, paw, command));
 CREATE TABLE if not exists core_parser (id integer primary key AUTOINCREMENT, ability integer, module text, UNIQUE(ability, module) ON CONFLICT REPLACE);
 CREATE TABLE if not exists core_parser_map (parser_id integer, source text, edge text, target text, UNIQUE(parser_id, source, edge, target) ON CONFLICT IGNORE);


### PR DESCRIPTION
`explode_operation` attempts to explode out agents based upon the `host_group` field which is a static field in the `core_agents` table.  If the `host_group` field is updated during an operation (i.e. an agent is removed from a group or added to a group), then those agents with the `host_group` in the `core_operation` will explode out. 

This create issues anywhere `explode_operation` is called.  Reporting for example, would act as though any agents added to the group after the operation ran (new agent in `my_group` for example) were part of the original operation and render them into the report.  Additionally removing agents from the group will break `planning_svc` and `parsing_svc` if the change happens mid-operation.