### PR TITLE
virts-513

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -14,10 +14,10 @@ class Ability(BaseObject):
                                test=self.test, description=self.description, cleanup=self.cleanup,
                                executor=self.executor,
                                platform=self.platform, payload=self.payload, parsers=[p.display for p in self.parsers],
-                               requirements=[r.display for r in self.requirements]))
+                               requirements=[r.display for r in self.requirements], privilege=self.privilege))
 
     def __init__(self, ability_id, tactic, technique_id, technique, name, test, description, cleanup, executor,
-                 platform, payload, parsers, requirements):
+                 platform, payload, parsers, requirements, privilege):
         self.ability_id = ability_id
         self.tactic = tactic
         self.technique_name = technique
@@ -31,7 +31,8 @@ class Ability(BaseObject):
         self.payload = payload
         self.parsers = parsers
         self.requirements = requirements
-
+        self.privilege = privilege
+        
     def store(self, ram):
         existing = self.retrieve(ram['abilities'], self.unique)
         if not existing:

--- a/app/service/agent_svc.py
+++ b/app/service/agent_svc.py
@@ -137,7 +137,8 @@ class AgentService(BaseService):
                              and (ab.platform == agent.platform) and (ab.executor in executors)]
             if len(total_ability) > 0:
                 val = next((ta for ta in total_ability if ta.executor == preferred), total_ability[0])
-                abilities.append(val)
+                if val.privilege and val.privilege == agent.privilege or not val.privilege:
+                    abilities.append(val)
         return abilities
 
     """ PRIVATE """

--- a/app/service/base_service.py
+++ b/app/service/base_service.py
@@ -80,6 +80,7 @@ class BaseService:
         FACT_DEPENDENCY = 2
         OP_RUNNING = 3
         UNTRUSTED = 4
+        PRIVILEGE = 5
 
     @staticmethod
     async def load_module(module_type, module_info):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -341,11 +341,13 @@ class DataService(BaseService):
                                                                    'utf-8')).decode() if info.get(
                                                                'cleanup') else None,
                                                            payload=info.get('payload'), parsers=info.get('parsers', []),
-                                                           requirements=ab.get('requirements', []))
+                                                           requirements=ab.get('requirements', []),
+                                                           privilege= ab['privilege'] if "privilege" in ab.keys()
+                                                           else None)
         self.log.debug('Loaded %s abilities' % len(self.ram['abilities']))
 
     async def _create_ability(self, ability_id, tactic, technique_name, technique_id, name, test, description, executor,
-                              platform, cleanup=None, payload=None, parsers=None, requirements=None):
+                              platform, cleanup=None, payload=None, parsers=None, requirements=None, privilege=None):
         ps = []
         for module in parsers:
             relation = [Relationship(source=r['source'], edge=r.get('edge'), target=r.get('target')) for r in
@@ -359,4 +361,4 @@ class DataService(BaseService):
         await self.store(Ability(ability_id=ability_id, name=name, test=test, tactic=tactic,
                                  technique_id=technique_id, technique=technique_name,
                                  executor=executor, platform=platform, description=description,
-                                 cleanup=cleanup, payload=payload, parsers=ps, requirements=rs))
+                                 cleanup=cleanup, payload=payload, parsers=ps, requirements=rs, privilege=privilege))

--- a/app/service/reporting_svc.py
+++ b/app/service/reporting_svc.py
@@ -111,6 +111,9 @@ class ReportingService(BaseService):
         elif variables and not all(op_fact in op_facts for op_fact in variables):
             return dict(reason='Fact dependency not fulfilled', reason_id=self.Reason.FACT_DEPENDENCY.value,
                         ability_id=ability.ability_id, ability_name=ability.name)
+        elif ability.privilege != agent.privilege:
+            return dict(reason='Ability privilege not fulfilled', reason_id=self.Reason.PRIVILEGE.value,
+                        ability_id=ability.ability_id, ability_name=ability.name)
         else:
             if (ability.platform == agent.platform and ability.executor in agent_executors
                     and ability.ability_id not in agent_ran):


### PR DESCRIPTION
Changes allow user to modify ability with a "privilege" flag of either
"Elevated" or "User" as `privilege: User` or `privilege: Elevated`. If the ability file has a privilege level that does not match the privilege level of the agent, ability is skipped and
report says "ability privilege not fulfilled". If the flag is not
present in the Ability file, ability is run on the agent regardles of
agent's privilege level. If multiple agents belong to same group and
have different privilege levels and ability is specified to run at User
level, it will only execute in the agent with the User level privileges.
Abilities without this flag will be run on both agents.