### PR TITLE
VIRTS-995-B/include jQuery on login screen

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,4 +1,3 @@
-<script src="/gui/js/shared.js"></script>
 <head>
     <title>Login | Access</title>
 	<link rel="shortcut icon" type="image/png" href="/gui/img/favicon.png"/>
@@ -32,6 +31,8 @@
 			</div>
 		</div>
 	</form>
+	<script src="/gui/jquery/jquery.js"></script>
+	<script src="/gui/js/shared.js"></script>
 </body>
 <script>
     document.cookie.split(";").forEach(function(c) { document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/"); });


### PR DESCRIPTION
`shared.js` depends on jQuery which is not loaded on the login screen. Adds script directive to load jQuery to avoid JS errors.