### PR TITLE
Fix width of potential links modal

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -161,6 +161,7 @@ pre {
     flex: 50%;
     color: var(--font-color);
     margin: 30px;
+    max-width: 100%;
 }
 .button-row {
     color: white;


### PR DESCRIPTION
Previously, the modal would annoyingly stretch horizontally when the agent was selected.