### PR TITLE
Also search within names and descriptions

### DIFF
--- a/static/js/ability.js
+++ b/static/js/ability.js
@@ -75,7 +75,13 @@ function searchAbilities(parent, abilities){
     if(val){
         abilities.forEach(function(ab){
             let cmd = atob(ab['test']);
-            if (cmd.toLowerCase().includes(val) && !added.includes(ab['ability_id'])){
+            if (
+                (
+                    ab['name'].toLowerCase().includes(val) ||
+                    ab['description'].toLowerCase().includes(val) ||
+                    cmd.toLowerCase().includes(val)
+                ) && !added.includes(ab['ability_id'])
+            ){
                 let composite = addPlatforms([ab]);
                 added.push(ab['ability_id']);
                 appendAbilityToList(parent, composite[0]);


### PR DESCRIPTION
This PR completes the 'search' ability and allows to search for a specific term within names and descriptions. One good example is fast searching for a specific technique ID.