### PR TITLE
Logging exception thrown in c_operation so that it is not hidden. Cap…

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -1,6 +1,7 @@
 import ast
 import asyncio
 import copy
+import logging
 import re
 import uuid
 from collections import defaultdict
@@ -235,8 +236,8 @@ class Operation(BaseObject):
             await self._cleanup_operation(services)
             await self.close()
             await self._save_new_source(services)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.error(e)
 
     """ PRIVATE """
 

--- a/app/utility/base_obfuscator.py
+++ b/app/utility/base_obfuscator.py
@@ -13,6 +13,6 @@ class BaseObfuscator(BaseWorld):
                 o = self.__getattribute__(link.ability.executor)
                 return o(link, **kwargs)
         except Exception:
-            logging.error("Failed to run BaseObfuscator, retuning default decoded bytes")
+            logging.error('Failed to run BaseObfuscator, returning default decoded bytes')
 
         return self.decode_bytes(link.command)

--- a/app/utility/base_obfuscator.py
+++ b/app/utility/base_obfuscator.py
@@ -1,3 +1,5 @@
+import logging
+
 from app.utility.base_world import BaseWorld
 
 
@@ -6,7 +8,11 @@ class BaseObfuscator(BaseWorld):
     def run(self, link, **kwargs):
         agent = self.__getattribute__('agent')
         supported_platforms = self.__getattribute__('supported_platforms')
-        if agent.platform in supported_platforms and link.ability.executor in agent.executors:
-            o = self.__getattribute__(link.ability.executor)
-            return o(link, **kwargs)
+        try:
+            if agent.platform in supported_platforms and link.ability.executor in agent.executors:
+                o = self.__getattribute__(link.ability.executor)
+                return o(link, **kwargs)
+        except Exception:
+            logging.error("Failed to run BaseObfuscator, retuning default decoded bytes")
+
         return self.decode_bytes(link.command)


### PR DESCRIPTION
…turing exception that can be thrown when running the base64 obfuscator. If this exception wasn't caught then no links would actually be generated for the agent