### PR TITLE
stop silencing some important logging handlers

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 import copy
 import re
+import logging
 import traceback
 import uuid
 from collections import defaultdict
@@ -235,8 +236,8 @@ class Operation(BaseObject):
             await self._cleanup_operation(services)
             await self.close()
             await self._save_new_source(services)
-        except Exception:
-            traceback.print_exc()
+        except Exception as e:
+            logging.error(e, exc_info=True)
 
     """ PRIVATE """
 

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -3,7 +3,6 @@ import asyncio
 import copy
 import re
 import logging
-import traceback
 import uuid
 from collections import defaultdict
 from datetime import datetime

--- a/server.py
+++ b/server.py
@@ -20,8 +20,11 @@ from app.utility.base_world import BaseWorld
 
 def setup_logger():
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-    for logger in [name for name in logging.root.manager.loggerDict]:
-        logging.getLogger(logger).setLevel(100)
+    for logger_name in logging.root.manager.loggerDict.keys():
+        if logger_name in ('aiohttp.server', 'asyncio'):
+            continue
+        else:
+            logging.getLogger(logger_name).setLevel(100)
 
 
 async def build_docs():


### PR DESCRIPTION
Changes: 

* stop silencing the asyncio logging handler.  When a unhandled exception occurs in a coroutine, asyncio will grab it and emit it via this handler. 
* stop silencing aiohttp.server logging handler.  Not 100% sure we should keep this on, but aiohttp docs make it sound like it might be helpful when debugging API problems https://docs.aiohttp.org/en/stable/logging.html#error-logs 

Thoughts / Alternative approaches: 

* If the asyncio logs are really loud in some cases, we can either raise the level (but not set to 100), or if we need to be more selective, we can create a custom logging handler for asyncio that will ignore the exceptions we don't care about https://docs.aiohttp.org/en/stable/logging.html#error-logs 