### PR TITLE
fixing xored payload references in downloads, patching planner UI bug

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -47,6 +47,8 @@ class FileSvc(BaseService):
             contents = xor_bytes(contents, xor_key.encode())
         if headers.get('name'):
             display_name = headers.get('name')
+        if file_path.endswith('.xored'):
+            display_name = file_path.replace('.xored', '')
         return file_path, contents, display_name
 
     async def save_file(self, filename, payload, target_dir):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -243,7 +243,9 @@ class RestService(BaseService):
     async def _build_operation_object(self, access, data):
         name = data.pop('name')
         group = data.pop('group', '')
-        planner = await self.get_service('data_svc').locate('planners', match=dict(name=data.pop('planner', 'sequential')))
+        planner = await self.get_service('data_svc').locate('planners',
+                                                            match=dict(name=data.pop('planner') if not
+                                                                       data.get('planner') == '' else 'sequential'))
         adversary = await self._construct_adversary_for_op(data.pop('adversary_id', ''))
         agents = await self.construct_agents_for_group(group)
         sources = await self.get_service('data_svc').locate('sources', match=dict(name=data.pop('source', 'basic')))

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -361,22 +361,21 @@
             warn('Jitter must be of the form "min/max" (e.x. 4/8)');
             return;
         }
-        let op = {
+        return {
             "index": "operations",
             "name":name,
             "group":document.getElementById("queueGroup").value,
             "adversary_id":document.getElementById("queueFlow").value,
             "state":document.getElementById("queueState").value,
+            "planner":document.getElementById("queuePlanner").value,
             "autonomous":document.getElementById("queueAuto").value,
             "atomic_enabled":document.getElementById("atomicEnabled").value,
-            "planner":document.getElementById("queuePlanner").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value
         };
-        return op;
     }
 
     function changeCurrentOperationState(newState){

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -369,16 +369,13 @@
             "state":document.getElementById("queueState").value,
             "autonomous":document.getElementById("queueAuto").value,
             "atomic_enabled":document.getElementById("atomicEnabled").value,
+            "planner":document.getElementById("queuePlanner").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value
         };
-        let planner = document.getElementById("queuePlanner").value;
-        if (planner) {
-        	op["planner"] = planner;
-        }
         return op;
     }
 

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -78,6 +78,7 @@
                 <option value="0">Prioritize Planner</option>
               </select>
               <select name="planner" id="queuePlanner" class="queueOption" style="opacity:0.5;display: none;" disabled="true">
+                    <option value="" class="queueOption" disabled selected>Select a planner</option>
                 {% for p in planners %}
                     <option value="{{ p.name }}">Use {{ p.name }} planner</option>
                 {% endfor %}
@@ -360,13 +361,12 @@
             warn('Jitter must be of the form "min/max" (e.x. 4/8)');
             return;
         }
-        return {
+        let op = {
             "index": "operations",
             "name":name,
             "group":document.getElementById("queueGroup").value,
             "adversary_id":document.getElementById("queueFlow").value,
             "state":document.getElementById("queueState").value,
-            "planner":document.getElementById("queuePlanner").value,
             "autonomous":document.getElementById("queueAuto").value,
             "atomic_enabled":document.getElementById("atomicEnabled").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
@@ -375,6 +375,11 @@
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value
         };
+        let planner = document.getElementById("queuePlanner").value;
+        if (planner) {
+        	op["planner"] = planner;
+        }
+        return op;
     }
 
     function changeCurrentOperationState(newState){


### PR DESCRIPTION
- Xored payloads will have their display_name value set to the actually payload (without .xored).  Abilities can reference the payload without the xored extension.
- Planner default select is now not provided during atomic mode