### PR TITLE
Add an event system

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -25,7 +25,7 @@ class Handler:
 
     async def handle(self, socket, path):
         try:
-            for handle in [h for h in self.handles if h.tag == path.split('/')[1]]:
+            for handle in [h for h in self.handles if path.split('/', 1)[1].startswith(h.tag)]:
                 await handle.run(socket, path, self.services)
         except Exception as e:
             self.log.debug(e)

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -59,6 +59,10 @@ class ContactService(ContactServiceInterface, BaseService):
     async def build_filename(self):
         return self.get_config(name='agents', prop='implant_name')
 
+    async def get_contact(self, name):
+        contact = [c for c in self.contacts if c.name == name]
+        return contact[0]
+
     """ PRIVATE """
 
     async def _save(self, result):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -43,6 +43,7 @@ class ContactService(ContactServiceInterface, BaseService):
             self.log.debug('Incoming %s beacon from %s' % (agent.contact, agent.paw))
             for result in results:
                 await self._save(Result(**result))
+                await self.get_service('event_svc').fire_event('link/completed', agent=agent.display, pid=result['pid'])
             return agent, await self._get_instructions(agent)
         agent = await self.get_service('data_svc').store(
             Agent.from_dict(dict(sleep_min=self.get_config(name='agents', prop='sleep_min'),

--- a/app/service/event_svc.py
+++ b/app/service/event_svc.py
@@ -14,16 +14,15 @@ class EventService(EventServiceInterface, BaseService):
         self.ws_uri = 'ws://{}'.format(self.get_config('app.contact.websocket'))
 
     async def observe_event(self, event, callback):
-        ws_contact = [c for c in self.contact_svc.contacts if c.name == 'websocket']
+        ws_contact = self.contact_svc.get_contact('websocket')
         handle = _Handle(event, callback)
-        ws_contact[0].handler.handles.append(handle)
+        ws_contact.handler.handles.append(handle)
 
     async def fire_event(self, event, **callback_kwargs):
         uri = '{}/{}'.format(self.ws_uri, event)
         msg = json.dumps(callback_kwargs)
-        loop = asyncio.get_event_loop()
         async with websockets.connect(uri) as websocket:
-            loop.create_task(websocket.send(msg))
+            asyncio.get_event_loop().create_task(websocket.send(msg))
 
 
 class _Handle:

--- a/app/service/event_svc.py
+++ b/app/service/event_svc.py
@@ -2,10 +2,11 @@ import asyncio
 import json
 import websockets
 
+from app.service.interfaces.i_event_svc import EventServiceInterface
 from app.utility.base_service import BaseService
 
 
-class EventService(BaseService):
+class EventService(EventServiceInterface, BaseService):
 
     def __init__(self):
         self.log = self.add_service('event_svc', self)

--- a/app/service/event_svc.py
+++ b/app/service/event_svc.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+import websockets
+
+from app.utility.base_service import BaseService
+
+
+class EventService(BaseService):
+
+    def __init__(self):
+        self.log = self.add_service('event_svc', self)
+        self.contact_svc = self.get_service('contact_svc')
+        self.ws_uri = 'ws://{}'.format(self.get_config('app.contact.websocket'))
+
+    async def observe_event(self, event, callback):
+        ws_contact = [c for c in self.contact_svc.contacts if c.name == 'websocket']
+        handle = _Handle(event, callback)
+        ws_contact[0].handler.handles.append(handle)
+
+    async def fire_event(self, event, **callback_kwargs):
+        uri = '{}/{}'.format(self.ws_uri, event)
+        msg = json.dumps(callback_kwargs)
+        loop = asyncio.get_event_loop()
+        async with websockets.connect(uri) as websocket:
+            loop.create_task(websocket.send(msg))
+
+
+class _Handle:
+
+    def __init__(self, tag, callback):
+        self.tag = tag
+        self.callback = callback
+
+    async def run(self, socket, path, services):
+        return await self.callback(socket, path, services)

--- a/app/service/interfaces/i_event_svc.py
+++ b/app/service/interfaces/i_event_svc.py
@@ -1,0 +1,25 @@
+import abc
+
+
+class EventServiceInterface(abc.ABC):
+
+    @abc.abstractmethod
+    def observe_event(self, event, callback):
+
+        """
+        Register an event handler
+        :param event: The event topic and (optional) subtopic, separated by a '/'
+        :param callback: The function that will handle the event
+        :return: None
+        """
+        pass
+
+    @abc.abstractmethod
+    def fire_event(self, event, **callback_kwargs):
+        """
+        Fire an event
+        :param event: The event topic and (optional) subtopic, separated by a '/'
+        :param callback_kwargs: Any additional parameters to pass to the event handler
+        :return: None
+        """
+        pass

--- a/server.py
+++ b/server.py
@@ -12,6 +12,7 @@ from app.service.app_svc import AppService
 from app.service.auth_svc import AuthService
 from app.service.contact_svc import ContactService
 from app.service.data_svc import DataService
+from app.service.event_svc import EventService
 from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
@@ -93,6 +94,7 @@ if __name__ == '__main__':
     auth_svc = AuthService()
     file_svc = FileSvc()
     learning_svc = LearningService()
+    event_svc = EventService()
     app_svc = AppService(application=web.Application())
 
     if args.fresh:


### PR DESCRIPTION
Follow-on from https://github.com/mitre/caldera/pull/1489. Moved it to a service, and to use the websocket contact as the backend.

Will be used in Response plugin (https://github.com/mitre/response/pull/16) for executing actions when links in an operation are completed.

Other options for pub/sub event handling were looked into, but most of them either seemed too bulky, not well maintained, or lacked asyncio support.