### PR TITLE
Stopping condition implemented after feedback from Hunt and Manners

### DIFF
--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -18,10 +18,7 @@ class Planner(BaseObject):
         self.module = module
         self.params = params
         self.description = description
-        self.stopping_conditions = []
-        if stopping_conditions:
-            self.stopping_conditions = [Fact(trait, value) for sc in stopping_conditions for trait, value in
-                                        sc.items()]
+        self.stopping_conditions = self._set_stopping_conditions(stopping_conditions)
 
     def store(self, ram):
         existing = self.retrieve(ram['planners'], self.unique)
@@ -29,3 +26,12 @@ class Planner(BaseObject):
             ram['planners'].append(self)
             return self.retrieve(ram['planners'], self.unique)
         return existing
+
+    """ PRIVATE """
+
+    @staticmethod
+    def _set_stopping_conditions(conditions):
+        if conditions:
+            return [Fact(trait, value) for sc in conditions for trait, value in
+                    sc.items()]
+        return []

--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -1,4 +1,5 @@
 from app.utility.base_object import BaseObject
+from app.objects.c_fact import Fact
 
 
 class Planner(BaseObject):
@@ -11,12 +12,16 @@ class Planner(BaseObject):
     def display(self):
         return dict(name=self.name, module=self.module, params=self.params, description=self.description)
 
-    def __init__(self, name, module, params, description=None):
+    def __init__(self, name, module, params, stopping_conditions=None, description=None):
         super().__init__()
         self.name = name
         self.module = module
         self.params = params
         self.description = description
+        self.stopping_conditions = []
+        if stopping_conditions:
+            self.stopping_conditions = [Fact(trait, value) for sc in stopping_conditions for trait, value in
+                                        sc.items()]
 
     def store(self, ram):
         existing = self.retrieve(ram['planners'], self.unique)

--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -32,6 +32,5 @@ class Planner(BaseObject):
     @staticmethod
     def _set_stopping_conditions(conditions):
         if conditions:
-            return [Fact(trait, value) for sc in conditions for trait, value in
-                    sc.items()]
+            return [Fact(trait, value) for sc in conditions for trait, value in sc.items()]
         return []

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -92,6 +92,8 @@ class AppService(BaseService):
             for phase in operation.adversary.phases:
                 await self._update_operation(operation)
                 await planner.execute(phase)
+                if planner.stopping_condition_met:
+                    break
                 await operation.wait_for_phase_completion()
                 operation.phase = phase
             await self._cleanup_operation(operation)
@@ -133,7 +135,8 @@ class AppService(BaseService):
         planning_module = import_module(operation.planner.module)
         planner_params = ast.literal_eval(operation.planner.params)
         return getattr(planning_module, 'LogicalPlanner')(operation,
-                                                          self.get_service('planning_svc'), **planner_params)
+                                                          self.get_service('planning_svc'), **planner_params,
+                                                          stopping_conditions=operation.planner.stopping_conditions)
 
     async def _cleanup_operation(self, operation):
         for member in operation.agents:

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -231,7 +231,8 @@ class DataService(BaseService):
             for planner in self.strip_yml(filename):
                 await self.store(
                     Planner(name=planner.get('name'), module=planner.get('module'),
-                            params=json.dumps(planner.get('params')), description=planner.get('description'))
+                            params=json.dumps(planner.get('params')), description=planner.get('description'),
+                            stopping_conditions=planner.get('stopping_conditions'))
                 )
 
     async def _add_adversary_packs(self, pack):


### PR DESCRIPTION
Feedback Addressed:
- When a stopping condition is met, the entire operation is stopped, and the additional phases are not looped thru
- Planning_Svc check_stopping_conditions functions changed to two return statements instead of 3
- Stopping_condtions are stored as Fact objects into the c_planner when the planner yamls are loaded by data_svc.