### PR TITLE
remove unecessary logic that actually raised an exception

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import websockets
 
 from app.utility.base_world import BaseWorld

--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -14,9 +14,8 @@ class WebSocket(BaseWorld):
         self.handler = Handler(services)
 
     async def start(self):
-        loop = asyncio.get_event_loop()
         web_socket = self.get_config('app.contact.websocket')
-        loop.create_task(await websockets.serve(self.handler.handle, '0.0.0.0', web_socket.split(':')[1]))
+        await websockets.serve(self.handler.handle, '0.0.0.0', web_socket.split(':')[1])
 
 
 class Handler:


### PR DESCRIPTION
I noticed an exception after enabling the asyncio log handler.  It looks like we were setting up the websocket server, and then unnecessarily (and incorrectly) treating the returned value like a coroutine when it's not.  


Fixes: 
```
future: <Task finished coro=<WebSocket.start() done, defined at /home/hfoster/projects/caldera-proj/caldera/app/contacts/contact_websocket.py:16> exception=TypeError('a coroutine was expected, got <websockets.server.WebSocketServer object at 0x7f301dbbc090>')>
Traceback (most recent call last):
  File "/home/hfoster/projects/caldera-proj/caldera/app/contacts/contact_websocket.py", line 19, in start
    loop.create_task(await websockets.serve(self.handler.handle, '0.0.0.0', web_socket.split(':')[1]))
  File "/usr/lib64/python3.7/asyncio/base_events.py", line 400, in create_task
    task = tasks.Task(coro, loop=self)
```