### PR TITLE
VIRTS-787 Contact switch

### DIFF
--- a/app/contacts/contact_http.py
+++ b/app/contacts/contact_http.py
@@ -28,6 +28,7 @@ class Http(BaseWorld):
             response = dict(paw=agent.paw,
                             sleep=await agent.calculate_sleep(),
                             watchdog=agent.watchdog,
+                            contact=agent.contact,
                             instructions=json.dumps([json.dumps(i.display) for i in instructions]))
             return web.Response(text=self.contact_svc.encode_string(json.dumps(response)))
         except Exception as e:

--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -65,12 +65,15 @@ class TcpSessionHandler(BaseWorld):
         agent, _ = await self.services.get('contact_svc').handle_heartbeat(**profile)
         new_session = Session(id=self.generate_number(size=6), paw=agent.paw, connection=connection)
         self.sessions.append(new_session)
-        await self.send(new_session.id, agent.paw)
+        await self.send(new_session.id, agent.paw, agent.contact)
 
-    async def send(self, session_id, cmd):
+    async def send(self, session_id, cmd, contact=None):
         try:
             conn = next(i.connection for i in self.sessions if i.id == int(session_id))
             conn.send(str.encode(' '))
+            if contact:
+                conn.send(str.encode(contact))
+                conn.send(str.encode('\t'))
             conn.send(str.encode('%s\n' % cmd))
             response = await self._attempt_connection(conn, 3)
             response = json.loads(response)

--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -4,7 +4,7 @@ import socket
 import time
 
 from app.utility.base_world import BaseWorld
-from plugins.manx.app.c_session import Session
+from app.objects.secondclass.c_session import Session
 
 
 class Tcp(BaseWorld):

--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -25,10 +25,11 @@ class Tcp(BaseWorld):
     async def operation_loop(self):
         while True:
             await self.tcp_handler.refresh()
-            for session in self.tcp_handler.sessions:
+            for index, session in enumerate(self.tcp_handler.sessions):
                 agent, instructions = await self.contact_svc.handle_heartbeat(paw=session.paw)
                 if agent.contact != self.name:
                     await self.tcp_handler.send(session.id, (agent.contact + '\t'))
+                    del self.tcp_handler.sessions[index]
                 for instruction in instructions:
                     try:
                         self.log.debug('TCP instruction: %s' % instruction.id)

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -6,7 +6,6 @@ from app.utility.base_object import BaseObject
 
 
 class Agent(BaseObject):
-
     RESERVED = dict(server='#{server}', group='#{group}', agent_paw='#{paw}', location='#{location}',
                     exe_name='#{exe_name}')
 
@@ -21,7 +20,7 @@ class Agent(BaseObject):
                     last_seen=self.last_seen.strftime('%Y-%m-%d %H:%M:%S'),
                     sleep_min=self.sleep_min, sleep_max=self.sleep_max, executors=self.executors,
                     privilege=self.privilege, display_name=self.display_name, exe_name=self.exe_name, host=self.host,
-                    watchdog=self.watchdog, contact=self.contact)
+                    watchdog=self.watchdog, contact=self.contact, c2=list(self.c2))
 
     @property
     def display_name(self):
@@ -29,7 +28,8 @@ class Agent(BaseObject):
 
     def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
-                 trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None):
+                 trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', c2=['http'],
+                 paw=None):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
         self.host = host
@@ -53,6 +53,7 @@ class Agent(BaseObject):
         self.sleep_max = int(sleep_max)
         self.watchdog = int(watchdog)
         self.contact = contact
+        self.c2 = c2
         self.access = self.Access.BLUE if group == 'blue' else self.Access.RED
 
     def store(self, ram):
@@ -95,6 +96,7 @@ class Agent(BaseObject):
         self.update('architecture', kwargs.get('architecture'))
         self.update('platform', kwargs.get('platform'))
         self.update('executors', kwargs.get('executors'))
+        self.update('contact', kwargs.get('contact'))
 
     async def gui_modification(self, **kwargs):
         self.update('group', kwargs.get('group'))
@@ -102,6 +104,7 @@ class Agent(BaseObject):
         self.update('sleep_min', int(kwargs.get('sleep_min')))
         self.update('sleep_max', int(kwargs.get('sleep_max')))
         self.update('watchdog', int(kwargs.get('watchdog')))
+        self.update('contact', kwargs.get('contact'))
 
     async def kill(self):
         self.update('watchdog', 1)

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -20,7 +20,7 @@ class Agent(BaseObject):
                     last_seen=self.last_seen.strftime('%Y-%m-%d %H:%M:%S'),
                     sleep_min=self.sleep_min, sleep_max=self.sleep_max, executors=self.executors,
                     privilege=self.privilege, display_name=self.display_name, exe_name=self.exe_name, host=self.host,
-                    watchdog=self.watchdog, contact=self.contact, c2=list(self.c2))
+                    watchdog=self.watchdog, contact=self.contact, contacts=list(self.contacts))
 
     @property
     def display_name(self):
@@ -28,7 +28,7 @@ class Agent(BaseObject):
 
     def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
-                 trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', c2=['http'],
+                 trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', contacts=[],
                  paw=None):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
@@ -53,7 +53,7 @@ class Agent(BaseObject):
         self.sleep_max = int(sleep_max)
         self.watchdog = int(watchdog)
         self.contact = contact
-        self.c2 = c2
+        self.contacts = contacts
         self.access = self.Access.BLUE if group == 'blue' else self.Access.RED
 
     def store(self, ram):

--- a/app/objects/secondclass/c_session.py
+++ b/app/objects/secondclass/c_session.py
@@ -1,0 +1,21 @@
+from app.utility.base_object import BaseObject
+
+
+class Session(BaseObject):
+
+    @property
+    def unique(self):
+        return self.hash('%s' % self.paw)
+
+    def __init__(self, id, paw, connection):
+        super().__init__()
+        self.id = id
+        self.paw = paw
+        self.connection = connection
+
+    def store(self, ram):
+        existing = self.retrieve(ram['sessions'], self.unique)
+        if not existing:
+            ram['sessions'].append(self)
+            return self.retrieve(ram['sessions'], self.unique)
+        return existing

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -52,7 +52,7 @@ class ContactService(BaseService):
             sleep_min=self.get_config(name='agents', prop='sleep_min'),
             sleep_max=self.get_config(name='agents', prop='sleep_max'),
             watchdog=self.get_config(name='agents', prop='watchdog'),
-            c2=[c.name for c in self.contacts],
+            contacts=[c.name for c in self.contacts],
             **kwargs)
         )
         await self._add_agent_to_operation(agent)

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -16,6 +16,7 @@ def report(func):
                    date=datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
         args[0].report[agent.contact].append(log)
         return agent, instructions
+
     return wrapper
 
 
@@ -51,6 +52,7 @@ class ContactService(BaseService):
             sleep_min=self.get_config(name='agents', prop='sleep_min'),
             sleep_max=self.get_config(name='agents', prop='sleep_max'),
             watchdog=self.get_config(name='agents', prop='watchdog'),
+            c2=[c.name for c in self.contacts],
             **kwargs)
         )
         await self._add_agent_to_operation(agent)

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -76,8 +76,9 @@
                 <hr>
                 <table class="obfuscation-table" border=1 frame=void rules=rows>
                     <tr>
-                        <td>Contact</td>
-                        <td><p id="modal-contact"></p></td>
+                        <!--TODO:  Dynamically list available contact options-->
+                        <td>Contact *</td>
+                        <td><select id="modal-contact"></select></td>
                     </tr>
                     <tr>
                         <td>Host</td>
@@ -254,7 +255,8 @@
             'index': 'agents',
             'paw': $('#modal-paw').text(),
             'group': $('#modal-group').val(),
-            'watchdog': parseInt($('#modal-watchdog').val())
+            'watchdog': parseInt($('#modal-watchdog').val()),
+            'contact': $('#modal-contact').val()
         };
         if (sleepArr.length !== 0) {
             data["sleep_min"] = parseInt(sleepArr[0]);
@@ -308,12 +310,22 @@
         return [];
     }
 
+    function createContactDropdown(data){
+        let str = `<option selected=\"selected\" value=${data['contact']}>${data['contact']}</option>\n`;
+        data['c2'].forEach(function(contact){
+            if(contact === data['contact']) return;
+            str += `<option>${contact}</option>\n`;
+        });
+        return str;
+    }
+
     function showAgentInfo(paw){
         function agentInfoCallback(data){
             let parent = $('#agent-modal');
             let agent = data[0];
+            let dropdown = createContactDropdown(agent);
             parent.find('#modal-paw').html(agent['paw']);
-            parent.find('#modal-contact').html(agent['contact']);
+            parent.find('#modal-contact').html(dropdown);
             parent.find('#modal-host').html(agent['host']);
             parent.find('#modal-privilege').html(agent['privilege']);
             parent.find('#modal-last_seen').html(agent['last_seen']);

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -76,9 +76,10 @@
                 <hr>
                 <table class="obfuscation-table" border=1 frame=void rules=rows>
                     <tr>
-                        <!--TODO:  Dynamically list available contact options-->
                         <td>Contact *</td>
-                        <td><select id="modal-contact"></select></td>
+                        <td>
+                            <select id="modal-contact" style="margin-top: 0; margin-left: 0; height: inherit;"></select>
+                        </td>
                     </tr>
                     <tr>
                         <td>Host</td>
@@ -311,21 +312,19 @@
     }
 
     function createContactDropdown(data){
-        let str = `<option selected=\"selected\" value=${data['contact']}>${data['contact']}</option>\n`;
-        data['c2'].forEach(function(contact){
+        $('#modal-contact').append(`<option selected=\"selected\" value="${data['contact']}">${data['contact']}</option>`);
+        data['contacts'].forEach(function(contact){
             if(contact === data['contact']) return;
-            str += `<option>${contact}</option>\n`;
+            $('#modal-contact').append(`<option value="${contact}">${contact}</option>`);
         });
-        return str;
     }
 
     function showAgentInfo(paw){
         function agentInfoCallback(data){
             let parent = $('#agent-modal');
             let agent = data[0];
-            let dropdown = createContactDropdown(agent);
+            createContactDropdown(agent);
             parent.find('#modal-paw').html(agent['paw']);
-            parent.find('#modal-contact').html(dropdown);
             parent.find('#modal-host').html(agent['host']);
             parent.find('#modal-privilege').html(agent['privilege']);
             parent.find('#modal-last_seen').html(agent['last_seen']);


### PR DESCRIPTION
Adds a dropdown to the agent modal that allows a user to change the communication channel of a particular agent.  Updates to the communication channel are made to the Agent object and then implemented the next time that the agent beacons the server.  Please see the corresponding PR under sandcat for the changes made to the agent code.