### PR TITLE
Reflect save ability without refresh

### DIFF
--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -331,11 +331,8 @@
             }
         });
         if ($to_replace != -1) {
-            $.each(data[0], function(key, value) {
-                exploits[$to_replace][key] = value;
-            });
-<!--            exploits[$to_replace] = data[0];-->
-<!--            options.find(":selected").data('ability', exploits[$to_replace]);-->
+            exploits[$to_replace] = data[0];
+            loadAdversary();
         }
     }
 
@@ -478,7 +475,7 @@
             let abList = pModal.find('#ability-ability-filter');
             tacList.val(ability['tactic']).change();
             techList.val(ability['technique_id']).change();
-            abList.val(ability['name']).data(ability).change();
+            abList.val(ability['name']).change();
             showPhaseModal(1);
         });
 

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -323,6 +323,20 @@
             appendAbilityToList('phase-modal', a[0]);
             options.val(a[0].name);
         }
+        var $to_replace = -1;
+        $.each(exploits, function(i, ab) {
+            if (ab.ability_id === data[0].ability_id) {
+                $to_replace = i;
+                return false;
+            }
+        });
+        if ($to_replace != -1) {
+            $.each(data[0], function(key, value) {
+                exploits[$to_replace][key] = value;
+            });
+<!--            exploits[$to_replace] = data[0];-->
+<!--            options.find(":selected").data('ability', exploits[$to_replace]);-->
+        }
     }
 
     function removeBlock(element){
@@ -464,7 +478,7 @@
             let abList = pModal.find('#ability-ability-filter');
             tacList.val(ability['tactic']).change();
             techList.val(ability['technique_id']).change();
-            abList.val(ability['name']).change();
+            abList.val(ability['name']).data(ability).change();
             showPhaseModal(1);
         });
 


### PR DESCRIPTION
When an ability is modified in the GUI, the change isn't reflected in the GUI until the modal is refreshed. This PR makes the required changes to the page without needing a manual refresh.