### PR TITLE
Fixing bugs around tasking agents outside an op

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -167,9 +167,11 @@ class Agent(BaseObject):
         await self.task(abilities)
 
     async def task(self, abilities, facts=()):
-        for i in await self.capabilities(abilities):
-            self.links.append(Link(operation=None, command=i.test, paw=self.paw, ability=i))
-        return await BasePlanningService().add_test_variants(links=self.links, agent=self, facts=facts)
+        bps = BasePlanningService()
+        potential_links = [Link(operation='task', command=i.test, paw=self.paw, ability=i) for i in await self.capabilities(abilities)]
+        for valid in await bps.remove_links_missing_facts(
+                await bps.add_test_variants(links=potential_links, agent=self, facts=facts)):
+            self.links.append(valid)
 
     """ PRIVATE """
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -75,12 +75,11 @@ class ContactService(BaseService):
                 if result.output:
                     link.output = True
                     self.get_service('file_svc').write_result_file(result.id, result.output)
+                    operation = await self.get_service('data_svc').locate('operations', dict(id=link.operation))
                     if link.ability.parsers:
-                        operation = await self.get_service('data_svc').locate('operations', dict(id=link.operation))
                         loop.create_task(link.parse(operation[0], result.output))
-                    else:
-                        if link.operation:
-                            loop.create_task(self.get_service('learning_svc').learn(link, result.output))
+                    elif operation:
+                        loop.create_task(self.get_service('learning_svc').learn(operation[0], link, result.output))
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
         except Exception as e:

--- a/app/service/learning_svc.py
+++ b/app/service/learning_svc.py
@@ -38,9 +38,8 @@ class LearningService(BaseService):
                     self.model.add(variables)
         self.model = set(self.model)
 
-    async def learn(self, link, blob):
+    async def learn(self, operation, link, blob):
         decoded_blob = b64decode(blob).decode('utf-8')
-        operation = (await self.get_service('data_svc').locate('operations', dict(id=link.operation)))[0]
 
         found_facts = []
         for parser in self.parsers:

--- a/tests/services/test_learning_svc.py
+++ b/tests/services/test_learning_svc.py
@@ -22,6 +22,7 @@ class TestLearningSvc:
         operation, link = setup_learning_service
         operation.add_link(link)
         loop.run_until_complete(learning_svc.learn(
+            operation=operation,
             link=link,
             blob=BaseWorld.encode_string('i contain 1 ip address 192.168.0.1 and one file /etc/host.txt. that is all.'))
         )


### PR DESCRIPTION
Simple PR that solves a few buggy areas of tasking an agent with an ability outside of an operation:
* We were not trimming out abilities with variables inside them, so I fixed that here
* I added in a pseudo-operation name (task) for any ability tasked outside of an operation. I needed to patch an area around the parsing after doing this, as we were expecting operation=None there if it was outside an operation.