### PR TITLE
virts-513 privilege flag in abilities

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -14,10 +14,10 @@ class Ability(BaseObject):
                                test=self.test, description=self.description, cleanup=self.cleanup,
                                executor=self.executor, unique=self.unique,
                                platform=self.platform, payload=self.payload, parsers=[p.display for p in self.parsers],
-                               requirements=[r.display for r in self.requirements]))
+                               requirements=[r.display for r in self.requirements], privilege=self.privilege))
 
     def __init__(self, ability_id, tactic, technique_id, technique, name, test, description, cleanup, executor,
-                 platform, payload, parsers, requirements):
+                 platform, payload, parsers, requirements, privilege):
         self.ability_id = ability_id
         self.tactic = tactic
         self.technique_name = technique
@@ -31,6 +31,7 @@ class Ability(BaseObject):
         self.payload = payload
         self.parsers = parsers
         self.requirements = requirements
+        self.privilege = privilege
 
     def store(self, ram):
         existing = self.retrieve(ram['abilities'], self.unique)

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -64,5 +64,6 @@ class Agent(BaseObject):
                              and (ab.platform == self.platform) and (ab.executor in executors)]
             if len(total_ability) > 0:
                 val = next((ta for ta in total_ability if ta.executor == preferred), total_ability[0])
-                abilities.append(val)
+                if val.privilege and val.privilege == self.privilege or not val.privilege:
+                    abilities.append(val)
         return abilities

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -157,6 +157,9 @@ class Operation(BaseObject):
         elif variables and not all(op_fact in op_facts for op_fact in variables):
             return dict(reason='Fact dependency not fulfilled', reason_id=self.Reason.FACT_DEPENDENCY.value,
                         ability_id=ability.ability_id, ability_name=ability.name)
+        elif ability.privilege != agent.privilege:
+             return dict(reason='Ability privilege not fulfilled', reason_id=self.Reason.PRIVILEGE.value,
+                         ability_id=ability.ability_id, ability_name=ability.name)
         else:
             if (ability.platform == agent.platform and ability.executor in agent_executors
                     and ability.ability_id not in agent_ran):
@@ -173,3 +176,4 @@ class Operation(BaseObject):
         FACT_DEPENDENCY = 2
         OP_RUNNING = 3
         UNTRUSTED = 4
+        PRIVILEGE = 5

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -146,7 +146,9 @@ class DataService(BaseService):
                                                                    'utf-8')).decode() if info.get(
                                                                'cleanup') else None,
                                                            payload=info.get('payload'), parsers=info.get('parsers', []),
-                                                           requirements=ab.get('requirements', []))
+                                                           requirements=ab.get('requirements', []),
+                                                           privilege=ab['privilege'] if 'privilege' in ab.keys() else
+                                                           None)
                                 total += 1
         self.log.debug('Loaded %s abilities' % total)
 
@@ -179,7 +181,7 @@ class DataService(BaseService):
             return [dict(phase=k, id=i) for k, v in adv.get('phases').items() for i in v]
 
     async def _create_ability(self, ability_id, tactic, technique_name, technique_id, name, test, description, executor,
-                              platform, cleanup=None, payload=None, parsers=None, requirements=None):
+                              platform, cleanup=None, payload=None, parsers=None, requirements=None, privilege=None):
         ps = []
         for module in parsers:
             relation = [Relationship(source=r['source'], edge=r.get('edge'), target=r.get('target')) for r in
@@ -193,4 +195,4 @@ class DataService(BaseService):
         await self.store(Ability(ability_id=ability_id, name=name, test=test, tactic=tactic,
                                  technique_id=technique_id, technique=technique_name,
                                  executor=executor, platform=platform, description=description,
-                                 cleanup=cleanup, payload=payload, parsers=ps, requirements=rs))
+                                 cleanup=cleanup, payload=payload, parsers=ps, requirements=rs, privilege=privilege))


### PR DESCRIPTION
Changes allow user to modify ability with a "privilege" flag of either "Elevated" or "User" as privilege: User or privilege: Elevated. If the ability file has a privilege level that does not match the privilege level of the agent, ability is skipped and report says "ability privilege not fulfilled". If the flag is not present in the Ability file, ability is run on the agent regardles of agent's privilege level. If multiple agents belong to same group and have different privilege levels and ability is specified to run at User level, it will only execute in the agent with the User level privileges. Abilities without this flag will be run on both agents.