### PR TITLE
Replace uuidgen 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -129,10 +129,10 @@ function centos_install_python() {
 
 function bash_set_random_conf_data() {
     echo "[-] Generating Random Values"
-    sed -i.backup "s/ADMIN123/$(uuidgen)/g" conf/default.yml
-    extra_error "sed -i.backup \"s/ADMIN123/$(uuidgen)/g\" conf/default.yml" "caldera random api_key" $WARNING
-    sed -i.backup "s/REPLACE_WITH_RANDOM_VALUE/$(uuidgen)/g" conf/default.yml
-    extra_error "sed -i.backup \"s/REPLACE_WITH_RANDOM_VALUE/$(uuidgen)/g\" conf/default.yml" "caldera random cryps_salt" $WARNING
+    sed -i.backup "s/ADMIN123/$(cat /proc/sys/kernel/random/uuid)/g" conf/default.yml
+    extra_error "sed -i.backup \"s/ADMIN123/$(cat /proc/sys/kernel/random/uuid)/g\" conf/default.yml" "caldera random api_key" $WARNING
+    sed -i.backup "s/REPLACE_WITH_RANDOM_VALUE/$(cat /proc/sys/kernel/random/uuid)/g" conf/default.yml
+    extra_error "sed -i.backup \"s/REPLACE_WITH_RANDOM_VALUE/$(cat /proc/sys/kernel/random/uuid)/g\" conf/default.yml" "caldera random cryps_salt" $WARNING
     echo "[+] Random Values added to default.yml"
 }
 


### PR DESCRIPTION
`uuidgen` is not present on Kali nor Debian by default:

```console
$ lsb_release -a
No LSB modules are available.
Distributor ID: Kali
Description:    Kali GNU/Linux Rolling
Release:        2020.1
Codename:       kali-rolling

$ sudo ./install.sh --kali
[sudo] password for yo:                                                                                                                                                                                      
[-] Installing on Ubuntu (Debian)...                                                                                                                                                                         
[-] Checking for GO                                                                                                                                                                                          
/usr/bin/go                                                                                                                                                                                                  
[+] GO already installed                                                                                                                                                                                     
[-] Checking for MinGW                                                                                                                                                                                       
/usr/bin/x86_64-w64-mingw32-gcc                                                                                                                                                                              
[+] MinGW already installed                                                                                                                                                                                  
[-] Checking for Python                                                                                                                                                                                      
/usr/bin/python3                                                                                                                                                                                             
[+] Python already installed                                                                                                                                                                                 
[-] Generating Random Values                                                                                                                                                                                 
./install.sh: line 132: uuidgen: command not found                                                                                                                                                           
./install.sh: line 133: uuidgen: command not found
[x] caldera random api_key FAILED to install
./install.sh: line 134: uuidgen: command not found
./install.sh: line 135: uuidgen: command not found
[x] caldera random cryps_salt FAILED to install

$ uuidgen
bash: uuidgen: command not found

$ cat /proc/sys/kernel/random/uuid
f9e6b453-f45f-403e-8a3e-e94b5f098ad9
```