### PR TITLE
add safety check to tox and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ language: python
 matrix:
     include:
         - python: 3.6
-          env: TOXENV=py36,style,coverage-ci
+          env: TOXENV=py36,style,coverage-ci,safety
 
         - python: 3.7
-          env: TOXENV=py37,style,coverage-ci
+          env: TOXENV=py37,style,coverage-ci,safety
 
         - python: 3.8
-          env: TOXENV=py38,style,coverage-ci
+          env: TOXENV=py38,style,coverage-ci,safety
 
 install:
     - pip install tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest
 pytest-aiohttp
 coverage
 pre-commit
+safety

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py{35,36,37,38,3}
     style
     coverage
+    safety
 skip_missing_interpreters = true
 
 [testenv]
@@ -62,3 +63,12 @@ commands =
     coverage combine
     coverage report
     codecov
+
+[testenv:safety]
+deps =
+    safety
+skip_install = true
+whitelist_externals=find
+commands =
+    safety check -r requirements.txt
+    safety check -r requirements-dev.txt


### PR DESCRIPTION
Add safety (https://pypi.org/project/safety/) to tox. Safety will check any pinned requirements in our requirements.txt and requirements-dev.txt against a database of insecure versions. 

We only pin a couple of our requirements right now, but this will help let us know if there is an issue with one of them.  Also, we may want to start pinning dependency versions more heavily in the future if we start running into compatibility problems. 
