### PR TITLE
fixing small potential bug

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -79,7 +79,8 @@ class ContactService(BaseService):
                         operation = await self.get_service('data_svc').locate('operations', dict(id=link.operation))
                         loop.create_task(link.parse(operation[0], result.output))
                     else:
-                        loop.create_task(self.get_service('learning_svc').learn(link, result.output))
+                        if link.operation:
+                            loop.create_task(self.get_service('learning_svc').learn(link, result.output))
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
         except Exception as e:


### PR DESCRIPTION
This PR fixes a small potential bug that can occur when tasking an agent with an ability outside the scope of an operation. You can currently only do this via a REST API call - and it won't fail the app currently, just throw a stack trace when attempting to parse the output from the ability. 

This PR avoids parsing non-operation-tied links, as the facts can't be fed into anything useful.