### PR TITLE
Only import exploits once in profiles.html

### DIFF
--- a/app/api/packs/campaign.py
+++ b/app/api/packs/campaign.py
@@ -1,3 +1,4 @@
+import operator
 from collections import defaultdict
 
 from aiohttp_jinja2 import template
@@ -41,7 +42,8 @@ class CampaignPack(BaseWorld):
         payloads = await self.rest_svc.list_payloads()
         adversaries = sorted([a.display for a in await self.data_svc.locate('adversaries', match=access)],
                              key=lambda a: a['name'])
-        return dict(adversaries=adversaries, exploits=[a.display for a in abilities], payloads=payloads,
+        exploits = sorted([a.display for a in abilities], key=operator.itemgetter('technique_id', 'name'))
+        return dict(adversaries=adversaries, exploits=exploits, payloads=payloads,
                     tactics=tactics, platforms=platforms, executors=executors)
 
     @check_authorization

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -42,19 +42,19 @@
     <form class="modal-content">
         <div class="container section-profile row ability-viewer modal-box">
             <div class="column" style="flex:100%;">
-                <select id="ability-tactic-filter" onchange="populateTechniques('phase-modal', {{ exploits | sort(attribute='technique_id') }});">
+                <select id="ability-tactic-filter" onchange="populateTechniques('phase-modal', exploits);">
                     <option disabled selected>Choose a tactic</option>
                     {% for tactic in tactics %}
                         <option value={{ tactic }} data-tactic={{ tactic }}>{{ tactic }}</option>
                     {% endfor %}}
                 </select>
-                <select id="ability-technique-filter" onchange="populateAbilities('phase-modal', {{ exploits | sort(attribute='name') }});">
+                <select id="ability-technique-filter" onchange="populateAbilities('phase-modal', exploits);">
                     <option disabled selected>Choose a technique</option>
                 </select>
-                <select id="ability-ability-filter" onchange="showAbility('phase-modal',  {{ exploits }})">
+                <select id="ability-ability-filter" onchange="showAbility('phase-modal', exploits)">
                     <option disabled selected>0 abilities</option>
                 </select>
-                <input id="ability-search-filter" style="width:60%;" type="text" placeholder="Search for abilities..." onkeyup="searchAbilities('phase-modal', {{ exploits }});">
+                <input id="ability-search-filter" style="width:60%;" type="text" placeholder="Search for abilities..." onkeyup="searchAbilities('phase-modal', exploits);">
                 <br><br>
                 <div class="ability-attack row-simple">
                     <div class="column" style="flex:60%">
@@ -226,6 +226,8 @@
 <script src="/gui/js/ability.js"></script>
 <script src="/gui/js/muuri.min.js"></script>
 <script>
+    var exploits = {{exploits | tojson}};
+
     $(document).ready(function () {
         stream('Profiles are optional. There are built-in profiles you can use right away, otherwise modify or build new ones here.');
         addPhase(1);


### PR DESCRIPTION
This PR changes the way we export the `exploits` variable with Jinja, in _profiles.html_. The variable was exported four times in the same page, making it more than 4 times as heavy. With these changes, the size went from 3.5MB to 700KB in my instance (the reduction factor is greater than 4 because not all characters are escaped, eg. `[` or `"` aren't)

This PR:

1. sorts the `exploits` list in the backend (two sorts merged in one)
2. exports `exploits` to _profiles.html_, within a `<script>` tag

To avoid any XSS attack, we use the `tojson` Jinja's filter (see the [documentation of the version 2.10.3 currently in use in caldera](https://jinja.palletsprojects.com/en/2.10.x/templates/#tojson)). This makes it safe to pass the variable in `<script>` tag.