### PR TITLE
Remove pypy3 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{35,36,37,38,py3}
+    py{35,36,37,38,3}
     style
     coverage
 skip_missing_interpreters = true


### PR DESCRIPTION
I'm pretty sure (but not 100% sure) that we're only targeting CPython for testing and not PyPy.  So this probably fixes a typo in our tox.ini. 