### PR TITLE
VIRTS-1150: Remove link references to operation

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -167,7 +167,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
 
     async def task(self, abilities, facts=(), operation='task'):
         bps = BasePlanningService()
-        potential_links = [Link(operation=operation, command=i.test, paw=self.paw, ability=i) for i in await self.capabilities(abilities)]
+        potential_links = [Link(command=i.test, paw=self.paw, ability=i) for i in await self.capabilities(abilities)]
         links = []
         for valid in await bps.remove_links_missing_facts(
                 await bps.add_test_variants(links=potential_links, agent=self, facts=facts)):

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -165,7 +165,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
                 abilities.append(a)
         await self.task(abilities)
 
-    async def task(self, abilities, facts=(), operation='task'):
+    async def task(self, abilities, facts=()):
         bps = BasePlanningService()
         potential_links = [Link(command=i.test, paw=self.paw, ability=i) for i in await self.capabilities(abilities)]
         links = []

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -58,7 +58,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.obfuscator = obfuscator
         self.auto_close = auto_close
         self.visibility = visibility
-        self.chain, self.rules = [], []
+        self.chain, self.potential_links, self.rules = [], [], []
         self.access = access if access else self.Access.APP
         if source:
             self.rules = source.rules

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -77,6 +77,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
     def add_link(self, link):
         self.chain.append(link)
 
+    def has_link(self, link_id):
+        return any(lnk.id == link_id for lnk in self.potential_links + self.chain)
+
     def all_facts(self):
         seeded_facts = [f for f in self.source.facts] if self.source else []
         learned_facts = [f for lnk in self.chain for f in lnk.facts if f.score > 0]

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -14,16 +14,16 @@ class Link(BaseObject):
     @classmethod
     def from_json(cls, json):
         ability = Ability.from_json(json['ability'])
-        return cls(id=json['id'], pin=json['pin'], operation=json['operation'], command=json['command'],
+        return cls(id=json['id'], pin=json['pin'], command=json['command'],
                    paw=json['paw'], host=json['host'], ability=ability)
 
     @property
     def unique(self):
-        return self.hash('%s-%s' % (self.operation, self.id))
+        return self.hash('%s' % self.id)
 
     @property
     def display(self):
-        return self.clean(dict(id=self.id, operation=self.operation, paw=self.paw, command=self.command,
+        return self.clean(dict(id=self.id, paw=self.paw, command=self.command,
                                executor=self.ability.executor, status=self.status, score=self.score,
                                decide=self.decide.strftime('%Y-%m-%d %H:%M:%S'), pin=self.pin, pid=self.pid,
                                facts=[fact.display for fact in self.facts], unique=self.unique,
@@ -47,13 +47,12 @@ class Link(BaseObject):
                     DISCARD=-2,
                     PAUSE=-1)
 
-    def __init__(self, operation, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0,
+    def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0,
                  host=None):
         super().__init__()
         self.id = id
         self.command = command
         self.command_hash = None
-        self.operation = operation
         self.paw = paw
         self.host = host
         self.cleanup = cleanup

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -64,6 +64,10 @@ class AppService(AppServiceInterface, BaseService):
         agents = await self.get_service('data_svc').locate('agents')
         return self._check_links_for_match(unique, [op.chain for op in operations] + [a.links for a in agents])
 
+    async def find_op_with_link(self, link_id):
+        operations = await self.get_service('data_svc').locate('operations', match=dict(state='running'))
+        return next((o for o in operations if o.has_link(link_id)), None)
+
     async def run_scheduler(self):
         while True:
             interval = 60

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -76,8 +76,7 @@ class ContactService(ContactServiceInterface, BaseService):
                 if result.output:
                     link.output = True
                     self.get_service('file_svc').write_result_file(result.id, result.output)
-                    all_operations = await self.get_service('data_svc').locate('operations')
-                    operation = next((o for o in all_operations if any(lnk.id == result.id for lnk in o.chain)), None)
+                    operation = await self.get_service('app_svc').find_op_with_link(result.id)
                     if not operation and not link.ability.parsers:
                         agent = await self.get_service('data_svc').locate('agents', dict(paw=link.paw))
                         loop.create_task(self.get_service('learning_svc').learn(agent[0].all_facts(), link, result.output))

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -76,7 +76,8 @@ class ContactService(ContactServiceInterface, BaseService):
                 if result.output:
                     link.output = True
                     self.get_service('file_svc').write_result_file(result.id, result.output)
-                    operation = await self.get_service('data_svc').locate('operations', dict(id=link.operation))
+                    all_operations = await self.get_service('data_svc').locate('operations')
+                    operation = next((o for o in all_operations if any(lnk.id == result.id for lnk in o.chain)), None)
                     if not operation and not link.ability.parsers:
                         agent = await self.get_service('data_svc').locate('agents', dict(paw=link.paw))
                         loop.create_task(self.get_service('learning_svc').learn(agent[0].all_facts(), link, result.output))

--- a/app/service/interfaces/i_app_svc.py
+++ b/app/service/interfaces/i_app_svc.py
@@ -21,6 +21,14 @@ class AppServiceInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def find_op_with_link(self, link_id):
+        """
+        Locate an operation with the given link ID
+        :param link_id:
+        :return: Operation or None
+        """
+
+    @abc.abstractmethod
     def run_scheduler(self, identifier):
         """
         Kick off all scheduled jobs, as their schedule determines

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -99,7 +99,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
                 await a.HOOKS[a.language](a)
             if a.test:
                 links.append(
-                    Link(operation=operation.id, command=a.test, paw=agent.paw, score=0, ability=a,
+                    Link(command=a.test, paw=agent.paw, score=0, ability=a,
                          status=link_status, jitter=self.jitter(operation.jitter))
                 )
         return links
@@ -112,7 +112,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
             for cleanup in ability.cleanup:
                 decoded_cmd = agent.replace(cleanup, file_svc=self.get_service('file_svc'))
                 variant, _, _ = await self._build_single_test_variant(decoded_cmd, link.used, link.ability.executor)
-                lnk = Link(operation=operation.id, command=self.encode_string(variant), paw=agent.paw, cleanup=1,
+                lnk = Link(command=self.encode_string(variant), paw=agent.paw, cleanup=1,
                            ability=ability, score=0, jitter=2, status=link_status)
                 if lnk.command not in [l.command for l in links]:
                     lnk.apply_id(agent.host)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -101,7 +101,7 @@ class RestService(RestServiceInterface, BaseService):
         return [o.display for o in await self.get_service('data_svc').locate(object_name, match=data)]
 
     async def display_result(self, data):
-        link_id = data.pop('link_id')
+        link_id = str(data.pop('link_id'))
         link = await self.get_service('app_svc').find_link(link_id)
         if link:
             try:

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -168,11 +168,12 @@ class RestService(RestServiceInterface, BaseService):
             return []
         agents = await self.get_service('data_svc').locate('agents', match=dict(paw=paw)) if paw else operation.agents
         potential_abilities = await self._build_potential_abilities(operation)
-        links = await self._build_potential_links(operation, agents, potential_abilities)
-        return dict(links=[l.display for l in links])
+        operation.potential_links = await self._build_potential_links(operation, agents, potential_abilities)
+        return dict(links=[l.display for l in operation.potential_links])
 
     async def apply_potential_link(self, link):
-        operation = (await self.get_service('data_svc').locate('operations', match=dict(id=link.operation)))[0]
+        all_operations = await self.get_service('data_svc').locate('operations')
+        operation = next((o for o in all_operations if any(lnk.id == link.id for lnk in o.potential_links)), None)
         return await operation.apply(link)
 
     async def task_agent_with_ability(self, paw, ability_id, facts=(), operation=None):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -172,8 +172,7 @@ class RestService(RestServiceInterface, BaseService):
         return dict(links=[l.display for l in operation.potential_links])
 
     async def apply_potential_link(self, link):
-        all_operations = await self.get_service('data_svc').locate('operations')
-        operation = next((o for o in all_operations if any(lnk.id == link.id for lnk in o.potential_links)), None)
+        operation = await self.get_service('app_svc').find_op_with_link(link.id)
         return await operation.apply(link)
 
     async def task_agent_with_ability(self, paw, ability_id, facts=(), operation=None):

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -435,7 +435,7 @@
                     template.find('#time-tactic').html('<div style="font-size: 13px;font-weight:100" ' +
                         'ondblclick="rollup('+OPERATION.chain[i].id+')">agent#'+ agentPaw + '... ' +
                         title + '<span id="'+OPERATION.chain[i].id+'-rs" class="tactic-find-result" ' +
-                        'onclick="findResults(this,'+lnk+','+OPERATION.id+')"' +
+                        'onclick="findResults(this,'+lnk+')"' +
                         'data-encoded-cmd="'+OPERATION.chain[i].command+'"'+'>&#9733;</span>' +
                         '<span id="'+OPERATION.chain[i].id+'-rm" style="font-size:11px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+', -2)">&#x274C;</span>' +
                         '<span id="'+OPERATION.chain[i].id+'-add" style="font-size:22px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+',-3)">&#x002B;</span></div>');
@@ -602,7 +602,7 @@
         }
     }
 
-    function findResults(elem, lnk, opId){
+    function findResults(elem, lnk){
         function loadResults(data){
             if (data) {
                 let res = atob(data.output);
@@ -615,8 +615,7 @@
         }
         document.getElementById('more-modal').style.display='block';
         $('#resultCmd').html(atob($(elem).attr('data-encoded-cmd')));
-        let link_id = opId + '-' + lnk;
-        restRequest('POST', {'index':'result','link_id':link_id}, loadResults);
+        restRequest('POST', {'index':'result','link_id':lnk.toString()}, loadResults);
     }
 
     function downloadOperationReport() {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -615,7 +615,7 @@
         }
         document.getElementById('more-modal').style.display='block';
         $('#resultCmd').html(atob($(elem).attr('data-encoded-cmd')));
-        restRequest('POST', {'index':'result','link_id':lnk.toString()}, loadResults);
+        restRequest('POST', {'index':'result','link_id':lnk}, loadResults);
     }
 
     function downloadOperationReport() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,8 +127,8 @@ def agent():
 
 @pytest.fixture
 def link():
-    def _generate_link(operation, command, paw, ability, *args, **kwargs):
-        return Link(operation=operation, ability=ability, command=command, paw=paw, *args, **kwargs)
+    def _generate_link(command, paw, ability, *args, **kwargs):
+        return Link(ability=ability, command=command, paw=paw, *args, **kwargs)
 
     return _generate_link
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,12 @@ def init_base_world():
 
 @pytest.fixture(scope='class')
 def app_svc():
-    return AppService(None)
+    async def _init_app_svc():
+        return AppService(None)
+
+    def _app_svc(loop):
+        return loop.run_until_complete(_init_app_svc())
+    return _app_svc
 
 
 @pytest.fixture(scope='class')

--- a/tests/contacts/test_contact_gist.py
+++ b/tests/contacts/test_contact_gist.py
@@ -4,13 +4,14 @@ from app.utility.base_world import BaseWorld
 
 class TestContactGist:
 
-    def test_retrieve_config(self, loop, services):
+    def test_retrieve_config(self, loop, app_svc):
         BaseWorld.apply_config(name='default', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
                                                        'plugins': ['sandcat', 'stockpile'],
                                                        'crypt_salt': 'BLAH',
                                                        'api_key': 'ADMIN123',
                                                        'encryption_key': 'ADMIN123',
                                                        'exfil_dir': '/tmp'})
-        gist_c2 = Gist(services)
+        internal_app_svc = app_svc(loop)
+        gist_c2 = Gist(internal_app_svc.get_services())
         loop.run_until_complete(gist_c2.start())
         assert gist_c2.retrieve_config() == 'arandomkeythatisusedtoconnecttogithubapi'

--- a/tests/objects/test_agent.py
+++ b/tests/objects/test_agent.py
@@ -1,0 +1,32 @@
+import pytest
+
+from app.objects.c_ability import Ability
+from app.objects.c_agent import Agent
+from app.objects.secondclass.c_fact import Fact
+from app.utility.base_world import BaseWorld
+
+
+class TestAgent:
+
+    def test_task_no_facts(self, loop, init_base_world):
+        ability = Ability(ability_id='123', test=BaseWorld.encode_string('whoami'), variations=[],
+                          executor='psh', platform='windows')
+        agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
+        loop.run_until_complete(agent.task([ability]))
+        assert 1 == len(agent.links)
+
+    def test_task_missing_fact(self, loop, init_base_world):
+        ability = Ability(ability_id='123', test=BaseWorld.encode_string('net user #{domain.user.name} /domain'),
+                          variations=[], executor='psh', platform='windows')
+        agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
+        loop.run_until_complete(agent.task([ability]))
+        assert 0 == len(agent.links)
+
+    def test_task_with_facts(self, loop, init_base_world):
+        ability = Ability(ability_id='123', test=BaseWorld.encode_string('net user #{domain.user.name} /domain'),
+                          variations=[], executor='psh', platform='windows')
+        agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
+        fact = Fact(trait='domain.user.name', value='bob')
+
+        loop.run_until_complete(agent.task([ability], [fact]))
+        assert 1 == len(agent.links)

--- a/tests/objects/test_agent.py
+++ b/tests/objects/test_agent.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.objects.c_ability import Ability
 from app.objects.c_agent import Agent
 from app.objects.secondclass.c_fact import Fact

--- a/tests/services/test_learning_svc.py
+++ b/tests/services/test_learning_svc.py
@@ -12,7 +12,7 @@ def setup_learning_service(loop, data_svc, ability, operation, link):
     loop.run_until_complete(data_svc.store(tability))
     toperation = operation(name='sample', agents=None, adversary=None)
     loop.run_until_complete(data_svc.store(toperation))
-    tlink = link(operation=toperation.id, ability=tability, command=None, paw=None)
+    tlink = link(ability=tability, command=None, paw=None)
     yield (toperation, tlink)
 
 

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -11,7 +11,7 @@ def setup_planning_test(loop, ability, agent, operation, data_svc, init_base_wor
     tability = ability(ability_id='123', executor='sh', platform='darwin', test=BaseWorld.encode_string('mkdir test'),
                        cleanup=BaseWorld.encode_string('rm -rf test'), variations=[])
     tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin')
-    tsource = Source(identifier='123', name='test', facts=[], adjustments=[])
+    tsource = Source(id='123', name='test', facts=[], adjustments=[])
     toperation = operation(name='test1', agents=tagent, adversary='hunter', source=tsource)
 
     loop.run_until_complete(data_svc.store(tability))

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -18,7 +18,7 @@ class TestPlanningService:
 
     def test_get_cleanup_links(self, loop, setup_planning_test, planning_svc):
         ability, agent, operation = setup_planning_test
-        operation.add_link(Link(operation=operation, command='', paw=agent.paw, ability=ability, status=0))
+        operation.add_link(Link(command='', paw=agent.paw, ability=ability, status=0))
         links = loop.run_until_complete(
             planning_svc.get_cleanup_links(operation=operation, agent=agent)
         )

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -1,16 +1,27 @@
 import pytest
 
+from app.objects.c_obfuscator import Obfuscator
+from app.objects.c_source import Source
 from app.objects.secondclass.c_link import Link
 from app.utility.base_world import BaseWorld
 
 
 @pytest.fixture
-def setup_planning_test(loop, ability, agent, operation, data_svc):
-    tability = ability(ability_id='123', executor='sh', test=BaseWorld.encode_string('mkdir test'),
+def setup_planning_test(loop, ability, agent, operation, data_svc, init_base_world):
+    tability = ability(ability_id='123', executor='sh', platform='darwin', test=BaseWorld.encode_string('mkdir test'),
                        cleanup=BaseWorld.encode_string('rm -rf test'), variations=[])
-    tagent = agent(sleep_min=1, sleep_max=2, watchdog=0)
-    toperation = operation(name='test1', agents=tagent, adversary='hunter')
+    tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin')
+    tsource = Source(identifier='123', name='test', facts=[], adjustments=[])
+    toperation = operation(name='test1', agents=tagent, adversary='hunter', source=tsource)
+
     loop.run_until_complete(data_svc.store(tability))
+
+    loop.run_until_complete(data_svc.store(
+        Obfuscator(name='plain-text',
+                   description='Does no obfuscation to any command, instead running it in plain text',
+                   module='plugins.stockpile.app.obfuscators.plain_text')
+    ))
+
     yield (tability, tagent, toperation)
 
 
@@ -25,3 +36,8 @@ class TestPlanningService:
         link_list = list(links)
         assert len(link_list) == 1
         assert link_list[0].command == ability.cleanup[0]
+
+    def test_generate_and_trim_links(self, loop, setup_planning_test, planning_svc):
+        ability, agent, operation = setup_planning_test
+        generated_links = loop.run_until_complete(planning_svc.generate_and_trim_links(agent, operation, [ability]))
+        assert 1 == len(generated_links)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -124,10 +124,11 @@ class TestRestSvc:
         links = loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
         assert 1 == len(links['links'])
 
-    def test_apply_potential_link(self, loop, rest_svc, planning_svc, data_svc):
+    def test_apply_potential_link(self, loop, rest_svc, planning_svc, data_svc, app_svc):
         internal_rest_svc = rest_svc(loop)
         internal_rest_svc.add_service('planning_svc', planning_svc)
         internal_rest_svc.add_service('data_svc', data_svc)
+        internal_rest_svc.add_service('app_svc', app_svc)
         loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
         operation = loop.run_until_complete(data_svc.locate('operations', match=dict(id='123'))).pop()
         link = operation.potential_links[0]

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -3,6 +3,8 @@ import pytest
 from app.objects.c_ability import Ability
 from app.objects.c_agent import Agent
 from app.objects.c_adversary import Adversary
+from app.objects.c_obfuscator import Obfuscator
+from app.objects.c_operation import Operation
 from app.objects.c_planner import Planner
 from app.objects.c_source import Source
 from app.utility.base_world import BaseWorld
@@ -17,19 +19,30 @@ def setup_rest_svc_test(loop, data_svc):
                                                    'encryption_key': 'ADMIN123',
                                                    'exfil_dir': '/tmp'})
     loop.run_until_complete(data_svc.store(
-        Ability(ability_id='123', test=BaseWorld.encode_string('curl #{app.contact.http}'), variations=[]))
+        Ability(ability_id='123', test=BaseWorld.encode_string('curl #{app.contact.http}'), variations=[],
+                executor='psh', platform='windows'))
     )
-    loop.run_until_complete(data_svc.store(
-        Adversary(adversary_id='123', name='test', description='test', atomic_ordering=[]))
-    )
-    loop.run_until_complete(data_svc.store(
-        Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0)
-    ))
+    adversary = Adversary(adversary_id='123', name='test', description='test', atomic_ordering=[])
+    loop.run_until_complete(data_svc.store(adversary))
+
+    agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
+    loop.run_until_complete(data_svc.store(agent))
+
     loop.run_until_complete(data_svc.store(
         Planner(planner_id='123', name='test', module='test', params=dict())
     ))
+
+    source = Source(identifier='123', name='test', facts=[], adjustments=[])
+    loop.run_until_complete(data_svc.store(source))
+
     loop.run_until_complete(data_svc.store(
-        Source(id='123', name='test', facts=[])
+        Operation(name='test', agents=[agent], adversary=adversary, id='123', source=source)
+    ))
+
+    loop.run_until_complete(data_svc.store(
+        Obfuscator(name='plain-text',
+                   description='Does no obfuscation to any command, instead running it in plain text',
+                   module='plugins.stockpile.app.obfuscators.plain_text')
     ))
 
 
@@ -62,9 +75,9 @@ class TestRestSvc:
 
     def test_create_operation(self, loop, rest_svc, data_svc):
         want = {'name': 'Test',
-                'host_group': [{'paw': '123', 'group': 'red', 'architecture': 'unknown', 'platform': 'unknown',
+                'host_group': [{'paw': '123', 'group': 'red', 'architecture': 'unknown', 'platform': 'windows',
                                 'server': '://None:None', 'location': 'unknown', 'pid': 0, 'ppid': 0, 'trusted': True,
-                                'sleep_min': 2, 'sleep_max': 8, 'executors': [], 'privilege': 'User',
+                                'sleep_min': 2, 'sleep_max': 8, 'executors': ['pwsh', 'psh'], 'privilege': 'User',
                                 'display_name': 'unknown$unknown', 'exe_name': 'unknown', 'host': 'unknown',
                                 'watchdog': 0, 'contact': 'unknown', 'links': [], 'username': 'unknown'}],
                 'adversary': {'adversary_id': 0, 'description': 'an empty adversary profile', 'name': 'ad-hoc',
@@ -103,3 +116,20 @@ class TestRestSvc:
         internal_rest_svc = rest_svc(loop)
         response = loop.run_until_complete(internal_rest_svc.delete_agent(data=dict(paw='123')))
         assert 'Delete action completed' == response
+
+    def test_get_potential_links(self, loop, rest_svc, planning_svc, data_svc):
+        internal_rest_svc = rest_svc(loop)
+        internal_rest_svc.add_service('planning_svc', planning_svc)
+        internal_rest_svc.add_service('data_svc', data_svc)
+        links = loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
+        assert 1 == len(links['links'])
+
+    def test_apply_potential_link(self, loop, rest_svc, planning_svc, data_svc):
+        internal_rest_svc = rest_svc(loop)
+        internal_rest_svc.add_service('planning_svc', planning_svc)
+        internal_rest_svc.add_service('data_svc', data_svc)
+        loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
+        operation = loop.run_until_complete(data_svc.locate('operations', match=dict(id='123'))).pop()
+        link = operation.potential_links[0]
+        loop.run_until_complete(internal_rest_svc.apply_potential_link(link))
+        assert 1 == len(operation.chain)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -32,7 +32,7 @@ def setup_rest_svc_test(loop, data_svc):
         Planner(planner_id='123', name='test', module='test', params=dict())
     ))
 
-    source = Source(identifier='123', name='test', facts=[], adjustments=[])
+    source = Source(id='123', name='test', facts=[], adjustments=[])
     loop.run_until_complete(data_svc.store(source))
 
     loop.run_until_complete(data_svc.store(
@@ -128,7 +128,7 @@ class TestRestSvc:
         internal_rest_svc = rest_svc(loop)
         internal_rest_svc.add_service('planning_svc', planning_svc)
         internal_rest_svc.add_service('data_svc', data_svc)
-        internal_rest_svc.add_service('app_svc', app_svc)
+        internal_rest_svc.add_service('app_svc', app_svc(loop))
         loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
         operation = loop.run_until_complete(data_svc.locate('operations', match=dict(id='123'))).pop()
         link = operation.potential_links[0]


### PR DESCRIPTION
- Removed link references to operation and stored potential links in operation instead
- Removed default 'task' operation from agent tasking
- Fixed js to display link results without operation id
- Fixed and added some tests