### PR TITLE
Print adversary ID and name when erroring on an ability.

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -149,7 +149,7 @@ class DataService(BaseService):
             if not abilities:
                 abilities = await self._add_adversary_packs(step['id'])
                 if not abilities:
-                    self.log.error('Missing ability or pack (%s) for adversary: %s' % (step['id'], adversary['name']))
+                    self.log.error('Missing ability or pack (%s) for adversary: %s (%s)' % (step['id'], adversary['name'], adversary['id']))
                 else:
                     is_pack = True
 


### PR DESCRIPTION
When an ability is not within an adversary the following error message is produced:
```
ERROR:data_svc:Missing ability or pack (ea713bc4-63f0-491c-9a6f-0b01d560b87e.yml) for adversary: $ADVERSARY 
```
The lack of UUID4 for the $ADVERSARY makes this slightly annoying to debug. Providing the UUID will quickly allow developers to identify where the issue is.