### PR TITLE
Changed column filter code for ignoring last column

### DIFF
--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -174,7 +174,7 @@ $(document).ready(function () {
             {
                 extend: 'colvis',
                 text: 'Filter Columns', // Button text.
-                columns: ':lt(10)' // Keep last column (the remove agent column) as is.
+                columns: ':not(:last-child)' // Keep last column (the remove agent column) as is.
             }
         ],
         // Button, length-changer, pRocessing display element, filtering, table,

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -174,7 +174,7 @@ $(document).ready(function () {
             {
                 extend: 'colvis',
                 text: 'Filter Columns', // Button text.
-                columns: ':lt(9)' // Keep last column (the remove agent column) as is.
+                columns: ':lt(10)' // Keep last column (the remove agent column) as is.
             }
         ],
         // Button, length-changer, pRocessing display element, filtering, table,


### PR DESCRIPTION
Since columns may change, I switched from a hardcoded index to simply ignoring the last column (which I assume will almost always be the "delete agent" button) for the filter.