### PR TITLE
VIRTS-907 Recursive Adversary Pack adding

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -221,15 +221,15 @@ class DataService(BaseService):
 
     @track_recursion
     async def _load_adversary(self, adv):
-            phases = adv.get('phases', dict())
-            for p in adv.get('packs', []):
-                adv_pack = await self._grab_adversary(id=p)
-                for pack in adv_pack:
-                    full_pack = await self._load_adversary(pack)
-                    await self._merge_phases(phases, full_pack['phases'])
-            sorted_phases = [phases[x] for x in sorted(phases.keys())]
-            phases = await self._add_phases(sorted_phases, adv)
-            return dict(adversary_id=adv['id'], name=adv['name'], description=adv['description'], phases=phases)
+        phases = adv.get('phases', dict())
+        for p in adv.get('packs', []):
+            adv_pack = await self._grab_adversary(id=p)
+            for pack in adv_pack:
+                full_pack = await self._load_adversary(pack)
+                await self._merge_phases(phases, full_pack['phases'])
+        sorted_phases = [phases[x] for x in sorted(phases.keys())]
+        phases = await self._add_phases(sorted_phases, adv)
+        return dict(adversary_id=adv['id'], name=adv['name'], description=adv['description'], phases=phases)
 
     async def _load_abilities(self, plugin):
         for filename in glob.iglob('%s/abilities/**/*.yml' % plugin.data_dir, recursive=True):

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -110,3 +110,4 @@ packs:
             with pytest.raises(Exception, match=r".*infinite loop detected.*"):
                 adversary = loop.run_until_complete(data_svc._grab_adversary(id='DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF'))
                 adversary_nextform = loop.run_until_complete(data_svc._load_adversary(adversary[0]))
+                assert adversary_nextform

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import os
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def temp_file(filename, contents):
+    f = open(filename, 'w')
+    f.write(contents)
+    name = f.name
+    f.close()
+    try:
+        yield name
+    finally:
+        if os.path.exists(filename):
+            os.remove(filename)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,4 +14,3 @@ def temp_file(filename, contents):
     finally:
         if os.path.exists(filename):
             os.remove(filename)
-


### PR DESCRIPTION
Adding the functionality to nest packs into packs into adversaries into packs and be able to expand them all out to a single adversary on loading.

Also added a decorator to catch infinite loops, since our function is stateless any call with the same parameters that has been already called in the recursion chain would loop back onto itself, so it is an easy detection.