### PR TITLE
VIRTS-764/Randomized payload names for operations

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -126,6 +126,8 @@ class PlanningService(BasePlanningService):
                                                                  match=dict(unique=link.ability.unique)))[0]
             for cleanup in ability.cleanup:
                 decoded_cmd = agent.replace(cleanup)
+                if operation.obfuscate_payloads:
+                    decoded_cmd = await operation.apply_payload_obfuscation(decoded_cmd, ability)
                 variant, _, _ = await self._build_single_test_variant(decoded_cmd, link.used, link.ability.executor)
                 lnk = Link(operation=operation.id, command=self.encode_string(variant), paw=agent.paw, cleanup=1,
                            ability=ability, score=0, jitter=2, status=link_status)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -242,7 +242,8 @@ class RestService(BaseService):
                          jitter=data.pop('jitter', '2/8'), source=next(iter(sources), None),
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          phases_enabled=bool(int(data.pop('phases_enabled', 1))), obfuscator=data.pop('obfuscator', 'plain-text'),
-                         auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')))
+                         auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')),
+                         obfuscate_payloads=bool(int(data.pop('obfuscate_payloads', 0))))
 
     @staticmethod
     async def _read_from_yaml(file_path):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -46,6 +46,8 @@ class BasePlanningService(BaseService):
         for link in links:
             decoded_test = agent.replace(link.command)
             variables = re.findall(self.re_variable, decoded_test)
+            if operation.obfuscate_payloads:
+                decoded_test = await operation.apply_payload_obfuscation(decoded_test, link.ability)
             if variables:
                 relevant_facts = await self._build_relevant_facts(variables, operation)
                 good_facts = await RuleSet(rules=operation.rules).apply_rules(facts=relevant_facts[0])

--- a/conf/abilities.yml
+++ b/conf/abilities.yml
@@ -1,0 +1,9 @@
+obfuscated_payloads:
+  names:
+    - README.md
+    - Copying
+    - TODO
+    - NEWS
+    - Makefile
+    - Important_Document.doc
+    - Cyber_bullets.txt

--- a/server.py
+++ b/server.py
@@ -77,6 +77,7 @@ if __name__ == '__main__':
     with open('conf/%s.yml' % config) as c:
         BaseWorld.apply_config('default', yaml.load(c, Loader=yaml.FullLoader))
         BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
+        BaseWorld.apply_config('abilities', BaseWorld.strip_yml('conf/abilities.yml')[0])
 
         data_svc = DataService()
         contact_svc = ContactService()

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -93,6 +93,10 @@
               <h5>STEALTH</h5>
           </div>
           <div id="stealth-options" class="column sidebar-cutout" style="display: none;">
+              <select name="phases" id="queueObfuscatePayloads" class="queueOption" style="opacity:0.5" disabled="true">
+                  <option value="0" selected>Standard Payload Names</option>
+                  <option value="1">Randomized Payload Names</option>
+              </select>
               <select name="phases" id="queueObfuscated" class="queueOption" style="opacity:0.5" disabled="true">
                   {% for o in obfuscators %}
                     <option value="{{ o.name }}">{{ o.name }} obfuscation</option>
@@ -370,6 +374,7 @@
             "autonomous":document.getElementById("queueAuto").value,
             "phases_enabled":document.getElementById("queuePhasesEnabled").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
+            "obfuscate_payloads":document.getElementById("queueObfuscatePayloads").value,
             "auto_close": document.getElementById("queueAutoClose").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
-import random
 import pytest
+import random
+import string
+import uuid
 import yaml
 
 from app.utility.base_world import BaseWorld
@@ -9,6 +11,7 @@ from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
 from app.service.rest_svc import RestService
+from app.objects.c_adversary import Adversary
 from app.objects.c_ability import Ability
 from app.objects.c_operation import Operation
 from app.objects.c_agent import Agent
@@ -71,6 +74,22 @@ def services(app_svc):
 
 
 @pytest.fixture
+def adversary():
+    def _generate_adversary(adversary_id=None, name=None, description=None, phases=None):
+        if not adversary_id:
+            adversary_id = uuid.uuid4()
+        if not name:
+            name = ''.join(random.choice(string.ascii_uppercase) for x in range(10))
+        if not description:
+            description = "description"
+        if not phases:
+            phases = dict()
+        return Adversary(adversary_id=adversary_id, name=name, description=description, phases=phases)
+
+    return _generate_adversary
+
+
+@pytest.fixture
 def ability():
     def _generate_ability(ability_id=None, variations=None, *args, **kwargs):
         if not ability_id:
@@ -88,6 +107,15 @@ def operation():
         return Operation(name=name, agents=agent, adversary=adversary, *args, **kwargs)
 
     return _generate_operation
+
+
+@pytest.fixture
+def demo_operation(loop, data_svc, operation, adversary):
+    tadversary = loop.run_until_complete(data_svc.store(
+        adversary()
+    ))
+    toperation = operation(name='my first op', agents=[], adversary=tadversary)
+    return toperation
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import random
 import pytest
+import yaml
 
+from app.utility.base_world import BaseWorld
 from app.service.app_svc import AppService
 from app.service.data_svc import DataService
 from app.service.file_svc import FileSvc
@@ -11,6 +13,14 @@ from app.objects.c_ability import Ability
 from app.objects.c_operation import Operation
 from app.objects.c_agent import Agent
 from app.objects.secondclass.c_link import Link
+
+
+@pytest.fixture(scope='session')
+def init_base_world():
+    with open('conf/default.yml') as c:
+        BaseWorld.apply_config('default', yaml.load(c, Loader=yaml.FullLoader))
+    BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
+    BaseWorld.apply_config('abilities', BaseWorld.strip_yml('conf/abilities.yml')[0])
 
 
 @pytest.fixture(scope='class')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,10 +62,12 @@ def services(app_svc):
 
 @pytest.fixture
 def ability():
-    def _generate_ability(ability_id=None, *args, **kwargs):
+    def _generate_ability(ability_id=None, variations=None, *args, **kwargs):
         if not ability_id:
             ability_id = random.randint(0, 999999)
-        return Ability(ability_id=ability_id, *args, **kwargs)
+        if not variations:
+            variations = []
+        return Ability(ability_id=ability_id, variations=variations, *args, **kwargs)
 
     return _generate_ability
 

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from app.objects.c_adversary import Adversary
+from app.utility.base_world import BaseWorld
+
+
+@pytest.fixture
+def setup_operation_test(operation):
+    BaseWorld.apply_config('abilities', BaseWorld.strip_yml('conf/abilities.yml')[0])
+
+
+@pytest.mark.usefixtures(
+    'setup_operation_test'
+)
+class TestOperation:
+
+    @pytest.fixture
+    def demo_operation(self, loop, data_svc, operation):
+        adversary = loop.run_until_complete(data_svc.store(
+            Adversary(adversary_id='123', name='test', description='test adversary', phases=dict())
+        ))
+        toperation = operation(name='my first op', agents=[], adversary=adversary)
+        yield toperation
+
+    def test__get_unique_payload_key_no_real_payloads(self, loop, demo_operation):
+        payloads = BaseWorld.get_config(prop='obfuscated_payloads', name='abilities').get('names')
+        payload_name = demo_operation._get_unique_payload_key(payload_name_len=10)
+        assert payload_name in payloads
+
+    def test__get_unique_payload_key_force_random(self, loop, demo_operation):
+        payloads = BaseWorld.get_config(prop='obfuscated_payloads', name='abilities').get('names')
+        for name in payloads:
+            demo_operation.payloads_map['to_real_payload'][name] = ''
+        payload_name = demo_operation._get_unique_payload_key(payload_name_len=10)
+        assert payload_name not in payloads
+        assert len(payload_name) == 10

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -22,15 +22,37 @@ class TestOperation:
         toperation = operation(name='my first op', agents=[], adversary=adversary)
         yield toperation
 
-    def test__get_unique_payload_key_no_real_payloads(self, loop, demo_operation):
+    def test__get_unique_payload_key_no_real_payloads(self, demo_operation):
         payloads = BaseWorld.get_config(prop='obfuscated_payloads', name='abilities').get('names')
         payload_name = demo_operation._get_unique_payload_key(payload_name_len=10)
         assert payload_name in payloads
 
-    def test__get_unique_payload_key_force_random(self, loop, demo_operation):
+    def test__get_unique_payload_key_force_random(self, demo_operation):
         payloads = BaseWorld.get_config(prop='obfuscated_payloads', name='abilities').get('names')
         for name in payloads:
             demo_operation.payloads_map['to_real_payload'][name] = ''
         payload_name = demo_operation._get_unique_payload_key(payload_name_len=10)
         assert payload_name not in payloads
         assert len(payload_name) == 10
+
+    def test_apply_payload_obfuscation(self, loop, ability, demo_operation):
+        orig_payload_name = 'wifi.sh'
+        decoded_command = './%s scan' % orig_payload_name
+
+        tability = ability(payload=orig_payload_name)
+        payload_name = loop.run_until_complete(demo_operation.apply_payload_obfuscation(decoded_command, tability))
+        print(payload_name)
+        assert orig_payload_name not in payload_name
+
+    def test_apply_payload_obfuscation_predetermined_mapping(self, loop, ability, demo_operation):
+        orig_payload_name = 'predeterminedobfuscation.exe'
+        decoded_command = './%s arg' % orig_payload_name
+        mapped_payload_name = 'unittestobfuscation'
+
+        # make mapping in payload map
+        demo_operation.payloads_map['to_obfuscated_payload'][orig_payload_name] = mapped_payload_name
+
+        tability = ability(payload=orig_payload_name)
+        payload_name = loop.run_until_complete(demo_operation.apply_payload_obfuscation(decoded_command, tability))
+        print(payload_name)
+        assert mapped_payload_name in payload_name

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.mark.usefixtures(
+    'init_base_world'
+)
+class TestFileSvc:
+
+    def test_check_payload_obfuscation(self, loop, data_svc, file_svc, ability, demo_operation):
+        orig_payload_name = 'predeterminedobfuscation.exe'
+        mapped_payload_name = 'unittestobfuscation'
+
+        # make mapping in payload map
+        demo_operation.payloads_map['to_real_payload'][mapped_payload_name] = orig_payload_name
+        demo_operation.obfuscate_payloads = True
+        demo_operation.set_start_details()  # set ID
+        loop.run_until_complete(data_svc.store(demo_operation))
+
+        identifier = "%d-12345" % demo_operation.id
+        payload, display_name = loop.run_until_complete(file_svc.check_payload_obfuscation(identifier, mapped_payload_name))
+        assert payload == orig_payload_name
+        assert display_name == mapped_payload_name

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -4,24 +4,46 @@ from app.objects.secondclass.c_link import Link
 from app.utility.base_world import BaseWorld
 
 
-@pytest.fixture
-def setup_planning_test(loop, ability, agent, operation, data_svc):
-    tability = ability(ability_id='123', executor='sh', test=BaseWorld.encode_string('mkdir test'),
-                       cleanup=BaseWorld.encode_string('rm -rf test'), variations=[])
-    tagent = agent(sleep_min=1, sleep_max=2, watchdog=0)
-    toperation = operation(name='test1', agents=tagent, adversary='hunter')
-    loop.run_until_complete(data_svc.store(tability))
-    yield (tability, tagent, toperation)
-
-
+@pytest.mark.usefixtures(
+    'init_base_world'
+)
 class TestPlanningService:
 
-    def test_get_cleanup_links(self, loop, setup_planning_test, planning_svc):
-        ability, agent, operation = setup_planning_test
-        operation.add_link(Link(operation=operation, command='', paw=agent.paw, ability=ability, status=0))
+    @pytest.fixture
+    def agent_op_pair(self, operation, agent):
+        tagent = agent(sleep_min=1, sleep_max=2, watchdog=0)
+        toperation = operation(name='test1', agents=tagent, adversary='hunter')
+        yield (tagent, toperation)
+
+    def test_get_cleanup_links(self, loop, agent_op_pair, ability, data_svc, planning_svc):
+        agent, operation = agent_op_pair
+        tability = ability(ability_id='123', executor='sh', test=BaseWorld.encode_string('mkdir test'),
+                           cleanup=BaseWorld.encode_string('rm -rf test'), variations=[])
+        loop.run_until_complete(data_svc.store(tability))
+
+        operation.add_link(Link(operation=operation, command='', paw=agent.paw, ability=tability, status=0))
         links = loop.run_until_complete(
             planning_svc.get_cleanup_links(operation=operation, agent=agent)
         )
         link_list = list(links)
         assert len(link_list) == 1
-        assert link_list[0].command == ability.cleanup[0]
+        assert link_list[0].command == tability.cleanup[0]
+
+    def test_get_cleanup_links_obfuscated_payloads(self, loop, agent_op_pair, ability, data_svc, planning_svc):
+        # test cleaning up links with obfuscated payloads enabled
+        agent, operation = agent_op_pair
+        operation.obfuscate_payloads = True
+        orig_payload_name = 'plnsvc_obfuscated_payload'
+
+        tability = ability(ability_id='123', executor='sh', payload=orig_payload_name, test=BaseWorld.encode_string('mkdir test'),
+                           cleanup=BaseWorld.encode_string('%s -rf test' % orig_payload_name), variations=[])
+        loop.run_until_complete(data_svc.store(tability))
+
+        operation.add_link(Link(operation=operation, command='', paw=agent.paw, ability=tability, status=0))
+        links = loop.run_until_complete(
+            planning_svc.get_cleanup_links(operation=operation, agent=agent)
+        )
+        link_list = list(links)
+        assert len(link_list) == 1
+        # ensure the original payload name is not in the command of the link
+        assert orig_payload_name not in link_list[0].command

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -3,6 +3,8 @@ import pytest
 from app.objects.c_ability import Ability
 from app.objects.c_agent import Agent
 from app.objects.c_adversary import Adversary
+from app.objects.c_planner import Planner
+from app.objects.c_source import Source
 from app.utility.base_world import BaseWorld
 
 
@@ -14,13 +16,19 @@ def setup_rest_svc_test(loop, data_svc):
                                                    'api_key': 'ADMIN123',
                                                    'exfil_dir': '/tmp'})
     loop.run_until_complete(data_svc.store(
-        Ability(ability_id='123', test=BaseWorld.encode_string('curl #{app.contact.http}'), variations=[]))
-    )
+        Ability(ability_id='123', test=BaseWorld.encode_string('curl #{app.contact.http}'), variations=[])
+    ))
     loop.run_until_complete(data_svc.store(
-        Adversary(adversary_id='123', name='test', description='test', phases=[]))
-    )
+        Adversary(adversary_id='123', name='test', description='test', phases=dict())
+    ))
     loop.run_until_complete(data_svc.store(
         Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0)
+    ))
+    loop.run_until_complete(data_svc.store(
+        Planner(planner_id='123', name='test', module='test', params=dict())
+    ))
+    loop.run_until_complete(data_svc.store(
+        Source(identifier='123', name='test', facts=[])
     ))
 
 
@@ -50,6 +58,25 @@ class TestRestSvc:
         assert ['sandcat', 'stockpile'] == BaseWorld.get_config('plugins')
         loop.run_until_complete(internal_rest_svc.update_config(data=dict(prop='plugin', value='ssl')))
         assert ['sandcat', 'stockpile', 'ssl'] == BaseWorld.get_config('plugins')
+
+    def test_create_operation(self, loop, rest_svc, data_svc):
+        want = {'name': 'Test',
+                'host_group': [{'paw': '123', 'group': 'red', 'architecture': 'unknown', 'platform': 'unknown',
+                                'server': '://None:None', 'location': 'unknown', 'pid': 0, 'ppid': 0, 'trusted': True,
+                                'sleep_min': 2, 'sleep_max': 8, 'executors': (), 'privilege': 'User',
+                                'display_name': 'unknown$unknown', 'exe_name': 'unknown', 'host': 'unknown',
+                                'watchdog': 0, 'contact': 'unknown'}],
+                'adversary': {'adversary_id': '123', 'name': 'test', 'description': 'test', 'phases': {}},
+                'jitter': '2/8', 'source': '', 'planner': 'test', 'state': 'finished', 'phase': 0,
+                'obfuscator': 'plain-text', 'autonomous': 1, 'finish': '', 'chain': []}
+        internal_rest_svc = rest_svc(loop)
+        operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
+            access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),
+            data=dict(name='Test', planner='test', adversary_id='123', source='123', state='finished')))
+        operation[0].pop('id')
+        operation[0]['host_group'][0].pop('last_seen')
+        operation[0].pop('start')
+        assert want == operation[0]
 
     def test_delete_ability(self, loop, rest_svc, file_svc):
         internal_rest_svc = rest_svc(loop)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.objects.c_ability import Ability
+from app.objects.c_agent import Agent
 from app.objects.c_adversary import Adversary
 from app.utility.base_world import BaseWorld
 
@@ -18,6 +19,9 @@ def setup_rest_svc_test(loop, data_svc):
     loop.run_until_complete(data_svc.store(
         Adversary(adversary_id='123', name='test', description='test', phases=[]))
     )
+    loop.run_until_complete(data_svc.store(
+        Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0)
+    ))
 
 
 @pytest.mark.usefixtures(
@@ -65,3 +69,8 @@ class TestRestSvc:
             f.write(data)
         response = loop.run_until_complete(internal_rest_svc.delete_adversary(data=dict(adversary_id='123')))
         assert 'Delete action completed' == response
+
+    def test_delete_agent(self, loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(loop)
+        response = loop.run_until_complete(internal_rest_svc.delete_agent(data=dict(paw='123')))
+        'Delete action completed' == response


### PR DESCRIPTION
Requires agent code changes here: https://github.com/mitre/sandcat/pull/288

* Enables payload name randomization based upon a provided list
* Payload randomization is handled on a per-operation basis (individual link variants are modified)
* Instructions have the modified payload name which gets decoded by the server
* Clean-up commands know to delete the modified file name