### PR TITLE
Reimplement get_file in file_svc to accept all flags

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -200,7 +200,7 @@ class RestApi:
         """
         try:
             payload = display_name = request.headers.get('file')
-            payload, content, display_name = await self.file_svc.get_file(**request.headers)
+            payload, content, display_name = await self.file_svc.get_file(request.headers)
 
             headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % display_name)])
             return web.Response(body=content, headers=headers)

--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -39,8 +39,8 @@ class RestApi:
         self.app_svc.application.router.add_route('POST', '/ping', self._ping)
         self.app_svc.application.router.add_route('POST', '/instructions', self._instructions)
         self.app_svc.application.router.add_route('POST', '/results', self._results)
-        self.app_svc.application.router.add_route('*', '/file/download', self.file_svc.download)
-        self.app_svc.application.router.add_route('POST', '/file/upload', self.file_svc.upload_exfil)
+        self.app_svc.application.router.add_route('*', '/file/download', self.download)
+        self.app_svc.application.router.add_route('POST', '/file/upload', self.upload_exfil_http)
 
     @template('login.html', status=401)
     async def login(self, request):
@@ -200,7 +200,7 @@ class RestApi:
         """
         try:
             payload = display_name = request.headers.get('file')
-            payload, content, display_name = await self.file_svc.read(payload, request.headers.get('platform'))
+            payload, content, display_name = await self.file_svc.get_file(**request.headers)
 
             headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % display_name)])
             return web.Response(body=content, headers=headers)

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -34,19 +34,19 @@ class FileSvc(BaseService):
         except Exception as e:
             return web.HTTPNotFound(body=e)
 
-    async def get_file(self, **kwargs):
+    async def get_file(self, request):
         """
         Retrieve file
         :param kwargs: Keyword arguments. The `file` key is REQUIRED.
         :return: File contents and optionally a display_name if the payload is a special payload
         """
-        if 'file' not in kwargs:
+        if 'file' not in request:
             raise FileNotFoundError('File key was not provided')
 
-        display_name = payload = kwargs.get('file')
-        self.log.info(kwargs)
+        display_name = payload = request.get('file')
+        self.log.info(request)
         if payload in self.special_payloads:
-            payload, display_name = await self.special_payloads[payload](kwargs)
+            payload, display_name = await self.special_payloads[payload](request)
         file_path, contents = await self.read_file(payload)
         return file_path, contents, display_name
 

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -14,34 +14,16 @@ class FileSvc(BaseService):
         self.data_svc = self.get_service('data_svc')
         self.special_payloads = dict()
 
-    async def download(self, request):
-        """
-        Accept a request with a required header, file, and an optional header, platform, and download the file.
-
-        :param request:
-        :return: a multipart file via HTTP
-        """
-        try:
-            payload = display_name = request.headers.get('file')
-            self.log.debug(request.headers)
-            if payload in self.special_payloads:
-                payload, display_name = await self.special_payloads[payload](request.headers)
-            payload, content = await self.read_file(payload)
-            headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % display_name)])
-            return web.Response(body=content, headers=headers)
-        except FileNotFoundError:
-            return web.HTTPNotFound(body='File not found')
-        except Exception as e:
-            return web.HTTPNotFound(body=e)
-
     async def get_file(self, request):
         """
         Retrieve file
-        :param kwargs: Keyword arguments. The `file` key is REQUIRED.
+        :param request: Request dictionary. The `file` key is REQUIRED.
+        :type request: dict or dict-equivalent
         :return: File contents and optionally a display_name if the payload is a special payload
+        :raises: KeyError if file key is not provided, FileNotFoundError if file cannot be found 
         """
         if 'file' not in request:
-            raise FileNotFoundError('File key was not provided')
+            raise KeyError('File key was not provided')
 
         display_name = payload = request.get('file')
         self.log.info(request)

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -20,7 +20,7 @@ class FileSvc(BaseService):
         :param request: Request dictionary. The `file` key is REQUIRED.
         :type request: dict or dict-equivalent
         :return: File contents and optionally a display_name if the payload is a special payload
-        :raises: KeyError if file key is not provided, FileNotFoundError if file cannot be found 
+        :raises: KeyError if file key is not provided, FileNotFoundError if file cannot be found
         """
         if 'file' not in request:
             raise KeyError('File key was not provided')


### PR DESCRIPTION
get_file now functions like the original `file_svc.download` and takes in a dict to allow for passing of all required flags for special payloads.