### PR TITLE
Fix for systems with both Python2 and Python3

### DIFF
--- a/auto-installer.sh
+++ b/auto-installer.sh
@@ -21,9 +21,9 @@ function all_install_go_dependencies() {
 
 function all_install_python_requirements() {
     pip3 install virtualenv
-    virtualenv calderaenv
+    virtualenv -p python3 calderaenv
     source calderaenv/bin/activate
-    pip install -r ./requirements.txt
+    pip3 install -r ./requirements.txt
 }
 
 function darwin_install_homebrew() {


### PR DESCRIPTION
This is a fix for systems (tested under Linux) that have both Python2 and Python3 installed. It makes sure that pip3 is used in a Python3 virtualenv