### PR TITLE
fixing consistency issues with facts in relationships

### DIFF
--- a/app/objects/secondclass/c_fact.py
+++ b/app/objects/secondclass/c_fact.py
@@ -51,7 +51,7 @@ class Fact(BaseObject):
             escaped_value = escaped_value.replace(char, (escape_ref[executor]['escape_prefix'] + char))
         return escaped_value
 
-    def __init__(self, trait, value, score=1, collected_by=None, technique_id=None):
+    def __init__(self, trait, value=None, score=1, collected_by=None, technique_id=None):
         super().__init__()
         self.trait = trait
         self.value = value

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -112,21 +112,21 @@ class Link(BaseObject):
             await self._save_fact(operation, relationship.target, relationship.score)
             self.relationships.append(relationship)
 
-    async def _save_fact(self, operation, trait, score):
+    async def _save_fact(self, operation, fact, score):
         all_facts = operation.all_facts() if operation else self.facts
-        if all(trait) and await self._is_new_trait(trait, all_facts):
-            self.facts.append(Fact(trait=trait[0], value=trait[1], score=score, collected_by=self.paw,
+        if all([fact.trait, fact.value]) and await self._is_new_fact(fact, all_facts):
+            self.facts.append(Fact(trait=fact.trait, value=fact.value, score=score, collected_by=self.paw,
                                    technique_id=self.ability.technique_id))
 
-    async def _is_new_trait(self, trait, facts):
-        return all(not self._trait_exists(trait, f) or self._is_new_host_trait(trait, f) for f in facts)
+    async def _is_new_fact(self, fact, facts):
+        return all(not self._fact_exists(fact, f) or self._is_new_host_fact(fact, f) for f in facts)
 
     @staticmethod
-    def _trait_exists(trait, fact):
-        return trait[0] == fact.trait and trait[1] == fact.value
+    def _fact_exists(new_fact, fact):
+        return new_fact.trait == fact.trait and new_fact.value == fact.value
 
-    def _is_new_host_trait(self, trait, fact):
-        return trait[0][:5] == 'host.' and self.paw != fact.collected_by
+    def _is_new_host_fact(self, new_fact, fact):
+        return new_fact.trait[:5] == 'host.' and self.paw != fact.collected_by
 
     async def _update_scores(self, operation, increment):
         for uf in self.used:

--- a/app/objects/secondclass/c_relationship.py
+++ b/app/objects/secondclass/c_relationship.py
@@ -12,8 +12,8 @@ class RelationshipSchema(ma.Schema):
     target = ma.fields.Nested(FactSchema())
     score = ma.fields.Integer()
 
-    @ma.post_load()
-    def build_fact(self, data, **_):
+    @ma.post_load
+    def build_relationship(self, data, **_):
         return Relationship(**data)
 
 


### PR DESCRIPTION
With the new schema changes all relationships should make sure they are using Facts as the source and target, not tuples, string, or other objects

other PRs in submodules that need to go with this change as well:
https://github.com/mitre/stockpile/pull/446
https://github.com/mitre/response/pull/24
https://github.com/mitre/gameboard/pull/7