### PR TITLE
Save identical host facts from different hosts

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -113,9 +113,7 @@ class Link(BaseObject):
             self.relationships.append(relationship)
 
     async def _save_fact(self, operation, trait, score):
-        if all(trait) and not \
-                any((f.trait == trait[0] and f.value == trait[1]) and
-                    (trait[0][:5] != 'host.' or self.paw == f.collected_by) for f in operation.all_facts()):
+        if all(trait) and not any(f.trait == trait[0] and f.value == trait[1] for f in operation.all_facts()):
             self.facts.append(Fact(trait=trait[0], value=trait[1], score=score, collected_by=self.paw,
                                    technique_id=self.ability.technique_id))
 

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -118,13 +118,13 @@ class Link(BaseObject):
                                    technique_id=self.ability.technique_id))
 
     async def _is_new_trait(self, trait, facts):
-        return all(not self._trait_exists(trait, f) or self._is_unique_host_trait(trait, f) for f in facts)
+        return all(not self._trait_exists(trait, f) or self._is_new_host_trait(trait, f) for f in facts)
 
     @staticmethod
     def _trait_exists(trait, fact):
         return trait[0] == fact.trait and trait[1] == fact.value
 
-    def _is_unique_host_trait(self, trait, fact):
+    def _is_new_host_trait(self, trait, fact):
         return trait[0][:5] == 'host.' and self.paw != fact.collected_by
 
     async def _update_scores(self, operation, increment):

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -113,7 +113,9 @@ class Link(BaseObject):
             self.relationships.append(relationship)
 
     async def _save_fact(self, operation, trait, score):
-        if all(trait) and not any(f.trait == trait[0] and f.value == trait[1] for f in operation.all_facts()):
+        if all(trait) and not \
+                any((f.trait == trait[0] and f.value == trait[1]) and
+                    (trait[0][:5] != 'host.' or self.paw == f.collected_by) for f in operation.all_facts()):
             self.facts.append(Fact(trait=trait[0], value=trait[1], score=score, collected_by=self.paw,
                                    technique_id=self.ability.technique_id))
 


### PR DESCRIPTION
Some facts may be identical in terms of trait and value, but where they came from may be important to keep track of. Two agents may produce the same fact, but a host fact that is relevant to just that particular host might need to be saved separately. This change provides for that ability.

This only affects facts that start with "host.".