### PR TITLE
Virts 917

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "plugins/gameboard"]
 	path = plugins/gameboard
 	url = https://github.com/mitre/gameboard.git
+[submodule "plugins/research"]
+	path = plugins/research
+	url = git@gitlab.mitre.org:caldera/research.git
+[submodule "plugins/dark"]
+	path = plugins/dark
+	url = git@gitlab.mitre.org:caldera/dark.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,3 @@
 [submodule "plugins/gameboard"]
 	path = plugins/gameboard
 	url = https://github.com/mitre/gameboard.git
-[submodule "plugins/research"]
-	path = plugins/research
-	url = git@gitlab.mitre.org:caldera/research.git
-[submodule "plugins/dark"]
-	path = plugins/dark
-	url = git@gitlab.mitre.org:caldera/dark.git

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -230,7 +230,6 @@ class Operation(BaseObject):
             self.phases_enabled = False
             while not await self.is_closeable():
                 await asyncio.sleep(10)
-                await self.update_operation(services)    # TODO: Call no longer needed if method continues to just have an agent update
                 await self._run_phases(services, planner)
             await self._cleanup_operation(services)
             await self.close()
@@ -243,7 +242,6 @@ class Operation(BaseObject):
     async def _run_phases(self, services, planner):
         for phase in self.adversary.phases:
             if not await self.is_closeable():
-                await self.update_operation(services)     # TODO: Call no longer needed if method continues to just have an agent update
                 await planner.execute(phase)
                 if planner.stopping_condition_met:
                     break

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -230,7 +230,7 @@ class Operation(BaseObject):
             self.phases_enabled = False
             while not await self.is_closeable():
                 await asyncio.sleep(10)
-                await self._update_operation(services)
+                await self.update_operation(services)    # TODO: Call no longer needed if method continues to just have an agent update
                 await self._run_phases(services, planner)
             await self._cleanup_operation(services)
             await self.close()
@@ -243,7 +243,7 @@ class Operation(BaseObject):
     async def _run_phases(self, services, planner):
         for phase in self.adversary.phases:
             if not await self.is_closeable():
-                await self._update_operation(services)
+                await self.update_operation(services)     # TODO: Call no longer needed if method continues to just have an agent update
                 await planner.execute(phase)
                 if planner.stopping_condition_met:
                     break
@@ -279,7 +279,7 @@ class Operation(BaseObject):
         )
         await services.get('rest_svc').persist_source(data)
 
-    async def _update_operation(self, services):
+    async def update_operation(self, services):
         self.agents = await services.get('rest_svc').construct_agents_for_group(self.group)
 
     async def _unfinished_links_for_agent(self, paw):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -95,6 +95,7 @@ class ContactService(BaseService):
         agent = await self.get_service('data_svc').store(Agent(
             sleep_min=self.sleep_min, sleep_max=self.sleep_max, watchdog=self.watchdog, **kwargs)
         )
+        await self._add_agent_to_operation(agent)
         self.log.debug('First time %s beacon from %s' % (agent.contact, agent.paw))
         return agent, await self._get_instructions(agent.paw) + await self._get_bootstrap_instructions(agent)
 
@@ -151,3 +152,17 @@ class ContactService(BaseService):
             cmd = self.encode_string(agent.replace(i.test))
             instructions.append(Instruction(identifier=new_id, command=cmd, executor=i.executor))
         return instructions
+
+    async def _add_agent_to_operation(self, agent):
+        """Determine which operation(s) incoming agent belongs to and
+        add it to operation.
+
+        Note: Agent is added immediately to operation, as certain planners
+        may execute single links at a time before relinquishing control back
+        to c_operation.run() (when previously the operation was updated with
+        new agents), and during those link executions, new agents may arise
+        which the planner needs to be aware of.
+        """
+        for op in await self.get_service('data_svc').locate('operations', match=dict(finish=None)):
+            if op.group == agent.group or op.group == None:
+                op.update_operation(self.get_services())

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -164,5 +164,5 @@ class ContactService(BaseService):
         which the planner needs to be aware of.
         """
         for op in await self.get_service('data_svc').locate('operations', match=dict(finish=None)):
-            if op.group == agent.group or op.group == None:
+            if op.group == agent.group or op.group is None:
                 op.update_operation(self.get_services())


### PR DESCRIPTION
Modification: When an agent beacons in, it is immediately added/picked up by the corresponding operation(s). Solves issue of varying planners not seeing agents until the next phase.

@privateducky - see the lines '#TODO' , do we need still need those calls to update_operation()? I dont think we do, unless more functionality will be added to it other than the agent update.