### PR TITLE
VIRTS-1093: Clean up for stopped keep open ops

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -101,7 +101,9 @@ class Operation(BaseObject):
         self.add_link(link)
         return link.id
 
-    async def close(self):
+    async def close(self, services):
+        await self._cleanup_operation(services)
+        await self._save_new_source(services)
         if self.state not in [self.states['FINISHED'], self.states['OUT_OF_TIME']]:
             self.state = self.states['FINISHED']
         self.finish = self.get_current_timestamp()
@@ -195,9 +197,7 @@ class Operation(BaseObject):
             while not await self.is_closeable():
                 await asyncio.sleep(10)
                 await self._run(planner)
-            await self._cleanup_operation(services)
-            await self.close()
-            await self._save_new_source(services)
+            await self.close(services)
         except Exception as e:
             logging.error(e, exc_info=True)
 

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -225,8 +225,6 @@ class RestService(BaseService):
                     raise web.HTTPBadRequest(body='This operation has already finished.')
                 elif state not in op[0].states.values():
                     raise web.HTTPBadRequest(body='state must be one of {}'.format(op[0].states.values()))
-                elif state == op[0].states['FINISHED']:
-                    await op[0].close()
             except Exception as e:
                 self.log.error(repr(e))
         operation = await self.get_service('data_svc').locate('operations', match=dict(id=op_id))


### PR DESCRIPTION
- Combined operation close functionality under single close() function
- Removed call to close operation from rest_svc validate