### PR TITLE
add some tests for web server

### DIFF
--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -77,7 +77,7 @@ class AuthService(BaseService):
         response = web.HTTPFound('/')
         if verified:
             await remember(request, response, data.get('username'))
-            return response
+            raise response
         raise web.HTTPFound('/login')
 
     async def check_permissions(self, group, request):

--- a/tests/base/test_base.py
+++ b/tests/base/test_base.py
@@ -8,7 +8,9 @@ from aiohttp.test_utils import AioHTTPTestCase
 from app.api.rest_api import RestApi
 from app.service.app_svc import AppService
 from app.service.auth_svc import AuthService
+from app.service.contact_svc import ContactService
 from app.service.data_svc import DataService
+from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
 from app.service.rest_svc import RestService
@@ -16,39 +18,23 @@ from app.utility.base_world import BaseWorld
 
 
 class TestBase(AioHTTPTestCase):
-    test_config = """
-        api_key: ADMIN123
-        app.contact.html: /weather
-        app.contact.http: http://127.0.0.1:8888
-        app.contact.tcp: 127.0.0.1:7010
-        app.contact.udp: 127.0.0.1:7011
-        app.contact.websocket: 127.0.0.1:7012
-        crypt_salt: REPLACE_WITH_RANDOM_VALUE
-        exfil_dir: /tmp
-        plugins: []
-        port: 8888
-        reports_dir: /tmp
-        users:
-          blue:
-            blue: admin
-          red:
-            admin: admin
-            red: admin
-        """
 
     @classmethod
     def patch_config(cls):
-        BaseWorld.apply_config('default', yaml.safe_load(cls.test_config))
+        with open(Path(__file__).parents[2] / 'conf' / 'default.yml', 'r') as fle:
+            BaseWorld.apply_config('default', yaml.safe_load(fle))
 
     def initialize(self):
+        self.patch_config()
         self.app_svc = AppService(web.Application())
         self.data_svc = DataService()
         self.rest_svc = RestService()
         self.planning_svc = PlanningService()
         self.learning_svc = LearningService()
         self.auth_svc = AuthService()
+        self.contact_svc = ContactService()
+        self.file_svc = FileSvc()
         self.services = self.app_svc.get_services()
-        self.patch_config()
 
     async def get_application(self):
         """
@@ -56,6 +42,7 @@ class TestBase(AioHTTPTestCase):
         """
         os.chdir(str(Path(__file__).parents[2]))
         self.initialize()
+        await self.app_svc.register_contacts()
         await self.app_svc.load_plugins()
         self.rest_api = await RestApi(self.services).enable()
         await self.auth_svc.apply(self.app_svc.application, self.auth_svc.get_config('users'))

--- a/tests/base/test_base.py
+++ b/tests/base/test_base.py
@@ -1,23 +1,65 @@
-import asyncio
-import unittest
+import os
+from pathlib import Path
 
+import yaml
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+
+from app.api.rest_api import RestApi
 from app.service.app_svc import AppService
+from app.service.auth_svc import AuthService
 from app.service.data_svc import DataService
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
 from app.service.rest_svc import RestService
+from app.utility.base_world import BaseWorld
 
 
-class TestBase(unittest.TestCase):
+class TestBase(AioHTTPTestCase):
+    test_config = """
+        api_key: ADMIN123
+        app.contact.html: /weather
+        app.contact.http: http://127.0.0.1:8888
+        app.contact.tcp: 127.0.0.1:7010
+        app.contact.udp: 127.0.0.1:7011
+        app.contact.websocket: 127.0.0.1:7012
+        crypt_salt: REPLACE_WITH_RANDOM_VALUE
+        exfil_dir: /tmp
+        plugins: []
+        port: 8888
+        reports_dir: /tmp
+        users:
+          blue:
+            blue: admin
+          red:
+            admin: admin
+            red: admin
+        """
+
+    @classmethod
+    def patch_config(cls):
+        BaseWorld.apply_config('default', yaml.safe_load(cls.test_config))
 
     def initialize(self):
-        self.app_svc = AppService(None)
+        self.app_svc = AppService(web.Application())
         self.data_svc = DataService()
         self.rest_svc = RestService()
         self.planning_svc = PlanningService()
         self.learning_svc = LearningService()
-        self.services = [self.app_svc.get_services()]
+        self.auth_svc = AuthService()
+        self.services = self.app_svc.get_services()
+        self.patch_config()
 
-    @staticmethod
-    def run_async(c):
-        return asyncio.get_event_loop().run_until_complete(c)
+    async def get_application(self):
+        """
+        Overrides AioHTTPTestCase.get_application to provide our TestCase with our server's application.
+        """
+        os.chdir(str(Path(__file__).parents[2]))
+        self.initialize()
+        await self.app_svc.load_plugins()
+        self.rest_api = await RestApi(self.services).enable()
+        await self.auth_svc.apply(self.app_svc.application, self.auth_svc.get_config('users'))
+        return self.app_svc.application
+
+    def run_async(self, c):
+        return self.loop.run_until_complete(c)

--- a/tests/objects/test_ability.py
+++ b/tests/objects/test_ability.py
@@ -6,6 +6,7 @@ from tests.base.test_base import TestBase
 class TestAbility(TestBase):
 
     def setUp(self):
+        super().setUp()
         self.initialize()
 
     def test_privileged_to_run__1(self):

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -12,6 +12,7 @@ from tests.base.test_base import TestBase
 class TestDataService(TestBase):
 
     def setUp(self):
+        super().setUp()
         self.initialize()
 
     def test_adversary(self):

--- a/tests/services/test_learning_svc.py
+++ b/tests/services/test_learning_svc.py
@@ -9,6 +9,7 @@ from tests.base.test_base import TestBase
 class TestLearningSvc(TestBase):
 
     def setUp(self):
+        super().setUp()
         self.initialize()
         self.ability = self.run_async(self.data_svc.store(
             Ability(ability_id='123', tactic='discovery', technique_id='T1033', technique='Find', name='test',

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -9,6 +9,7 @@ from tests.base.test_base import TestBase
 class TestPlanningService(TestBase):
 
     def setUp(self):
+        super().setUp()
         self.initialize()
         self.ability = Ability(ability_id='123', executor='sh', test=BaseWorld.encode_string('mkdir test'),
                                cleanup=BaseWorld.encode_string('rm -rf test'), variations=[])

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -6,6 +6,7 @@ from tests.base.test_base import TestBase
 class TestRestSvc(TestBase):
 
     def setUp(self):
+        super().setUp()
         self.initialize()
         BaseWorld.apply_config(name='default', config={'app.contact.http': '0.0.0.0', 'plugins': ['sandcat', 'stockpile']})
         self.run_async(self.data_svc.store(

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -42,4 +42,3 @@ class TestCoreEndponts(TestBase):
     async def test_core(self):
         resp = await self.authorized_request('POST', '/api/rest', json=dict(index='agents'))
         assert resp.status == HTTPStatus.OK
-

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -1,0 +1,45 @@
+from http import HTTPStatus
+
+from aiohttp.test_utils import unittest_run_loop
+
+from tests.base.test_base import TestBase
+
+
+class TestCoreEndponts(TestBase):
+
+    _cookies = ''
+
+    async def authorized_request(self, *args, **kwargs):
+        if not self._cookies:
+            resp = await self.client.request('POST', '/enter', allow_redirects=False,
+                                             data=dict(username='admin', password='admin'))
+            self._cookies = resp.cookies
+        return await self.client.request(*args, cookies=self._cookies, **kwargs)
+
+    async def get(self):
+        return self.client.session()
+
+    @unittest_run_loop
+    async def test_home(self):
+        resp = await self.client.request('GET', '/')
+        assert resp.status == HTTPStatus.OK
+        assert resp.content_type == 'text/html'
+
+    @unittest_run_loop
+    async def test_access_denied(self):
+        resp = await self.client.request('GET', '/enter')
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+
+    @unittest_run_loop
+    async def test_login(self):
+        resp = await self.client.request('POST', '/enter', allow_redirects=False,
+                                         data=dict(username='admin', password='admin'))
+        assert resp.status == HTTPStatus.FOUND
+        assert resp.headers.get('Location') == '/'
+        assert 'API_SESSION' in resp.cookies
+
+    @unittest_run_loop
+    async def test_core(self):
+        resp = await self.authorized_request('POST', '/api/rest', json=dict(index='agents'))
+        assert resp.status == HTTPStatus.OK
+


### PR DESCRIPTION
Changes: 

* Add some tests for our aiohttp endpoints 
* refactor existing tests to not be broken by adding in aiohttp tests 

Discussion: 

My main goal here was to get to the point were it would be easy to start writing tests for the rest api.  Currently it justs tests the landing pages, and that hitting rest_core with {'index':'agents'} returns 200. 

More annoyingly, aiohttp's AioHTTPTestCase, seems to run event loops in different threads in a way that broke our current method of testing asynchronous code.  The solution in this PR makes all test cases inherit from AioHTTPTest case.  The upside of this is that we should be able to use the `aiohttp.test_utils.unnittest_run_loop` decorator to convert our current tests to coroutines (instead of the somewhat awkward `run_async` function.  

I was trying to get this done without switching test frameworks (aiohttp seems to more actively support py.test), but these would probably look nicer if we adopted py.test in this other PR: https://github.com/mitre/caldera/pull/1401 