### PR TITLE
add timestamps to exfil dirs

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import uuid
 
@@ -122,7 +123,8 @@ class FileSvc(BaseService):
         return None
 
     async def _create_exfil_sub_directory(self, headers):
-        dir_name = headers.get('X-Request-ID', str(uuid.uuid4()))
+        dir_name = '{}.{}'.format(headers.get('X-Request-ID', str(uuid.uuid4())),
+                                  datetime.datetime.now().strftime('%Y.%h.%d.%H.%M'))
         path = os.path.join(self.exfil_dir, dir_name)
         if not os.path.exists(path):
             os.makedirs(path)


### PR DESCRIPTION
Changes:
* Add a date and time to exfil directories. 

Right now there's a good chance exfilled files will be clobbered if they're uploaded more than once from the same agent. I believe minute granularity here should be good enough for most cases. 