### PR TITLE
support writing config to non-default.yml config files

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -144,10 +144,10 @@ class AppService(BaseService):
     """ PRIVATE """
 
     async def _save_configuration(self):
-        with open('conf/{}.yml'.format(self.config_name), 'w') as config:
+        with open('conf/{}.yml'.format(self.config_name), 'r') as config:
             old_config = yaml.load(config, Loader=yaml.FullLoader)
         if self.get_config() != old_config:
-            with open('conf/default.yml', 'w') as config:
+            with open('conf/{}.yml'.format(self.config_name), 'w') as config:
                 config.write(yaml.dump(self.get_config()))
 
     async def _destroy_plugins(self):

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -19,10 +19,11 @@ from app.utility.base_service import BaseService
 
 class AppService(BaseService):
 
-    def __init__(self, application):
+    def __init__(self, application, config_name):
         self.application = application
         self.log = self.add_service('app_svc', self)
         self.loop = asyncio.get_event_loop()
+        self.config_name = config_name
 
     async def start_sniffer_untrusted_agents(self):
         """
@@ -143,8 +144,11 @@ class AppService(BaseService):
     """ PRIVATE """
 
     async def _save_configuration(self):
-        with open('conf/default.yml', 'w') as config:
-            config.write(yaml.dump(self.get_config()))
+        with open('conf/{}.yml'.format(self.config_name), 'w') as config:
+            old_config = yaml.load(config, Loader=yaml.FullLoader)
+        if self.get_config() != old_config:
+            with open('conf/default.yml', 'w') as config:
+                config.write(yaml.dump(self.get_config()))
 
     async def _destroy_plugins(self):
         for plugin in await self._services.get('data_svc').locate('plugins'):

--- a/server.py
+++ b/server.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
         rest_svc = RestService()
         auth_svc = AuthService()
         file_svc = FileSvc()
-        app_svc = AppService(application=web.Application())
+        app_svc = AppService(application=web.Application(), config_name=config)
 
         if args.fresh:
             asyncio.get_event_loop().run_until_complete(data_svc.destroy())


### PR DESCRIPTION
Changes: 

* previously changes to in memory config would always be written to default.yml even if caldera was started with a different conf file
* only write changes if the config has actually changed (this prevents re-ordering the conf file unecessarily) 

Thoughts: 

Not sure I like re-writing the config file that much, since it reorders the option and will eat any comments in it.  Maybe we could instead write a `<conf-name>-overide.yml` file and then our config loading option would get the config from the original file, and then just `.update()` it with the overrides. 