### PR TITLE
Fix IndexError

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -76,13 +76,13 @@ class ContactService(BaseService):
                     link.output = True
                     self.get_service('file_svc').write_result_file(result.id, result.output)
                     operation = await self.get_service('data_svc').locate('operations', dict(id=link.operation))
-                    if link.ability.parsers:
-                        loop.create_task(link.parse(operation[0], result.output))
-                    elif operation:
-                        loop.create_task(self.get_service('learning_svc').learn(operation[0].all_facts(), link, result.output))
-                    else:
+                    if not operation:
                         agent = await self.get_service('data_svc').locate('agents', dict(paw=link.paw))
                         loop.create_task(self.get_service('learning_svc').learn(agent[0].all_facts(), link, result.output))
+                    elif link.ability.parsers:
+                        loop.create_task(link.parse(operation[0], result.output))
+                    else:
+                        loop.create_task(self.get_service('learning_svc').learn(operation[0].all_facts(), link, result.output))
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
         except Exception as e:


### PR DESCRIPTION
Prevent an IndexError if no operation is found (because of `operation[0]`).