### PR TITLE
Virts 619

### DIFF
--- a/app/api/packs/campaign.py
+++ b/app/api/packs/campaign.py
@@ -34,7 +34,7 @@ class CampaignPack(BaseWorld):
         tactics = set([a.tactic.lower() for a in abilities])
         payloads = await self.rest_svc.list_payloads()
         adversaries = sorted([a.display for a in await self.data_svc.locate('adversaries', match=access)],
-                              key=lambda a: a['name'])
+                             key=lambda a: a['name'])
         return dict(adversaries=adversaries, exploits=[a.display for a in abilities], payloads=payloads,
                     tactics=tactics)
 
@@ -45,10 +45,10 @@ class CampaignPack(BaseWorld):
         hosts = [h.display for h in await self.data_svc.locate('agents', match=access)]
         groups = sorted(list(set(([h['group'] for h in hosts]))))
         adversaries = sorted([a.display for a in await self.data_svc.locate('adversaries', match=access)],
-                              key=lambda a: a['name'])
+                             key=lambda a: a['name'])
         sources = [s.display for s in await self.data_svc.locate('sources', match=access)]
         planners = sorted([p.display for p in await self.data_svc.locate('planners')],
-                           key=lambda p: p['name'])
+                          key=lambda p: p['name'])
         obfuscators = [o.display for o in await self.data_svc.locate('obfuscators')]
         operations = [o.display for o in await self.data_svc.locate('operations', match=access)]
         return dict(operations=operations, groups=groups, adversaries=adversaries, sources=sources, planners=planners,

--- a/app/api/packs/campaign.py
+++ b/app/api/packs/campaign.py
@@ -33,7 +33,8 @@ class CampaignPack(BaseWorld):
         abilities = await self.data_svc.locate('abilities', match=access)
         tactics = set([a.tactic.lower() for a in abilities])
         payloads = await self.rest_svc.list_payloads()
-        adversaries = [a.display for a in await self.data_svc.locate('adversaries', match=access)]
+        adversaries = sorted([a.display for a in await self.data_svc.locate('adversaries', match=access)],
+                              key=lambda a: a['name'])
         return dict(adversaries=adversaries, exploits=[a.display for a in abilities], payloads=payloads,
                     tactics=tactics)
 
@@ -42,10 +43,12 @@ class CampaignPack(BaseWorld):
     async def _section_operations(self, request):
         access = dict(access=tuple(await self.auth_svc.get_permissions(request)))
         hosts = [h.display for h in await self.data_svc.locate('agents', match=access)]
-        groups = list(set(([h['group'] for h in hosts])))
-        adversaries = [a.display for a in await self.data_svc.locate('adversaries', match=access)]
+        groups = sorted(list(set(([h['group'] for h in hosts]))))
+        adversaries = sorted([a.display for a in await self.data_svc.locate('adversaries', match=access)],
+                              key=lambda a: a['name'])
         sources = [s.display for s in await self.data_svc.locate('sources', match=access)]
-        planners = [p.display for p in await self.data_svc.locate('planners')]
+        planners = sorted([p.display for p in await self.data_svc.locate('planners')],
+                           key=lambda p: p['name'])
         obfuscators = [o.display for o in await self.data_svc.locate('obfuscators')]
         operations = [o.display for o in await self.data_svc.locate('operations', match=access)]
         return dict(operations=operations, groups=groups, adversaries=adversaries, sources=sources, planners=planners,


### PR DESCRIPTION
Changes made while completing virts-619. These changes are unrelated to the planners, but these UI changes make it easier to select all the options when running an operation. (e.g. planner and adversary names are ordered so you can search for them easily)