### PR TITLE
Update server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
                         help='remove object_store on start')
     args = parser.parse_args()
     config = args.environment if pathlib.Path('conf/%s.yml' % args.environment).exists() else 'default'
-    BaseWorld.apply_config('default', BaseWorld.strip_yml('conf/default.yml')[0])
+    BaseWorld.apply_config('default', BaseWorld.strip_yml('conf/%s.yml' % config)[0])
     BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
     BaseWorld.apply_config('payloads', BaseWorld.strip_yml('conf/payloads.yml')[0])
 


### PR DESCRIPTION
On March 24th , there was a MERGE which removed the `open` call for the config file (https://github.com/mitre/caldera/pull/1435/commits/5b18d180db7e6b41ed1f387af7d08443d30e9f10) . However:`default.yml` was hardcoded on the `BaseWorld.strip_yml` method to read the config file as shown in here (https://github.com/mitre/caldera/blob/master/server.py#L74) . Even though one runs `python server.py -E local`, the parameter does not get passed to the `Baseworld.strip_yml` method. It is evaluated properly by the conditional to handle the `args.environment` parameter (https://github.com/mitre/caldera/blob/master/server.py#L73) and stores the value in the variable `config` (https://github.com/mitre/caldera/blob/master/server.py#L73), but it is never used.