### PR TITLE
base_world styling changes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 180
+
+per-file-ignores =
+    app/service/file_svc.py:B305

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -93,7 +93,7 @@ class BaseWorld:
 
     @staticmethod
     async def walk_file_path(path, target):
-        for root, dirs, files in os.walk(path):
+        for root, _, files in os.walk(path):
             if target in files:
                 return os.path.join(root, target)
             if '%s.xored' % target in files:


### PR DESCRIPTION
* Remove unused loop variables from `base_world` to resolve B007
* Ignores rule B305 on `file_svc` since `reader.next()` is a function of MultipartReader and not of the default iterator which would normally use `next(reader)` in Python 3.