### PR TITLE
Add pip dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,7 @@ function ubuntu_install_mingw() {
 
 function ubuntu_install_python() {
     install_wrapper "Python" python3 "apt-get install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt-get update -y && apt-get install -y python3.7" $CRITICAL
+    install_wrapper "Pip" pip3 "apt-get install -y python3-pip" $CRITICAL
 }
 
 function centos_install_core_tools() {


### PR DESCRIPTION
On lastest Kali, `pip` is not installed by default:

```console
$ lsb_release -a
No LSB modules are available.
Distributor ID: Kali
Description:    Kali GNU/Linux Rolling
Release:        2020.1
Codename:       kali-rolling

$ sudo ./install.sh --kali
[-] Installing on Ubuntu (Debian)...
[-] Checking for GO
/usr/bin/go
[+] GO already installed
[-] Checking for MinGW
/usr/bin/x86_64-w64-mingw32-gcc
[+] MinGW already installed
[-] Checking for Python
/usr/bin/python3
[+] Python already installed
[-] Generating Random Values
[+] caldera random api_key installed
[+] caldera random cryps_salt installed
[+] Random Values added to default.yml
[-] Installing on GO dependencies
[+] GO github installed
[+] GO oath2 installed
[-] Setting up Python venv
-bash: pip3: command not found
...
```