### PR TITLE
add operation schema

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -12,6 +12,7 @@ import marshmallow as ma
 
 from app.objects.c_adversary import AdversarySchema
 from app.objects.c_agent import AgentSchema
+from app.objects.c_planner import PlannerSchema
 from app.objects.interfaces.i_object import FirstClassObjectInterface
 from app.utility.base_object import BaseObject
 
@@ -23,7 +24,7 @@ class OperationSchema(ma.Schema):
     adversary = ma.fields.Nested(AdversarySchema())
     jitter = ma.fields.String()
     atomic = ma.fields.Boolean()
-    planner = ma.fields.Function(lambda obj: obj.planner.name)
+    planner = ma.fields.Nested(PlannerSchema())
     start = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
     state = ma.fields.String()
     obfuscator = ma.fields.String()
@@ -31,6 +32,10 @@ class OperationSchema(ma.Schema):
     chain = ma.fields.Function(lambda obj: [lnk.display for lnk in obj.chain])
     auto_close = ma.fields.Boolean()
     visibility = ma.fields.Integer()
+
+    @ma.post_load
+    def build_planner(self, data, **_):
+        return Operation(**data)
 
 
 class Operation(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -8,27 +8,38 @@ from enum import Enum
 from importlib import import_module
 from random import randint
 
+import marshmallow as ma
+
+from app.objects.c_adversary import AdversarySchema
+from app.objects.c_agent import AgentSchema
 from app.objects.interfaces.i_object import FirstClassObjectInterface
 from app.utility.base_object import BaseObject
 
 
+class OperationSchema(ma.Schema):
+    id = ma.fields.Integer()
+    name = ma.fields.String()
+    host_group = ma.fields.List(ma.fields.Nested(AgentSchema()), attribute='agents')
+    adversary = ma.fields.Nested(AdversarySchema())
+    jitter = ma.fields.String()
+    atomic = ma.fields.Boolean()
+    planner = ma.fields.Function(lambda obj: obj.planner.name)
+    start = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
+    state = ma.fields.String()
+    obfuscator = ma.fields.String()
+    autonomous = ma.fields.Integer()
+    chain = ma.fields.Function(lambda obj: [lnk.display for lnk in obj.chain])
+    auto_close = ma.fields.Boolean()
+    visibility = ma.fields.Integer()
+
+
 class Operation(FirstClassObjectInterface, BaseObject):
+
+    schema = OperationSchema()
 
     @property
     def unique(self):
         return self.hash('%s' % self.id)
-
-    @property
-    def display(self):
-        return self.clean(dict(id=self.id, name=self.name, host_group=[a.display for a in self.agents],
-                               adversary=self.adversary.display if self.adversary else '', jitter=self.jitter,
-                               source=self.source.display if self.source else '',
-                               atomic=self.atomic,
-                               planner=self.planner.name if self.planner else '',
-                               start=self.start.strftime('%Y-%m-%d %H:%M:%S') if self.start else '',
-                               state=self.state, obfuscator=self.obfuscator,
-                               autonomous=self.autonomous, finish=self.finish,
-                               chain=[lnk.display for lnk in self.chain]))
 
     @property
     def states(self):

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -75,15 +75,18 @@ class TestRestSvc:
 
     def test_create_operation(self, loop, rest_svc, data_svc):
         want = {'name': 'Test',
-                'host_group': [{'paw': '123', 'group': 'red', 'architecture': 'unknown', 'platform': 'windows',
-                                'server': '://None:None', 'location': 'unknown', 'pid': 0, 'ppid': 0, 'trusted': True,
-                                'sleep_min': 2, 'sleep_max': 8, 'executors': ['pwsh', 'psh'], 'privilege': 'User',
-                                'display_name': 'unknown$unknown', 'exe_name': 'unknown', 'host': 'unknown',
-                                'watchdog': 0, 'contact': 'unknown', 'links': [], 'username': 'unknown'}],
-                'adversary': {'adversary_id': 'ad-hoc', 'description': 'an empty adversary profile', 'name': 'ad-hoc',
-                              'atomic_ordering': []},
-                'jitter': '2/8', 'source': '', 'planner': 'test', 'state': 'finished',
-                'obfuscator': 'plain-text', 'autonomous': 1, 'finish': '', 'chain': [], 'atomic': False}
+                'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc', 'adversary_id': 'ad-hoc',
+                              'atomic_ordering': []}, 'state': 'finished', 'atomic': False,
+                'planner': {'name': 'test', 'description': None, 'module': 'test', 'stopping_conditions': [],
+                            'params': {},
+                            'ignore_enforcement_modules': [], 'id': '123'},
+                'jitter': '2/8',
+                'host_group': [
+                    {'trusted': True, 'architecture': 'unknown', 'watchdog': 0, 'contact': 'unknown', 'username': 'unknown',
+                     'links': [], 'sleep_max': 8, 'exe_name': 'unknown', 'executors': ['pwsh', 'psh'], 'ppid': 0,
+                     'sleep_min': 2, 'server': '://None:None', 'platform': 'windows', 'host': 'unknown', 'paw': '123',
+                     'pid': 0, 'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User'}],
+                'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),


### PR DESCRIPTION
Changes:

* add operation marshmallow schema
* empty string fields are no longer included in API output of operation fields -- this is due to calling the 'clean' method on all display object -- I'd be worried about 'undefined' front-end errors, but didn't see any. 
* operation.planner is no longer just the planner name, but the full serialized planner object.  This is 1) easier to implement than keeping it just the name 2) might be useful data to have and avoid future client-side dereferencing and 3) surprisingly doesn't seem to require any front-end change right now. 

This is just the schema and for serialization.  Deserialization from the API is actually a bit more complicated and has a lot of logic that takes place on this function https://github.com/mitre/caldera/blob/1c2b34f961a6d0dbc9a6df4fdb81b37853326817/app/service/rest_svc.py#L233 .  The request schema for creating operations looks slightly different from the response schema right now too.  It might be best to tackle the deserialization later on (along with some potential API changes). 