### PR TITLE
Fix add-apt-repository dependency for go install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,7 +100,7 @@ function darwin_install_python() {
 }
 
 function ubuntu_install_go() {
-    install_wrapper "GO" go "add-apt-repository -y ppa:longsleep/golang-backports && apt-get update -y && apt-get install -y golang-go" $WARNING
+    install_wrapper "GO" go "apt-get install -y software-properties-common && add-apt-repository -y ppa:longsleep/golang-backports && apt-get update -y && apt-get install -y golang-go" $WARNING
 }
 
 function ubuntu_install_mingw() {


### PR DESCRIPTION
On latest Kali GNU/Linux Rolling 2020.1:

```console
$ sudo ./install.sh --kali
[-] Installing on Ubuntu (Debian)...
[-] Checking for GO
[-] Installing GO
./install.sh: line 12: add-apt-repository: command not found
[+] GO installed
[-] Checking for MinGW
/usr/bin/x86_64-w64-mingw32-gcc
...
```