### PR TITLE
docker compose works with gui based functions. cli is unaccessible.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,10 @@ services:
     - "8888"
 
     ports:
-      - "8880:8880"
       - "8888:8888"
     working_dir: /usr/src/app
 
     volumes:
       - ./:/usr/src/app
 
-    command: /bin/bash -c "pip install --no-cache-dir -r requirements.txt && python server.py -E local"
+    command: /bin/bash -c "pip install --no-cache-dir -r requirements.txt && python server.py"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  caldera:
+    image: python:3
+
+    expose:
+    - "8880"
+    - "8888"
+
+    ports:
+      - "8880:8880"
+      - "8888:8888"
+    working_dir: /usr/src/app
+
+    volumes:
+      - ./:/usr/src/app
+
+    command: /bin/bash -c "pip install --no-cache-dir -r requirements.txt && python server.py -E local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: python:3
 
     expose:
-    - "8880"
     - "8888"
 
     ports:


### PR DESCRIPTION
CALDERA starts properly in the latest python:3 docker container. Due to port bindings, the web interface is accessible by browsing to http://localhost:8888 and agents are able to properly interact with it.