### PR TITLE
Make 'id' constructor parameters consistent

### DIFF
--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -46,7 +46,7 @@ class SourceSchema(ma.Schema):
 
     @ma.post_load()
     def build_source(self, data, **_):
-        data['identifier'] = data.pop('id')
+        data['id'] = data.pop('id')
         return Source(**data)
 
 

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -59,9 +59,9 @@ class Source(FirstClassObjectInterface, BaseObject):
     def unique(self):
         return self.hash('%s' % self.id)
 
-    def __init__(self, identifier, name, facts, rules=(), adjustments=()):
+    def __init__(self, id, name, facts, rules=(), adjustments=()):
         super().__init__()
-        self.id = identifier
+        self.id = id
         self.name = name
         self.facts = facts
         self.rules = rules

--- a/app/objects/secondclass/c_instruction.py
+++ b/app/objects/secondclass/c_instruction.py
@@ -8,9 +8,9 @@ class Instruction(BaseObject):
         return self.clean(dict(id=self.id, sleep=self.sleep, command=self.command, executor=self.executor,
                                timeout=self.timeout, payloads=self.payloads))
 
-    def __init__(self, identifier, command, executor, payloads=None, sleep=0, timeout=60):
+    def __init__(self, id, command, executor, payloads=None, sleep=0, timeout=60):
         super().__init__()
-        self.id = identifier
+        self.id = id
         self.sleep = sleep
         self.command = command
         self.executor = executor

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -104,7 +104,7 @@ class ContactService(ContactServiceInterface, BaseService):
     @staticmethod
     def _convert_link_to_instruction(link):
         link.collect = datetime.now()
-        return Instruction(identifier=link.unique,
+        return Instruction(id=link.unique,
                            sleep=link.jitter,
                            command=link.command,
                            executor=link.ability.executor,

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -29,7 +29,7 @@ def setup_rest_svc_test(loop, data_svc):
         Planner(planner_id='123', name='test', module='test', params=dict())
     ))
     loop.run_until_complete(data_svc.store(
-        Source(identifier='123', name='test', facts=[])
+        Source(id='123', name='test', facts=[])
     ))
 
 


### PR DESCRIPTION
Most objects with an `id` attribute also use `id` as the name for the parameter in their constructor, but `Instruction` and `Source` used `identifier`. This PR fixes this inconsistency. I understand this shadows the `id` builtin, but since we already do this on other object types I assume this is okay.

I checked plugins and the only one I found that will need to change if this gets merged in is the response plugin.