### PR TITLE
ability to comma separate platforms for agent names

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -67,9 +67,25 @@ class ContactService(BaseService):
         self._sleep_min = agent_config['sleep_min']
         self._sleep_max = agent_config['sleep_max']
         self._watchdog = agent_config['watchdog']
-        self._file_names = agent_config['names']
+        self._file_names = self.collect_file_names(agent_config['names'])
         self._untrusted_timer = agent_config['untrusted_timer']
         self._bootstrap_instructions = agent_config['bootstrap_abilities']
+
+    def collect_file_names(self, names):
+        multiplatform = []
+        for platform, agents in names.items():
+            if "," in platform:
+                multiplatform.append(platform)
+
+        if multiplatform is not []:
+            for string in multiplatform:
+                agents = names[string]
+                platforms = string.split(",")
+                for p in platforms:
+                    new = {p: agents}
+                    names.update(new)
+                del names[string]
+        return names
 
     async def register(self, contact):
         try:

--- a/conf/agents.yml
+++ b/conf/agents.yml
@@ -49,7 +49,7 @@ agent_config:
       - coreservicesd
       - authd
       - splunkd
-    linux:
+    linux,freebsd:
       - hosts
       - ntp.conf
       - mnt


### PR DESCRIPTION
In the agents.yml file, rather than duplicate agent name lists for each platforms, lets add the ability to provide multiple platforms to a single list of agents by comma separating values. 