### PR TITLE
virts-513-precursor-different process integrity levels

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -12,11 +12,11 @@ class Agent(BaseObject):
         return dict(paw=self.paw, group=self.group, architecture=self.architecture, platform=self.platform,
                     server=self.server, location=self.location, pid=self.pid, ppid=self.ppid, trusted=self.trusted,
                     last_seen=self.last_seen, last_trusted_seen=self.last_trusted_seen, sleep_min=self.sleep_min,
-                    sleep_max=self.sleep_max, executors=self.executors)
+                    sleep_max=self.sleep_max, executors=self.executors, privilege=self.privilege)
 
     def __init__(self, paw, last_seen=None, architecture=None, platform=None, server=None, group=None,
                  location=None, pid=None, ppid=None, trusted=None, last_trusted_seen=None, sleep_min=None,
-                 sleep_max=None, executors=None):
+                 sleep_max=None, executors=None, privilege=None):
         self.paw = paw
         self.group = group
         self.architecture = architecture
@@ -31,6 +31,7 @@ class Agent(BaseObject):
         self.sleep_min = sleep_min
         self.sleep_max = sleep_max
         self.executors = executors
+        self.privilege = privilege
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -48,5 +49,6 @@ class Agent(BaseObject):
             existing.update('sleep_min', self.sleep_min)
             existing.update('sleep_max', self.sleep_max)
             existing.update('group', self.group)
+            existing.update('privilege', self.privilege)
         return existing
 

--- a/app/service/agent_svc.py
+++ b/app/service/agent_svc.py
@@ -38,7 +38,7 @@ class AgentService(BaseService):
         except Exception as e:
             self.log.error('[!] start_sniffer_untrusted_agents: %s' % e)
 
-    async def handle_heartbeat(self, paw, platform, server, group, executors, architecture, location, pid, ppid, sleep):
+    async def handle_heartbeat(self, paw, platform, server, group, executors, architecture, location, pid, ppid, sleep, privilege):
         """
         Accept all components of an agent profile and save a new agent or register an updated heartbeat.
         :param paw:
@@ -57,7 +57,7 @@ class AgentService(BaseService):
         return await self.data_svc.store(
             Agent(last_seen=now, paw=paw, platform=platform, server=server, group=group,
                   location=location, architecture=architecture, pid=pid, ppid=ppid,
-                  trusted=True, last_trusted_seen=now, sleep_min=sleep, sleep_max=sleep, executors=executors)
+                  trusted=True, last_trusted_seen=now, sleep_min=sleep, sleep_max=sleep, executors=executors, privilege=privilege)
         )
 
     async def calculate_sleep(self, agent):


### PR DESCRIPTION
changes allow the server to add the "privilege" field to the agent. This
field is tracked per agent on heartbeat. Related to similar pull request in Sandcat and Chain