### PR TITLE
Move C2 configuration reader to core

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -118,8 +118,9 @@ class ContactService(BaseService):
 
     async def load_c2_config(self, directory):
         c2_configs = {}
+        data_svc = self.get_service('data_svc')
         for filename in glob.iglob('%s/*.yml' % directory, recursive=False):
-            for c2 in self.data_svc.strip_yml(filename):
+            for c2 in data_svc.strip_yml(filename):
                 c2_configs[c2['name']] = c2
         return c2_configs
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -1,4 +1,5 @@
 import asyncio
+import glob
 import json
 from datetime import datetime
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -115,6 +115,13 @@ class ContactService(BaseService):
         except Exception:
             pass
 
+    async def load_c2_config(self, directory):
+        c2_configs = {}
+        for filename in glob.iglob('%s/*.yml' % directory, recursive=False):
+            for c2 in self.data_svc.strip_yml(filename):
+                c2_configs[c2['name']] = c2
+        return c2_configs
+
     """ PRIVATE """
 
     async def _start_c2_channel(self, contact):


### PR DESCRIPTION
`load_c2_configs` pulled into core from `stockpile` to allow multiple plugins to utilize the function. Registration calls that use `stockpile`'s `load_c2_configs` will need to be modified to switch to the `contact_svc` version.