### PR TITLE
Fix bug introduced in 9b0ff60

### DIFF
--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -512,7 +512,7 @@
                 template.find('#ability-platform').val(ability.platform);
                 template.find('#ability-executor').val(ability.executor);
                 template.find('#ability-command').val(atob(ability.test));
-                if(ability.cleanup[0] > 0) {
+                if(ability.cleanup[0]) {
                     template.find('#ability-cleanup').val(atob(ability.cleanup[0]));
                 }
                 template.show();


### PR DESCRIPTION
cleanup didn't show anymore (`ability.cleanup[0]` is a string). We could also check the length of `ability.cleanup` instead of what this PR does, not sure if one is preferable.