### PR TITLE
terminate agents from web

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -124,11 +124,12 @@ class RestService(BaseService):
         return dict(contacts=self.get_service('contact_svc').report.get(contact.get('contact'), dict()))
 
     async def update_agent_data(self, data):
+        if 'paw' not in data:
+            await self._update_global_props(data.get('sleep_min'), data.get('sleep_max'), data.get('watchdog'))
+
         for agent in await self.get_service('data_svc').locate('agents', match=dict(paw=data.get('paw'))):
             await agent.gui_modification(**data)
             return agent.display
-        else:
-            await self._update_global_props(data.get('sleep_min'), data.get('sleep_max'), data.get('watchdog'))
 
     async def update_chain_data(self, data):
         link = await self.get_service('app_svc').find_link(data.pop('link_id'))

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -17,7 +17,6 @@ select {
    border-radius: 10px;
 }
 .modal button {
-    background-color: green;
     color: white;
     padding: 14px 20px;
     margin: 8px 0;

--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -118,6 +118,7 @@ pre {
     border-radius: 4px;
     background-color: darkgreen;
     margin:0;
+    cursor: pointer;
 }
 .button-success,
 .button-notready,

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -52,7 +52,7 @@
 
 <div id="agent-modal" class="modal">
     <form class="modal-content">
-        <div class="container section-profile row ability-viewer modal-box">
+        <div class="container row ability-viewer modal-box">
             <div class="column" style="flex:100%;">
                 <h3 id="modal-paw"></h3>
                 <p style="font-size: 11px">* Property can be updated</p>
@@ -116,6 +116,7 @@
                     </tr>
                 </table>
                 <br>
+                <button type="button" class="button-warn" onclick="killAgent()">Kill Agent</button>
                 <button type="button" class="button-row" onclick="updateAgent()">Save</button>
             </div>
         <div class="imgcontainer">
@@ -195,6 +196,24 @@
         let globalWatchdog = $('#globalWatchdog').val();
         let d = {"index": "agents","sleep_min":parseInt(globalMinsleep),"sleep_max":parseInt(globalMaxsleep),"watchdog":parseInt(globalWatchdog)};
         restRequest('PUT', d, doNothing);
+    }
+    function killAgent(){
+        /**
+        Sets the currently displayed agent to terminate by setting its sleep seconds greater than its watchdog minutes.
+        **/
+        let data = {
+            'index': 'agents',
+            'paw': $('#modal-paw').text(),
+            'watchdog': 1,
+            'sleep_min': 2*60,
+            'sleep_max': 2*60
+        };
+        if (confirm(`Are you sure you want to terminate agent ${data.paw}?`)){
+            restRequest('PUT', data, (data) => {
+                document.getElementById('agent-modal').style.display='none';
+                stream(`Agent ${data.paw} will self terminate.`);
+            });
+        }
     }
 
     function parseSleep(sleep){

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -52,7 +52,7 @@
 
 <div id="agent-modal" class="modal">
     <form class="modal-content">
-        <div class="container row ability-viewer modal-box">
+        <div class="container section-profile row ability-viewer modal-box">
             <div class="column" style="flex:100%;">
                 <h3 id="modal-paw"></h3>
                 <p style="font-size: 11px">* Property can be updated</p>


### PR DESCRIPTION
Changes:

* Add button to agent model to schedule an agent to terminate itself
* Change logic of changing agent global setting to avoid accidentally changing globals when specifying an agent paw that does not exist 
* removed background color from buttons in modal.css (this was overriding the button color classes defined in shared.css (I didn't notice any button style that was broken by the change, but we should keep our eyes open for them)
* Add `cursor: pointer;` style for more buttons in the web app. 