### PR TITLE
WIP: Windows bugfixes

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -160,16 +160,10 @@ class FileSvc(BaseService):
         :return:
         """
         if os.name == 'nt':
-            os.system(
-                'set GOARCH=%s set GOOS=%s %s go build %s -o %s -ldflags=\'%s\' %s' % (arch, platform, cflags,
-                                                                                       buildmode, output, ldflags,
-                                                                                       src_fle)
-            )
+            env_var = 'set GOARCH=%s set GOOS=%s' % (arch, platform)
         else:
-            os.system(
-                'GOARCH=%s GOOS=%s %s go build %s -o %s -ldflags=\'%s\' %s' % (arch, platform, cflags, buildmode, output,
-                                                                           ldflags, src_fle)
-            )
+            env_var = 'GOARCH=%s GOOS=%s' % (arch, platform)
+        os.system('%s %s go build %s -o %s -ldflags=\'%s\' %s' % (env_var, cflags, buildmode, output, ldflags, src_fle))
 
     """ PRIVATE """
 

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -159,10 +159,17 @@ class FileSvc(BaseService):
         :param buildmode: GO compiler buildmode flag
         :return:
         """
-        os.system(
-            'GOARCH=%s GOOS=%s %s go build %s -o %s -ldflags=\'%s\' %s' % (arch, platform, cflags, buildmode, output,
+        if os.name == 'nt':
+            os.system(
+                'set GOARCH=%s set GOOS=%s %s go build %s -o %s -ldflags=\'%s\' %s' % (arch, platform, cflags,
+                                                                                       buildmode, output, ldflags,
+                                                                                       src_fle)
+            )
+        else:
+            os.system(
+                'GOARCH=%s GOOS=%s %s go build %s -o %s -ldflags=\'%s\' %s' % (arch, platform, cflags, buildmode, output,
                                                                            ldflags, src_fle)
-        )
+            )
 
     """ PRIVATE """
 

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -122,7 +122,7 @@ class BasePlanningService(BaseService):
             score += (score + var.score)
             used.append(var)
             re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
-            copy_test = re.sub(re_variable, str(var.value).strip(), copy_test)
+            copy_test = re.sub(re_variable, var.value.replace('\\','\\\\').strip(), copy_test)
         return copy_test, score, used
 
     @staticmethod

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -122,7 +122,7 @@ class BasePlanningService(BaseService):
             score += (score + var.score)
             used.append(var)
             re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
-            copy_test = re.sub(re_variable, var.value.replace('\\','\\\\').strip(), copy_test)
+            copy_test = re.sub(re_variable, var.value.replace('\\', '\\\\').strip(), copy_test)
         return copy_test, score, used
 
     @staticmethod


### PR DESCRIPTION
I ran into a few instances of weird behavior when testing some of the new planners in my windows environment. I tracked down 2 separate things: 1) go compiling not working because the way env variables are set is different on windows (easy and quick fix), and 2) some variables don't properly handle the \ dividers windows environments use, and this can cause issues with regex replace (also an easy enough fix). This pull would fix both, but there may be better places/ways to address these issues.