### PR TITLE
Add feature to see a built ability

### DIFF
--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -451,9 +451,19 @@
         if(ability.payloads.length > 0) {
            template.find('#ability-metadata').append('<td><div id="ability-payload"><div class="tooltip"><span class="tooltiptext">This ability uses a payload</span>&#128176;</div></div></td>');
         }
-        template.find('#ability-rm').html('<div class="ability-remove"><div style="font-size:8px;">&#x274C;</div></div>');
+        template.find('#ability-rm').html('<div class="ability-remove"><div style="font-size:8px;">&#x274C;</div></div><div class="ability-show">?</div>');
         template.find('.ability-remove').click(function() {
             removeAbility(ability);
+        });
+        template.find('.ability-show').click(function() {
+            let pModal = $('#phase-modal');
+            let tacList = pModal.find('#ability-tactic-filter');
+            let techList = pModal.find('#ability-technique-filter');
+            let abList = pModal.find('#ability-ability-filter');
+            tacList.val(ability['tactic']).change();
+            techList.val(ability['technique_id']).change();
+            abList.val(ability['name']).change();
+            showPhaseModal(1);
         });
 
         ability.platform.forEach(function(p, index) {


### PR DESCRIPTION
This PR adds the possibility to open the `phase-modal` window, while showing the ability selected. It is useful when looking at an adversary, wondering what a given ability actually does (the only way to do that right now is to click "add ability" and then look up the ability).

I initially wanted to use the `showAbility()` function: that would have been cleaner imho. For instance something like
```js
template.find('.ability-show').click(function() {
    // clean the phase-modal window, not the interesting part of the code
    […]
    
    // show the ability
    appendAbilityToList("phase-modal", ability);
    showAbility('phase-modal', [ability]);
}
```
Yet when calling `buildAbility(ability)`, `ability` has already gone through `addPlatforms()`, and is not formatted in the way expected by `showAbility()` any more. Indeed, the former contains `executor` and `platform` as lists, while the latter expects abilities to have one executor and platform each.