### PR TITLE
adding function for link object that allows planners to check if the link has been parsed

### DIFF
--- a/app/objects/c_link.py
+++ b/app/objects/c_link.py
@@ -23,7 +23,8 @@ class Link(BaseObject):
 
     @property
     def states(self):
-        return dict(UNTRUSTED=-4,
+        return dict(PARSED=-5,
+                    UNTRUSTED=-4,
                     EXECUTE=-3,
                     DISCARD=-2,
                     PAUSE=-1)
@@ -63,8 +64,14 @@ class Link(BaseObject):
                 relationships = await self._parse_link_result(self.output, parser)
                 await self._update_scores(operation, increment=len(relationships))
                 await self._create_relationships(relationships, operation)
+                self.status = self.states['PARSED']
         except Exception as e:
             print(e)
+
+    def is_finished(self):
+        if self.status == self.states['PARSED'] or self.status == 0:
+            return True
+        return False
 
     """ PRIVATE """
 


### PR DESCRIPTION
Necessary changes for use by Guided_planner so that the planner can check if a link has been parsed. 