### PR TITLE
install.sh - Redirect the 'No such file or directory' to /dev/null

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -236,7 +236,7 @@ if [[ "$(uname)" == *"Darwin"* ]]; then
   darwin
 elif [[ "$(lsb_release -d)" == *"Ubuntu"* ]]; then
   ubuntu
-elif [[ "$(cat /etc/centos-release)" == *"CentOS"* ]]; then
+elif [[ "$(cat /etc/centos-release 2>/dev/null)" == *"CentOS"* ]]; then
   centos
 elif [[ "$(lsb_release -d)" == *"Fedora"* ]]; then
   centos


### PR DESCRIPTION
Currently when executing ```install.sh``` you'll see the following message:
```
cat: /etc/centos-release: No such file or directory
You must run the script with sudo.
```
To suppress the message stderr is redirected to /dev/null.