### PR TITLE
bug fixes for saving sources and regex for file paths

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -121,7 +121,7 @@ class BasePlanningService(BaseService):
             score += (score + var.score)
             used.append(var)
             re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
-            copy_test = re.sub(re_variable, str(var.value).strip(), copy_test)
+            copy_test = re.sub(re_variable, str(var.value).strip().encode('unicode-escape').decode('utf-8'), copy_test)
         return copy_test, score, used
 
     @staticmethod

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -167,7 +167,7 @@
             source.data('id', id);
         }
         let data = {};
-        data['index'] = 'source';
+        data['index'] = 'sources';
         data['id'] = id;
         data['name'] = name;
         data['facts'] = [];


### PR DESCRIPTION
1. Saving sources would return an internal server error due to the change in the rest_api.py rest_core function which now expects "sources" for the index, not "source"
2. Server would fail to build the test variant for compressing host.dir.staged due to the way the file path was being parsed in Python 3.7 and would skip the "compress staged directory" ability saying the fact dependency (host.dir.staged) was not met. This is despite the staged directory having been created and host.dir.staged appearing properly in the source's facts.