### PR TITLE
Virts 1106e additional bandit findings

### DIFF
--- a/app/learning/p_ip.py
+++ b/app/learning/p_ip.py
@@ -18,7 +18,8 @@ class Parser:
     @staticmethod
     def _is_valid_ip(raw_ip):
         try:
-            if raw_ip in ['0.0.0.0', '127.0.0.1']:
+            # The following hardcoded addresses are not used to bind to an interface.
+            if raw_ip in ['0.0.0.0', '127.0.0.1']:  # nosec
                 return False
             ip_address(raw_ip)
         except BaseException:

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -129,7 +129,7 @@ class AppService(BaseService):
 
     async def retrieve_compiled_file(self, name, platform):
         _, path = await self._services.get('file_svc').find_file_path('%s-%s' % (name, platform))
-        signature = hashlib.md5(open(path, 'rb').read()).hexdigest()
+        signature = hashlib.sha256(open(path, 'rb').read()).hexdigest()
         display_name = await self._services.get('contact_svc').build_filename()
         self.log.debug('%s downloaded with hash=%s and name=%s' % (name, signature, display_name))
         return '%s-%s' % (name, platform), display_name

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -65,7 +65,9 @@ class DataService(BaseService):
         """
         if os.path.exists('data/object_store'):
             _, store = await self.get_service('file_svc').read_file('object_store', 'data')
-            ram = pickle.loads(store)
+            # Pickle is only used to load a local file that caldera creates. Pickled data is not
+            # received over the network.
+            ram = pickle.loads(store)  # nosec
             for key in ram.keys():
                 self.ram[key] = []
                 for c_object in ram[key]:

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -259,7 +259,7 @@ class RestService(BaseService):
     @staticmethod
     async def _read_from_yaml(file_path):
         with open(file_path, 'r') as f:
-            return yaml.load(f.read(), Loader=yaml.FullLoader)
+            return yaml.safe_load(f.read())
 
     @staticmethod
     async def _write_to_yaml(file_path, content):

--- a/app/utility/base_obfuscator.py
+++ b/app/utility/base_obfuscator.py
@@ -14,7 +14,7 @@ class BaseObfuscator(BaseWorld):
         supported_platforms = self.__getattribute__('supported_platforms')
         try:
             if agent.platform in supported_platforms and link.ability.executor in agent.executors:
-                link.command_hash = hashlib.md5(str.encode(link.command)).hexdigest()
+                link.command_hash = hashlib.sha256(str.encode(link.command)).hexdigest()
                 o = self.__getattribute__(link.ability.executor)
                 return o(link, **kwargs)
         except Exception:


### PR DESCRIPTION
Addresses some things that bandit alerts on, but were either false positives or borderline: 

Changes: 

- use yaml.safe_load intead of FullLoader 
- Use sha256 instead of md5 (our use of md5 here was OK, but I don't see a problem with switching to sha256). 
- Use `#nosec` to ignore a couple lines and add a comments to justify why they're being ignored. 