### PR TITLE
strip off \r at the end of lines for window style linebreaks

### DIFF
--- a/app/utility/base_parser.py
+++ b/app/utility/base_parser.py
@@ -50,7 +50,7 @@ class BaseParser:
         :param blob:
         :return:
         """
-        return [x for x in blob.split('\n') if x]
+        return [x.rstrip('\r') for x in blob.split('\n') if x]
 
     @staticmethod
     def ip(blob):


### PR DESCRIPTION
Since windows style linebreaks can have the CRLF `\r\n` sequence, simply splitting blobs on `\n` can cause facts to be generated with trailing carriage return `\r` characters. Having the base parser also remove these trailing `\r` characters will make for cleaner facts