### PR TITLE
virts-909: removing unnecessary header grab, custom payload name

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -197,7 +197,6 @@ class RestApi(BaseWorld):
         :return: a multipart file via HTTP
         """
         try:
-            payload = display_name = request.headers.get('file')
             payload, content, display_name = await self.file_svc.get_file(request.headers)
             headers = dict([('CONTENT-DISPOSITION', 'attachment; filename="%s"' % display_name)])
             return web.Response(body=content, headers=headers)

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -38,6 +38,8 @@ class FileSvc(BaseService):
         if payload in self.special_payloads:
             payload, display_name = await self.special_payloads[payload](request)
         file_path, contents = await self.read_file(payload)
+        if request.get('name'):
+            display_name = request.get('name')
         return file_path, contents, display_name
 
     async def save_file(self, filename, payload, target_dir):


### PR DESCRIPTION
Header flag allows payload name to overwrite if it exists