### PR TITLE
Default to generating secure config 

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -109,9 +109,9 @@ class AppService(AppServiceInterface, BaseService):
         self.log.debug('%s downloaded with hash=%s and name=%s' % (name, signature, display_name))
         return '%s-%s' % (name, platform), display_name
 
-    async def teardown(self):
+    async def teardown(self, main_config='default'):
         await self._destroy_plugins()
-        await self._save_configurations()
+        await self._save_configurations(main_config=main_config)
         await self._services.get('data_svc').save_state()
         await self._write_reports()
         self.log.debug('[!] shutting down server...good-bye')
@@ -137,8 +137,11 @@ class AppService(AppServiceInterface, BaseService):
 
     """ PRIVATE """
 
-    async def _save_configurations(self):
-        for cfg in ['default', 'agents', 'payloads']:
+    async def _save_configurations(self, main_config='default'):
+        with open('conf/%s.yml' % main_config, 'w') as config:
+            config.write(yaml.dump(self.get_config(name='main')))
+
+        for cfg in ['agents', 'payloads']:
             with open('conf/%s.yml' % cfg, 'w') as config:
                 config.write(yaml.dump(self.get_config(name=cfg)))
 

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -109,9 +109,9 @@ class AppService(AppServiceInterface, BaseService):
         self.log.debug('%s downloaded with hash=%s and name=%s' % (name, signature, display_name))
         return '%s-%s' % (name, platform), display_name
 
-    async def teardown(self, main_config='default'):
+    async def teardown(self, main_config_file='default'):
         await self._destroy_plugins()
-        await self._save_configurations(main_config=main_config)
+        await self._save_configurations(main_config_file=main_config_file)
         await self._services.get('data_svc').save_state()
         await self._write_reports()
         self.log.debug('[!] shutting down server...good-bye')
@@ -137,13 +137,10 @@ class AppService(AppServiceInterface, BaseService):
 
     """ PRIVATE """
 
-    async def _save_configurations(self, main_config='default'):
-        with open('conf/%s.yml' % main_config, 'w') as config:
-            config.write(yaml.dump(self.get_config(name='main')))
-
-        for cfg in ['agents', 'payloads']:
-            with open('conf/%s.yml' % cfg, 'w') as config:
-                config.write(yaml.dump(self.get_config(name=cfg)))
+    async def _save_configurations(self, main_config_file='default'):
+        for cfg_name, cfg_file in [('main', main_config_file), ('agents', 'agents'), ('payloads', 'payloads')]:
+            with open('conf/%s.yml' % cfg_file, 'w') as config:
+                config.write(yaml.dump(self.get_config(name=cfg_name)))
 
     async def _destroy_plugins(self):
         for plugin in await self._services.get('data_svc').locate('plugins', dict(enabled=True)):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -203,7 +203,7 @@ class RestService(RestServiceInterface, BaseService):
             enabled_plugins = self.get_config('plugins')
             enabled_plugins.append(data.get('value'))
         else:
-            self.set_config('default', data.get('prop'), data.get('value'))
+            self.set_config('main', data.get('prop'), data.get('value'))
 
     async def update_operation(self, op_id, state=None, autonomous=None):
         async def validate(op):

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -31,7 +31,7 @@ class BaseWorld:
 
     @staticmethod
     def get_config(prop=None, name=None):
-        name = name if name else 'default'
+        name = name if name else 'main'
         if prop:
             return BaseWorld._app_configuration[name].get(prop)
         return BaseWorld._app_configuration[name]

--- a/app/utility/config_generator.py
+++ b/app/utility/config_generator.py
@@ -1,0 +1,59 @@
+import logging
+import pathlib
+import secrets
+
+import jinja2
+import yaml
+
+
+CONFIG_MSG_TEMPLATE = jinja2.Template("""
+Log into Caldera with the following admin credentials:
+    Red:
+    {%- if users.red.red %}
+        USERNAME: red
+        PASSWORD: {{ users.red.red }}
+    {%- endif %}
+        API_TOKEN: {{ api_key_red }}
+    Blue:
+    {%- if users.blue.blue %}
+        USERNAME: blue
+        PASSWORD: {{ users.blue.blue }}
+    {%- endif %}
+        API_TOKEN: {{ api_key_blue }}
+To modify these values, edit the {{ config_path }} file.
+""")
+
+
+def log_config_message(config_path):
+    with pathlib.Path(config_path).open('r') as fle:
+        config = yaml.safe_load(fle)
+    logging.info(CONFIG_MSG_TEMPLATE.render(config_path=str(config_path), **config))
+
+
+def make_secure_config():
+    with open('conf/default.yml', 'r') as fle:
+        config = yaml.safe_load(fle)
+
+    secret_options = ('api_key_blue', 'api_key_red', 'crypt_salt', 'encryption_key')
+    for option in secret_options:
+        config[option] = secrets.token_urlsafe()
+
+    config['users'] = dict(red=dict(red=secrets.token_urlsafe()),
+                           blue=dict(blue=secrets.token_urlsafe()))
+
+    return config
+
+
+def ensure_local_config():
+    """
+    Checks if a local.yml config file exists. If not, generates a new local.yml file using secure random values.
+    """
+    local_conf_path = pathlib.Path('conf/local.yml')
+    if local_conf_path.exists():
+        return
+
+    logging.info('Creating new secure config in %s' % local_conf_path)
+    with local_conf_path.open('w') as fle:
+        yaml.safe_dump(make_secure_config(), fle, default_flow_style=False)
+
+    log_config_message(local_conf_path)

--- a/server.py
+++ b/server.py
@@ -66,7 +66,7 @@ def run_tasks(services):
         logging.info('All systems ready.')
         loop.run_forever()
     except KeyboardInterrupt:
-        loop.run_until_complete(services.get('app_svc').teardown(main_config=args.environment))
+        loop.run_until_complete(services.get('app_svc').teardown(main_config_file=args.environment))
 
 
 def make_secure_config(config_name):

--- a/server.py
+++ b/server.py
@@ -112,7 +112,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     setup_logger(getattr(logging, args.logLevel))
 
-    if not args.insecure and not pathlib.Path('conf/{}.yml'.format(args.environment)).exists():
+    if args.insecure and args.environment not in ('default', 'local'):
+        args.environment = 'default'
+    elif not args.insecure and not pathlib.Path('conf/{}.yml'.format(args.environment)).exists():
         make_secure_config(args.environment)
 
     config = args.environment if pathlib.Path('conf/%s.yml' % args.environment).exists() else 'default'

--- a/server.py
+++ b/server.py
@@ -116,7 +116,9 @@ if __name__ == '__main__':
         make_secure_config(args.environment)
 
     config = args.environment if pathlib.Path('conf/%s.yml' % args.environment).exists() else 'default'
-    BaseWorld.apply_config('main', BaseWorld.strip_yml('conf/%s.yml' % config)[0])
+    main_config_path = 'conf/%s.yml' % config
+    BaseWorld.apply_config('main', BaseWorld.strip_yml(main_config_path)[0])
+    logging.info('Using main config from %s' % main_config_path)
     BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
     BaseWorld.apply_config('payloads', BaseWorld.strip_yml('conf/payloads.yml')[0])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from app.objects.secondclass.c_link import Link
 @pytest.fixture(scope='session')
 def init_base_world():
     with open('conf/default.yml') as c:
-        BaseWorld.apply_config('default', yaml.load(c, Loader=yaml.FullLoader))
+        BaseWorld.apply_config('main', yaml.load(c, Loader=yaml.FullLoader))
     BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
     BaseWorld.apply_config('payloads', BaseWorld.strip_yml('conf/payloads.yml')[0])
 

--- a/tests/contacts/test_contact_gist.py
+++ b/tests/contacts/test_contact_gist.py
@@ -5,12 +5,12 @@ from app.utility.base_world import BaseWorld
 class TestContactGist:
 
     def test_retrieve_config(self, loop, app_svc):
-        BaseWorld.apply_config(name='default', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
-                                                       'plugins': ['sandcat', 'stockpile'],
-                                                       'crypt_salt': 'BLAH',
-                                                       'api_key': 'ADMIN123',
-                                                       'encryption_key': 'ADMIN123',
-                                                       'exfil_dir': '/tmp'})
+        BaseWorld.apply_config(name='main', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
+                                                    'plugins': ['sandcat', 'stockpile'],
+                                                    'crypt_salt': 'BLAH',
+                                                    'api_key': 'ADMIN123',
+                                                    'encryption_key': 'ADMIN123',
+                                                    'exfil_dir': '/tmp'})
         internal_app_svc = app_svc(loop)
         gist_c2 = Gist(internal_app_svc.get_services())
         loop.run_until_complete(gist_c2.start())

--- a/tests/contacts/test_contact_gist.py
+++ b/tests/contacts/test_contact_gist.py
@@ -5,12 +5,12 @@ from app.utility.base_world import BaseWorld
 class TestContactGist:
 
     def test_retrieve_config(self, loop, services):
-        BaseWorld.apply_config(name='default', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
-                                                       'plugins': ['sandcat', 'stockpile'],
-                                                       'crypt_salt': 'BLAH',
-                                                       'api_key': 'ADMIN123',
-                                                       'encryption_key': 'ADMIN123',
-                                                       'exfil_dir': '/tmp'})
+        BaseWorld.apply_config(name='main', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
+                                                    'plugins': ['sandcat', 'stockpile'],
+                                                    'crypt_salt': 'BLAH',
+                                                    'api_key': 'ADMIN123',
+                                                    'encryption_key': 'ADMIN123',
+                                                    'exfil_dir': '/tmp'})
         gist_c2 = Gist(services)
         loop.run_until_complete(gist_c2.start())
         assert gist_c2.retrieve_config() == 'arandomkeythatisusedtoconnecttogithubapi'

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -10,12 +10,12 @@ from app.utility.base_world import BaseWorld
 
 @pytest.fixture
 def setup_rest_svc_test(loop, data_svc):
-    BaseWorld.apply_config(name='default', config={'app.contact.http': '0.0.0.0',
-                                                   'plugins': ['sandcat', 'stockpile'],
-                                                   'crypt_salt': 'BLAH',
-                                                   'api_key': 'ADMIN123',
-                                                   'encryption_key': 'ADMIN123',
-                                                   'exfil_dir': '/tmp'})
+    BaseWorld.apply_config(name='main', config={'app.contact.http': '0.0.0.0',
+                                                'plugins': ['sandcat', 'stockpile'],
+                                                'crypt_salt': 'BLAH',
+                                                'api_key': 'ADMIN123',
+                                                'encryption_key': 'ADMIN123',
+                                                'exfil_dir': '/tmp'})
     loop.run_until_complete(data_svc.store(
         Ability(ability_id='123', test=BaseWorld.encode_string('curl #{app.contact.http}'), variations=[]))
     )

--- a/tests/utility/test_base_world.py
+++ b/tests/utility/test_base_world.py
@@ -7,7 +7,7 @@ from app.utility.base_world import BaseWorld
 
 class TestBaseWorld:
 
-    default_config = dict(name='default', config={'app.contact.http': '0.0.0.0', 'plugins': ['sandcat', 'stockpile']})
+    default_config = dict(name='main', config={'app.contact.http': '0.0.0.0', 'plugins': ['sandcat', 'stockpile']})
 
     default_yaml = dict(test_dir=1, implant_name='unittesting', test_int=1234)
 
@@ -42,12 +42,12 @@ class TestBaseWorld:
 
     @pytest.mark.usefixtures('reset_config')
     def test_get_prop_from_config(self):
-        assert BaseWorld.get_config(name='default', prop='app.contact.http') == '0.0.0.0'
+        assert BaseWorld.get_config(name='main', prop='app.contact.http') == '0.0.0.0'
 
     @pytest.mark.usefixtures('reset_config')
     def test_set_prop_from_config(self):
-        BaseWorld.set_config(name='default', prop='newprop', value='unittest')
-        assert BaseWorld.get_config(name='default', prop='newprop') == 'unittest'
+        BaseWorld.set_config(name='main', prop='newprop', value='unittest')
+        assert BaseWorld.get_config(name='main', prop='newprop') == 'unittest'
 
     def test_encode_and_decode_string(self):
         plaintext = 'unit testing string'

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -25,7 +25,7 @@ def aiohttp_client(loop, aiohttp_client):
 
     async def initialize():
         with open(Path(__file__).parents[2] / 'conf' / 'default.yml', 'r') as fle:
-            BaseWorld.apply_config('default', yaml.safe_load(fle))
+            BaseWorld.apply_config('main', yaml.safe_load(fle))
         with open(Path(__file__).parents[2] / 'conf' / 'payloads.yml', 'r') as fle:
             BaseWorld.apply_config('payloads', yaml.safe_load(fle))
 


### PR DESCRIPTION
Changes: 
* Alter caldera so that when started, it will generate a new config file with random values for the security relevant parameters
* A secure config will not be generated if server.py is started with `--insecure` or `-E default`
* ~~The old default behavior will be used if server.py is started with `-E default`~~
* `-E default` and `--insecure` basically do the same thing 
* Caldera will encounter a FileNotFound exception when trying to load a specified config that does not exist (I think this is preferable to silently falling back to default.yml)
* Correct(?) some logic for passing in different names of config files. Now, there is a 'main' config that is loaded from the file specified by the `-E` flag.  Precedence for preferring the main config: 
  1. `-E` option in argv
  2. `local.yml`  (this will be generated with random secret values if it does not exist)
  3. ~~`default.yml`~~

`default.yml` will only be used if caldera is started with `-E default` or `--insecure`!

Behavior examples: 

1. Caldera is started with no options, the  `conf/local.yml` path does NOT exist:
    Caldera will generate a new config and store it in `conf/local.yml`
2. Caldera is started with no options, the `conf/local.yml` path DOES exist:
    Caldera will not generate a new config and use the values in `local.yml`
3. Caldera is started with only the `--insecure`, the  `conf/local.yml` path does NOT exist:
    Caldera will use the `conf/default.yml` config.
4. Caldera is started with only the `--insecure`, the  `conf/local.yml` path does exist:
    ~~Caldera will still use the `conf/default.yml` config.~~
    Caldera will use the `conf/default.yml` config file
5. ~~Caldera is started with `-E custom`, and `conf/custom.yml` does not exist:
    Caldera will generate a new config file and write it to `conf/custom.yml`~~

Example of output when a new config is generated: 

UPDATED example: 

```
2020-04-28 15:02:32 - INFO  (config_generator.py:55 ensure_local_config) Creating new secure config in conf/local.yml
2020-04-28 15:02:32 - INFO  (config_generator.py:30 log_config_message) 
Log into Caldera with the following admin credentials:
    Red:
        USERNAME: red
        PASSWORD: wYFXUeKT1PGdK0S0j2zfgAhNupITk2eA9ZwUU51pPg4
        API_TOKEN: s8lfLNVAFAPMuszT1V-GFqB3A2Rk_Yp6Go1oj5DwJTM
    Blue:
        USERNAME: blue
        PASSWORD: dH2bTgDYP5HmIBoX_8fWYQYNHGmyf7vtyJHked_tJ0o
        API_TOKEN: -J8rGP5q4HwL4E3kgLz3Q3aaxY0uqDmaxLDbUVbtX5M
To modify these values, edit the conf/local.yml file.
```