### PR TITLE
virts-851 result file encryption

### DIFF
--- a/app/objects/c_link.py
+++ b/app/objects/c_link.py
@@ -2,7 +2,6 @@ from base64 import b64decode
 from datetime import datetime
 from importlib import import_module
 
-from app.utility.base_service import BaseService
 from app.objects.c_ability import Ability
 from app.objects.c_fact import Fact
 from app.objects.secondclass.c_visibility import Visibility
@@ -47,13 +46,6 @@ class Link(BaseObject):
                     DISCARD=-2,
                     PAUSE=-1)
 
-    @property
-    def output(self):
-        try:
-            return BaseService.get_service('file_svc').read_result_file(self.unique)
-        except FileNotFoundError:
-            return None
-
     def __init__(self, operation, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0):
         super().__init__()
         self.id = id
@@ -74,6 +66,7 @@ class Link(BaseObject):
         self.used = []
         self.visibility = Visibility()
         self._pin = pin
+        self.output = None
 
     async def parse(self, operation):
         try:

--- a/app/objects/c_link.py
+++ b/app/objects/c_link.py
@@ -2,6 +2,7 @@ from base64 import b64decode
 from datetime import datetime
 from importlib import import_module
 
+from app.utility.base_service import BaseService
 from app.objects.c_ability import Ability
 from app.objects.c_fact import Fact
 from app.objects.secondclass.c_visibility import Visibility
@@ -49,9 +50,8 @@ class Link(BaseObject):
     @property
     def output(self):
         try:
-            with open('data/results/%s' % self.unique, 'r') as fle:
-                return fle.read()
-        except Exception:
+            return BaseService.get_service('file_svc').read_result_file(self.unique)
+        except FileNotFoundError:
             return None
 
     def __init__(self, operation, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -95,6 +95,7 @@ class ContactService(BaseService):
                     link.finish = self.get_service('data_svc').get_current_timestamp()
                     link.status = int(status)
                     if output:
+                        link.output = output
                         file_svc.write_result_file(id, output)
                         loop.create_task(link.parse(op))
                     await self.get_service('data_svc').store(Agent(paw=link.paw))

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -85,6 +85,7 @@ class ContactService(BaseService):
         :param pid:
         :return: a JSON status message
         """
+        file_svc = self.get_service('file_svc')
         try:
             loop = asyncio.get_event_loop()
             for op in await self.get_service('data_svc').locate('operations', match=dict(finish=None)):
@@ -94,8 +95,7 @@ class ContactService(BaseService):
                     link.finish = self.get_service('data_svc').get_current_timestamp()
                     link.status = int(status)
                     if output:
-                        with open('data/results/%s' % id, 'w') as out:
-                            out.write(output)
+                        file_svc.write_result_file(id, output)
                         loop.create_task(link.parse(op))
                     await self.get_service('data_svc').store(Agent(paw=link.paw))
                     return json.dumps(dict(status=True))

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -187,4 +187,3 @@ class FileSvc(BaseService):
                                    iterations=2 ** 20,
                                    backend=default_backend())
         return Fernet(base64.urlsafe_b64encode(generated_key.derive(bytes(api_key, 'utf-8'))))
-

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -127,8 +127,8 @@ class FileSvc(BaseService):
         with open('%s/%s' % (location, link_id), 'rb') as fle:
             buf = fle.read()
         if self.encryptor and buf.startswith(bytes(self._encryption_flag, encoding='utf-8')):
-            buf = self.encryptor.decrypt(buf[len(self._encryption_flag):]).decode()
-        return buf
+            buf = self.encryptor.decrypt(buf[len(self._encryption_flag):])
+        return buf.decode('utf-8')
 
     def write_result_file(self, link_id, output, location='data/results'):
         """

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -20,7 +20,7 @@ class FileSvc(BaseService):
         self.special_payloads = dict()
 
         if file_encryption and not (api_key and crypt_salt):
-            self.log.error('File encryption requires setting api_key and crypt_salt int he config file.')
+            self.log.error('File encryption requires setting api_key and crypt_salt in the config file.')
         elif file_encryption:
             generated_key = PBKDF2HMAC(algorithm=hashes.SHA256(),
                                        length=32,

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -114,7 +114,7 @@ class RestService(BaseService):
         link = await self.get_service('app_svc').find_link(link_id)
         if link:
             try:
-                _, content = await self.get_service('file_svc').read_file(name='%s' % link_id, location='data/results')
+                content = self.get_service('file_svc').read_result_file('%s' % link_id)
                 return dict(link=link.display, output=content.decode('utf-8'))
             except FileNotFoundError:
                 return ''

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -115,7 +115,7 @@ class RestService(BaseService):
         if link:
             try:
                 content = self.get_service('file_svc').read_result_file('%s' % link_id)
-                return dict(link=link.display, output=content.decode('utf-8'))
+                return dict(link=link.display, output=content)
             except FileNotFoundError:
                 return ''
         return ''

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -12,3 +12,5 @@ debug: True
 api_key: ADMIN123
 users:
   admin: admin
+file_encryption: True
+crypt_salt: REPLACE_WITH_RANDOM_VALUE

--- a/server.py
+++ b/server.py
@@ -86,7 +86,11 @@ if __name__ == '__main__':
         planning_svc = PlanningService()
         rest_svc = RestService()
         auth_svc = AuthService(cfg['api_key'])
-        file_svc = FileSvc(cfg['exfil_dir'])
+        file_svc = FileSvc(cfg['exfil_dir'],
+                           file_encryption=cfg['file_encryption'],
+                           api_key=cfg['api_key'],
+                           crypt_salt=cfg['crypt_salt']
+                           )
         app_svc = AppService(application=web.Application(), config=cfg)
 
         if args.fresh:


### PR DESCRIPTION
Changes: 

* use cryptography.Fernet to encrypt result files 
* Encryption key is generated based on the caldera api_key and a configurable crypt_salt value
* File encryption is enabled by default in the config file 
* Two new methods added to file_svc `read_result_file` and `write_result_file` that handle the encryption. 
* Result loading code throughout the app changed to use the new file_svc methods. 

Thoughts: 

I looked into doing AES directly, but the simplicity of using cryptography.Fernet was really nice, plus we already have it as a dependency. Our files are small enough that this listed limitation shouldn't apply to us: https://cryptography.io/en/latest/fernet/#limitations 

The new methods in file_svc can probably be generalized to a `write_sensitive_file` and `read_sensitive_file` method when we start encrypting more files.  Extending `FileService.read_file` would have been awkward since it's a coroutine and sometimes file results are called by synchronous functions. 