### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:bionic
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+ENV GOPATH=/usr/bin/go
+RUN apt-get update && \
+    apt-get install python3 python3-pip golang -y && \
+    pip3 install --no-cache-dir -r requirements.txt
+ENTRYPOINT ["python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -39,10 +39,24 @@ Then start the server.
 python server.py
 ```
 
+
 ## Quick start
 
 To understand CALDERA, it helps to run an operation. Below are pre-built missions you can execute to understand 
 the system. The missions assume CALDERA is running locally.
+
+## Docker Quick Start
+If you wish to run CALDERA from a Docker container, execute the commands below.
+
+1. Build a container from the latest changes.
+```
+docker build . -t caldera:server
+```
+
+2. Run the docker caldera server
+```
+docker run -p 8888:8888 caldera:server
+```
 
 ### Mission #1: Nosy Neighbor
 


### PR DESCRIPTION
Now that CALDERA requires Golang to dynamically build binaries during execution, moving from a docker-compose file that used Python as a base image to a Dockerfile that uses ubuntu:1804 should be more flexible in the future. 

