### PR TITLE
destroy data/sources when --fresh is used

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -41,7 +41,7 @@ class DataService(BaseService):
         """
         if os.path.exists('data/object_store'):
             os.remove('data/object_store')
-        for d in ['data/results', 'data/adversaries', 'data/abilities', 'data/facts']:
+        for d in ['data/results', 'data/adversaries', 'data/abilities', 'data/facts', 'data/sources']:
             for f in glob.glob('%s/*' % d):
                 if not f.startswith('.'):
                     os.remove(f)


### PR DESCRIPTION
When `server.py --fresh` is executed, data/sources are not destroyed. The only time the data_svc.destory() method is leveraged is when the --fresh argument is provided (server.py line 97). For this reason, it is safe include the data/sources directory in destroy() 