### PR TITLE
Improve error handling for websockets/events

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -13,7 +13,10 @@ class WebSocket(BaseWorld):
 
     async def start(self):
         web_socket = self.get_config('app.contact.websocket')
-        await websockets.serve(self.handler.handle, *web_socket.split(':'))
+        try:
+            await websockets.serve(self.handler.handle, *web_socket.split(':'))
+        except OSError as e:
+            self.log.error("WebSocket error: {}".format(e))
 
 
 class Handler:

--- a/app/service/event_svc.py
+++ b/app/service/event_svc.py
@@ -18,11 +18,19 @@ class EventService(EventServiceInterface, BaseService):
         handle = _Handle(event, callback)
         ws_contact.handler.handles.append(handle)
 
+    async def handle_exceptions(self, awaitable, event):
+        try:
+            return await awaitable
+        except websockets.exceptions.ConnectionClosedOK:
+            self.log.debug("No event handler registered for '{}'".format(event))
+        except Exception as e:
+            self.log.error("WebSocket error: {}".format(e), exc_info=True)
+
     async def fire_event(self, event, **callback_kwargs):
         uri = '{}/{}'.format(self.ws_uri, event)
         msg = json.dumps(callback_kwargs)
         async with websockets.connect(uri) as websocket:
-            asyncio.get_event_loop().create_task(websocket.send(msg))
+            asyncio.get_event_loop().create_task(self.handle_exceptions(websocket.send(msg), event))
 
 
 class _Handle:


### PR DESCRIPTION
Handles `Task exception was never retrieved ... exception=ConnectionClosedOK('code = 1000 (OK), no reason')` errors, as well as `cannot assign requested address` errors.

Reference: https://docs.python.org/3.6/library/asyncio-dev.html#detect-exceptions-never-consumed