### PR TITLE
glob caused issues when running server in pycharm on windows

### DIFF
--- a/app/service/learning_svc.py
+++ b/app/service/learning_svc.py
@@ -16,7 +16,7 @@ class LearningService(BaseService):
     def add_parsers(directory):
         parsers = []
         for filepath in glob.iglob('%s/**.py' % directory):
-            module = import_module(filepath.replace('/', '.').replace('.py', ''))
+            module = import_module(filepath.replace('/', '.').replace('\\', '.').replace('.py', ''))
             parsers.append(getattr(module, 'Parser')())
         return parsers
 


### PR DESCRIPTION
glob.iglob in learning_svc.py used backslashes instead of forward slashes on windows. This change replaces backslashes as well