### PR TITLE
Planning svc facts

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -117,7 +117,7 @@ class Operation(BaseObject):
                     break
 
     def get_fact_dict(self, agent_paw=None):
-        facts = self._create_fact_dict(self.source.facts)
+        facts = self._create_fact_dict(self.source.facts, f_dict={})
         found_facts = self._get_found_facts(agent_paw=agent_paw)
         return self._create_fact_dict(list_facts=found_facts, f_dict=facts)
 
@@ -134,7 +134,7 @@ class Operation(BaseObject):
         return found_facts
 
     @staticmethod
-    def _create_fact_dict(list_facts, f_dict={}):
+    def _create_fact_dict(list_facts, f_dict):
         for f in list_facts:
             try:
                 f_dict[f.trait].add(f)

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -116,6 +116,32 @@ class Operation(BaseObject):
                 if await self._trust_issues(member):
                     break
 
+    def get_fact_dict(self, agent_paw=None):
+        facts = self._create_fact_dict(self.source.facts)
+        found_facts = self._get_found_facts(agent_paw=agent_paw)
+        return self._create_fact_dict(list_facts=found_facts, f_dict=facts)
+
+    def _get_found_facts(self, agent_paw=None):
+        found_facts = []
+        for link in self.chain:
+            for f in link.facts:
+                if f.score > 0:
+                    if f.trait.startswith('host'):
+                        if link.paw == agent_paw:
+                            found_facts.append(f)
+                    else:
+                        found_facts.append(f)
+        return found_facts
+
+    @staticmethod
+    def _create_fact_dict(list_facts, f_dict={}):
+        for f in list_facts:
+            try:
+                f_dict[f.trait].add(f)
+            except KeyError:
+                f_dict[f.trait] = {f}
+        return f_dict
+
     async def _trust_issues(self, agent):
         if not self.allow_untrusted:
             return not agent.trusted

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -90,7 +90,7 @@ class PlanningService(BaseService):
                 if not valid_facts:
                     continue
                 for combo in list(itertools.product(*valid_facts.values())):
-                    if ability_requirements and not await self._do_enforcements(ability_requirements[link.ability.unique], combo):
+                    if ability_requirements and not await self._do_enforcements(ability_requirements[link.ability.unique], operation, link, combo):
                         continue
 
                     copy_test = copy.deepcopy(decoded_test)
@@ -105,11 +105,12 @@ class PlanningService(BaseService):
                 final_links.append(link)
         return final_links
 
-    async def _do_enforcements(self, ability_requirements, combo):
+    async def _do_enforcements(self, ability_requirements, operation, link, combo):
         for req_inst in ability_requirements:
+            uf = link.get('used', [])
             requirements_info = dict(module=req_inst.module, enforcements=req_inst.relationships[0])
             requirement = await self.load_module('Requirement', requirements_info)
-            if not requirement.enforce(combo):
+            if not requirement.enforce(combo[0], uf, operation['facts']):
                 return False
         return True
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -92,7 +92,6 @@ class PlanningService(BaseService):
                 for combo in list(itertools.product(*valid_facts.values())):
                     if ability_requirements and not await self._do_enforcements(ability_requirements[link.ability.unique], operation, link, combo):
                         continue
-
                     copy_test = copy.deepcopy(decoded_test)
                     copy_link = copy.deepcopy(link)
                     variant, score, used = await self._build_single_test_variant(copy_test, combo)

--- a/app/utility/rule.py
+++ b/app/utility/rule.py
@@ -25,13 +25,13 @@ class RuleSet:
 
     async def apply_rules(self, facts):
         if await self._has_rules():
-            valid_facts = []
+            valid_facts = set()
             for fact in facts:
                 if await self.is_fact_allowed(fact):
-                    valid_facts.append(fact)
-            return [valid_facts]
+                    valid_facts.add(fact)
+            return valid_facts
         else:
-            return [facts]
+            return facts
 
     async def _has_rules(self):
         return len(self.rules)


### PR DESCRIPTION
This pull request is a preliminary change to make it easier to enforce fact relationships. Rather than getting a list of relevant facts in the beginning of _add_test_variants, this approach stores facts in a dictionary keyed by the trait of each fact available to the operation. Each value in the fact dictionary is a set of fact objects. I think that this makes some of the planning_svc functions cleaner, but also allows one to ground links "all at once" vs the current approach of one variable at a time. Consider an ability with the following command: 
echo '#{password}' is the password of '#{user}'
and has a relationship requirement of: "user, has_password, password"
Depending on the order of the facts collected in the list, the password may get filled in first or the user value may get filled in first. Either way, it is not totally clean to enforce the relationships when you don't know what facts may be substituted into the link later in the loop iteration. 
When substituting fact values into the links by using a dictionary, we can build relevant combinations of variables and check the relationships for every variable combination at once because we know the entire combination of facts that is going to be substituted into the link.
