### PR TITLE
requirement utilization

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -144,6 +144,12 @@ class PlanningService(BaseService):
             score += (score + var['score'])
             used.append(var['id'])
             copy_test = copy_test.replace('#{%s}' % var['property'], var['value'])
+            if len(var['relationships']):
+                for link in var['relationships']:
+                    entry = link['target']
+                    score += (score + entry['score'])
+                    used.append(entry['id'])
+                    copy_test = copy_test.replace('#{%s}' % entry['property'], entry['value'])
         return copy_test, score, used
 
     async def _get_agent_facts(self, op_id, paw):


### PR DESCRIPTION
Quick patch to improve efficiency of using requirements - why do all the processing a second time if we can just pull that data and insert it now? At the moment, we're only enforcing the relationship, and while that works for the most part, it means that we have to generate an additional set of links to fill in data we've already validated...