### PR TITLE
Remove Agent Name Conflicts

### DIFF
--- a/conf/default.yml
+++ b/conf/default.yml
@@ -59,4 +59,3 @@ agent_config:
       - ps
       - pstree
       - rc.common
-secrets: {}

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -60,5 +60,3 @@ agent_config:
       - pstree
       - rc.common
 secrets: {}
-
-

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -38,9 +38,6 @@ agent_config:
       - winlogon
       - taskmgr
     darwin:
-      - Documents
-      - Downloads
-      - Desktop
       - asl.conf
       - hosts
       - chrome

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -59,3 +59,4 @@ agent_config:
       - ps
       - pstree
       - rc.common
+secrets: {}

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -60,3 +60,5 @@ agent_config:
       - pstree
       - rc.common
 secrets: {}
+
+


### PR DESCRIPTION
these could easily cause a conflict when attempting to start caldera from a users home folder