### PR TITLE
add data/payloads dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ conf/*.yml
 data/object_store
 data/results/*
 !data/results/.gitkeep
+data/payloads/*
+!data/payloads/.gitkeep

--- a/server.py
+++ b/server.py
@@ -59,7 +59,7 @@ async def init(address, port, services, users):
     app.on_startup.append(background_tasks)
 
     app.router.add_route('*', '/file/download', services.get('file_svc').download)
-    app.router.add_route('POST', '/file/upload', services.get('file_svc').upload)
+    app.router.add_route('POST', '/file/upload', services.get('file_svc').upload_exfil)
 
     await attach_plugins(app, services)
     runner = web.AppRunner(app)


### PR DESCRIPTION
Changes:
* gitkeep a directory for payloads to be uploaded to 
* abstract the multipart upload request handling logic into it's own public method so that plugins can use it more easily