### PR TITLE
Don't check cleanup links against requirements

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -95,7 +95,7 @@ class BasePlanningService(BaseService):
         return links
 
     async def remove_links_missing_requirements(self, links, operation):
-        links[:] = [l for l in links if await self._do_enforcements(l, operation)]
+        links[:] = [l for l in links if l.cleanup or await self._do_enforcements(l, operation)]
         return links
 
     @staticmethod


### PR DESCRIPTION
We don't need to check requirements for cleanup links. Without this fix, some cleanup links won't get run because the requirement on the ability is no longer valid. For example, an ability with a requirement that a file doesn't exist which creates that file. When the cleanup link was checked against the requirement it would fail because the ability had created it.

Here is an example ability that failed to run the cleanup command without this fix: https://github.com/mitre/stockpile/blob/master/data/abilities/lateral-movement/65048ec1-f7ca-49d3-9410-10813e472b30.yml