### PR TITLE
yaml config loading

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -239,7 +239,7 @@ class DataService(BaseService):
             for planner in self.strip_yml(filename):
                 await self.store(
                     Planner(planner_id=planner.get('id'), name=planner.get('name'), module=planner.get('module'),
-                            params=json.dumps(planner.get('params')), description=planner.get('description'),
+                            params=str(planner.get('params')), description=planner.get('description'),
                             stopping_conditions=planner.get('stopping_conditions'),
                             ignore_enforcement_modules=planner.get('ignore_enforcement_modules', ()))
                 )

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -1,7 +1,6 @@
 import asyncio
 import copy
 import glob
-import json
 import os.path
 import pickle
 import traceback


### PR DESCRIPTION
currently using json.dumps() to dump yaml config to string causes booleans to become lowercase..when those booleans are then interpreted by ast.literal_eval they blow up, this fixes that