### PR TITLE
VIRTS-550 Make sure "unsupported browser" notification stays while scrolling (CLEAN)

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -320,6 +320,10 @@ p[onclick] {
   height: 17px;
   font-size: 14px;
   text-align: center;
+  position: fixed;
+  top:43; left:5; bottom: auto;
+  z-index: 20;
+  width: 100%;
 }
 
 /* The close button */

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -128,5 +128,12 @@ function alphabetize_dropdown(obj) {
 window.onload = function checkBrowser(){
     if(navigator.vendor !==  "Google Inc." && navigator.vendor !==  "Apple Computer, Inc.") {
         $('#notice').css('display', 'block');
+        $(window).scroll(function(){
+            var sticky = $('.notice'),
+                scroll = $(window).scrollTop();
+
+            if (scroll >= 100) sticky.addClass('.notice');
+            else sticky.removeClass('.notice');
+          });
     }
 };


### PR DESCRIPTION
Added a few lines of code to shared.css and shared.js to make the "unsupported browser" notification banner stick on the page while scrolling.