### PR TITLE
add aiohttp tests with aiohttp-pytest

### DIFF
--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -76,7 +76,7 @@ class AuthService(BaseService):
         response = web.HTTPFound('/')
         if verified:
             await remember(request, response, data.get('username'))
-            return response
+            raise response
         raise web.HTTPFound('/login')
 
     async def check_permissions(self, group, request):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 tox
 pytest
+pytest-aiohttp
 coverage
 pre-commit

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -1,0 +1,77 @@
+import os
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+import yaml
+from aiohttp import web
+
+from app.api.rest_api import RestApi
+from app.service.app_svc import AppService
+from app.service.auth_svc import AuthService
+from app.service.contact_svc import ContactService
+from app.service.data_svc import DataService
+from app.service.file_svc import FileSvc
+from app.service.learning_svc import LearningService
+from app.service.planning_svc import PlanningService
+from app.service.rest_svc import RestService
+from app.utility.base_world import BaseWorld
+
+
+@pytest.fixture
+def aiohttp_client(loop, aiohttp_client):
+
+    async def initialize():
+        with open(Path(__file__).parents[2] / 'conf' / 'default.yml', 'r') as fle:
+            BaseWorld.apply_config('default', yaml.safe_load(fle))
+
+        app_svc = AppService(web.Application())
+        _ = DataService()
+        _ = RestService()
+        _ = PlanningService()
+        _ = LearningService()
+        auth_svc = AuthService()
+        _ = ContactService()
+        _ = FileSvc()
+        services = app_svc.get_services()
+        os.chdir(str(Path(__file__).parents[2]))
+
+        await app_svc.register_contacts()
+        await app_svc.load_plugins()
+        _ = await RestApi(services).enable()
+        await auth_svc.apply(app_svc.application, auth_svc.get_config('users'))
+        return app_svc.application
+
+    app = loop.run_until_complete(initialize())
+    return loop.run_until_complete(aiohttp_client(app))
+
+
+@pytest.fixture
+def authorized_cookies(loop, aiohttp_client):
+    async def get_cookie():
+        r = await aiohttp_client.post('/enter', allow_redirects=False, data=dict(username='admin', password='admin'))
+        return r.cookies
+    return loop.run_until_complete(get_cookie())
+
+
+async def test_home(aiohttp_client):
+    resp = await aiohttp_client.get('/')
+    assert resp.status == HTTPStatus.OK
+    assert resp.content_type == 'text/html'
+
+
+async def test_access_denied(aiohttp_client):
+    resp = await aiohttp_client.get('/enter')
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_login(aiohttp_client):
+    resp = await aiohttp_client.post('/enter', allow_redirects=False, data=dict(username='admin', password='admin'))
+    assert resp.status == HTTPStatus.FOUND
+    assert resp.headers.get('Location') == '/'
+    assert 'API_SESSION' in resp.cookies
+
+
+async def test_core(aiohttp_client, authorized_cookies):
+    resp = await aiohttp_client.post('/api/rest', json=dict(index='agents'), cookies=authorized_cookies)
+    assert resp.status == HTTPStatus.OK

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     -rrequirements.txt
     pre-commit
     pytest
+    pytest-aiohttp
     coverage
     codecov
 commands =
@@ -30,6 +31,7 @@ deps =
     -rrequirements.txt
     pre-commit
     pytest
+    pytest-aiohttp
     coverage
     codecov
 commands =


### PR DESCRIPTION
Changes: 

* add aiohttp-pytest 
* refactor tests from old PR to use aiohttp-pytest https://github.com/mitre/caldera/pull/1403 (we should close 1403 if we merge this one) 

@christophert , apparently  pytest-aiohttp and pytest-asyncio (which, I know you were thinking of adding) are incompatible.  We probably need to pick one of the two.  