### PR TITLE
Use correct vars for cleanup commands

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -52,7 +52,7 @@ class PlanningService(BasePlanningService):
         else:
             for agent in operation.agents:
                 links.extend(await self._check_and_generate_cleanup_links(agent, operation))
-        return reversed(await self.trim_links(operation, links, agent))
+        return reversed(links)
 
     async def generate_and_trim_links(self, agent, operation, abilities, trim=True):
         """
@@ -124,7 +124,9 @@ class PlanningService(BasePlanningService):
             ability = (await self.get_service('data_svc').locate('abilities',
                                                                  match=dict(unique=link.ability.unique)))[0]
             if ability.cleanup and link.status >= 0:
-                links.append(Link(operation=operation.id, command=ability.cleanup, paw=agent.paw, cleanup=1,
+                decoded_cmd = self.decode(ability.cleanup, agent, agent.group, operation.RESERVED)
+                variant, _, _ = await self._build_single_test_variant(decoded_cmd, link.used)
+                links.append(Link(operation=operation.id, command=self.encode_string(variant), paw=agent.paw, cleanup=1,
                                   ability=ability, score=0, jitter=0, status=link_status))
         return links
 


### PR DESCRIPTION
Ensures that cleanup links with vars will be built with the same vars used by the original link.

Changes: 

* trim_links no longer called to instantiate cleanup commands 
* cleanup commands are now instantiated with the Link.used facts from the link that is being cleaned up. 