### PR TITLE
Fix for 'no version' error in UI when on a labeled version

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,5 @@ omit =
     *tests*
     *.tox*
     *venv*
+[html]
+directory = _htmlcov

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -147,7 +147,7 @@ class BaseWorld:
 
     @staticmethod
     def get_version(path='.'):
-        ignore = ['/plugins/', '/.tox/']
+        ignore = ['/plugins/', '/.tox/', '_*/']
         included_extensions = ['*.py', '*.html', '*.js', '*.go']
         version_file = os.path.join(path, 'VERSION.txt')
         if os.path.exists(version_file):

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -147,7 +147,7 @@ class BaseWorld:
 
     @staticmethod
     def get_version(path='.'):
-        ignore = ['/plugins/', '/.tox/', '_*/']
+        ignore = ['/plugins/', '.*/', '_*/']
         included_extensions = ['*.py', '*.html', '*.js', '*.go']
         version_file = os.path.join(path, 'VERSION.txt')
         if os.path.exists(version_file):


### PR DESCRIPTION
ignoring a few folders with generated objects and changing the code coverage folder name `htmlcov` to match an ignore pattern for generated files `_htmlcov`

this fix will take effect on the next release, it will not be able to fix prior releases obviously.