### PR TITLE
Minimum version checking refactor

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -150,6 +150,12 @@ class AppService(BaseService):
         await contact_svc.register(Html(self.get_services()))
         await contact_svc.register(Gist(self.get_services()))
 
+    async def validate_requirements(self):
+        for requirement, params in self.get_config('requirements').items():
+            if not self.check_requirement(params):
+                self.log.error('%s does not meet the minimum version of %s' % (requirement, params['version']))
+                self._errors.append(Error('requirement', '%s version needs to be >= %s' % (requirement, params['version'])))
+
     """ PRIVATE """
 
     async def _save_configurations(self):

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -127,7 +127,6 @@ class BaseWorld:
                 return distutils.version.StrictVersion(str(parse_version(mod_version))) >= distutils.version.StrictVersion(str(params['version']))
             elif 'command' in params:
                 output = subprocess.check_output(params['command'].split(' '), shell=False)
-                v = parse_version(output.decode('utf-8'))
                 return distutils.version.StrictVersion(str(parse_version(output.decode('utf-8')))) >= distutils.version.StrictVersion(str(params['version']))
         except Exception as e:
             logging.getLogger('check_requirement').error(repr(e))

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -134,17 +134,16 @@ class BaseWorld:
                 return groups[1]
             return '0.0.0'
 
-        checkers = {
-            'python_module': check_module_version,
-            'installed_program': check_program_version
-        }
+        checkers = dict(
+            python_module=check_module_version,
+            installed_program=check_program_version
+        )
 
         try:
             requirement_type = params.get('type')
             return checkers[requirement_type](**params)
         except Exception as e:
             logging.getLogger('check_requirement').error(repr(e))
-        return False
 
     @staticmethod
     def get_version(path='.'):

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -146,6 +146,7 @@ class BaseWorld:
             logging.getLogger('check_requirement').error(repr(e))
         return False
 
+    @staticmethod
     def get_version(path='.'):
         ignore = ['/plugins/', '/.tox/']
         included_extensions = ['*.py', '*.html', '*.js', '*.go']

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -117,7 +117,7 @@ class BaseWorld:
             attr = attr if attr else '__version__'
             mod_version = getattr(import_module(module), attr, '')
             return compare_versions(mod_version, version)
-    
+
         def check_program_version(command, version, **kwargs):
             output = subprocess.check_output(command.split(' '), shell=False)
             return compare_versions(output.decode('utf-8'), version)

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -20,6 +20,14 @@ plugins:
 - access
 port: 8888
 reports_dir: /tmp
+requirements:
+  go:
+    command: go version
+    version: 1.11
+  python:
+    attr: version
+    module: sys
+    version: 3.6.1
 users:
   blue:
     blue: admin

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -23,10 +23,12 @@ reports_dir: /tmp
 requirements:
   go:
     command: go version
+    type: installed_program
     version: 1.11
   python:
     attr: version
     module: sys
+    type: python_module
     version: 3.6.1
 users:
   blue:

--- a/server.py
+++ b/server.py
@@ -48,7 +48,7 @@ async def start_server():
 def run_tasks(services):
     loop = asyncio.get_event_loop()
     loop.create_task(build_docs())
-    loop.run_until_complete(app_svc.validate_requirements())
+    loop.create_task(app_svc.validate_requirements())
     loop.run_until_complete(data_svc.restore_state())
     loop.run_until_complete(RestApi(services).enable())
     loop.run_until_complete(app_svc.register_contacts())

--- a/server.py
+++ b/server.py
@@ -48,6 +48,7 @@ async def start_server():
 def run_tasks(services):
     loop = asyncio.get_event_loop()
     loop.create_task(build_docs())
+    loop.run_until_complete(app_svc.validate_requirements())
     loop.run_until_complete(data_svc.restore_state())
     loop.run_until_complete(RestApi(services).enable())
     loop.run_until_complete(app_svc.register_contacts())


### PR DESCRIPTION
Background:
Spawned from a discussion in slack about agent compilation errors when the installed go version is too old.  General idea is to be able to setup a set of version dependencies for caldera and be able to evaluate them and notify the user on server boot.