### PR TITLE
Virts 508 uuid paws

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -15,12 +15,18 @@ class Agent(BaseObject):
                     server=self.server, location=self.location, pid=self.pid, ppid=self.ppid, trusted=self.trusted,
                     last_seen=self.last_seen.strftime('%Y-%m-%d %H:%M:%S'), last_trusted_seen=self.last_trusted_seen,
                     sleep_min=self.sleep_min, sleep_max=self.sleep_max, executors=self.executors,
-                    privilege=self.privilege)
+                    privilege=self.privilege, display_name=self.display_name)
 
-    def __init__(self, paw, architecture=None, platform=None, server=None, group=None,
+    @property
+    def display_name(self):
+        return '{}${}'.format(self.host, self.username)
+
+    def __init__(self, paw, host=None, username=None, architecture=None, platform=None, server=None, group=None,
                  location=None, pid=None, ppid=None, trusted=None, last_trusted_seen=None, sleep_min=None,
                  sleep_max=None, executors=None, privilege=None):
         self.paw = paw
+        self.host = host
+        self.username = username
         self.group = group
         self.architecture = architecture
         self.platform = platform

--- a/app/service/agent_svc.py
+++ b/app/service/agent_svc.py
@@ -13,14 +13,16 @@ class AgentService(BaseService):
         self.data_svc = self.get_service('data_svc')
         self.loop = asyncio.get_event_loop()
 
-    async def handle_heartbeat(self, paw, platform, server, group, executors, architecture, location, pid, ppid,
-                               sleep, privilege):
+    async def handle_heartbeat(self, paw, platform, server, group, host, username, executors, architecture, location,
+                               pid, ppid, sleep, privilege):
         """
         Accept all components of an agent profile and save a new agent or register an updated heartbeat.
         :param paw:
         :param platform:
         :param server:
         :param group:
+        :param host:
+        :param username:
         :param executors:
         :param architecture:
         :param location:
@@ -32,7 +34,7 @@ class AgentService(BaseService):
         """
         self.log.debug('HEARTBEAT (%s)' % paw)
         now = self.get_current_timestamp()
-        agent = Agent(paw=paw, platform=platform, server=server, location=location, executors=executors,
+        agent = Agent(paw=paw, host=host, username=username, platform=platform, server=server, location=location, executors=executors,
                       architecture=architecture, pid=pid, ppid=ppid, last_trusted_seen=now, privilege=privilege)
         if await self.data_svc.locate('agents', dict(paw=paw)):
             return await self.data_svc.store(agent)

--- a/app/service/agent_svc.py
+++ b/app/service/agent_svc.py
@@ -34,8 +34,9 @@ class AgentService(BaseService):
         """
         self.log.debug('HEARTBEAT (%s)' % paw)
         now = self.get_current_timestamp()
-        agent = Agent(paw=paw, host=host, username=username, platform=platform, server=server, location=location, executors=executors,
-                      architecture=architecture, pid=pid, ppid=ppid, last_trusted_seen=now, privilege=privilege)
+        agent = Agent(paw=paw, host=host, username=username, platform=platform, server=server, location=location,
+                      executors=executors, architecture=architecture, pid=pid, ppid=ppid, last_trusted_seen=now,
+                      privilege=privilege)
         if await self.data_svc.locate('agents', dict(paw=paw)):
             return await self.data_svc.store(agent)
         agent.sleep_min = agent.sleep_max = sleep

--- a/tests/test_agent_svc.py
+++ b/tests/test_agent_svc.py
@@ -14,8 +14,9 @@ class TestAgent(TestBase):
 
     def test_heartbeat(self):
         agent_details = dict(
-            paw='test$user', platform='windows', server='http://localhost:8888', group='my_group',
-            executors='psh,cmd', architecture=None, location=None, pid=1000, ppid=1, sleep=60, privilege=None
+            paw='bab90a6d-6ad7-45af-aab0-e2c2951f7bf8', platform='windows', server='http://localhost:8888',
+            host='test', username='user', group='my_group', executors='psh,cmd', architecture=None, location=None,
+            pid=1000, ppid=1, sleep=60, privilege=None
         )
         t1 = self.run_async(self.agent_svc.handle_heartbeat(**agent_details)).last_seen
         self.assertEqual(1, len(self.data_svc.ram['agents']))
@@ -25,7 +26,7 @@ class TestAgent(TestBase):
         self.assertTrue(t2 > t1)
 
     def test_instructions(self):
-        i = self.run_async(self.agent_svc.get_instructions('test$user'))
+        i = self.run_async(self.agent_svc.get_instructions('bab90a6d-6ad7-45af-aab0-e2c2951f7bf8'))
         self.assertEqual(i, '[]')
 
 


### PR DESCRIPTION
Changes:

* Host and user name are now separate fields for Agent objects 
* Agent objects have a new display name that is the same as the old PAW value (see https://github.com/mitre/sandcat/pull/127 ) 

Depends on: 
* https://github.com/mitre/sandcat/pull/127 

Related GUI changes: 
* https://github.com/mitre/chain/pull/211