### PR TITLE
backtrack prevention fix

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -163,7 +163,7 @@ class BasePlanningService(BaseService):
     @staticmethod
     async def _exclude_existing(link, operation):
         all_hostnames = [agent.host for agent in await operation._active_agents()]
-        for item in link.relationships:
+        for item in link.used:
             # prevent backwards lateral movement
             if 'remote.host' in item.trait:
                 target_name = item.value.split('.')[0].lower()


### PR DESCRIPTION
While working on another ticket, I noticed that the planner core wasn't filtering out already-"owned" boxes, and would attempt to move backwards. This is highly inefficient and something we had previously fixed, but it would appear some recent changes to the core broke it. 