### PR TITLE
Eliminate 500 response

### DIFF
--- a/app/contacts/contact_http.py
+++ b/app/contacts/contact_http.py
@@ -37,3 +37,4 @@ class Http(BaseWorld):
     async def _results(self, request):
         data = json.loads(self.contact_svc.decode_bytes(await request.read()))
         await self.contact_svc.save_results(**data)
+        return web.Response()


### PR DESCRIPTION
Add a web.Response() return statement to the _results method in order to stop getting 500 response codes from the server when POSTing to /result