### PR TITLE
Updates to Requirement for schema and relationships

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -28,7 +28,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
     @classmethod
     def from_json(cls, json):
         parsers = [Parser.load(p) for p in json['parsers']]
-        requirements = [Requirement.from_json(r) for r in json['requirements']]
+        requirements = [Requirement.load(r) for r in json['requirements']]
         return cls(ability_id=json['ability_id'], tactic=json['tactic'], technique_id=json['technique_id'],
                    technique=json['technique_name'], name=json['name'], test=json['test'], variations=[],
                    description=json['description'], cleanup=json['cleanup'], executor=json['executor'],

--- a/app/objects/secondclass/c_requirement.py
+++ b/app/objects/secondclass/c_requirement.py
@@ -1,16 +1,15 @@
 import marshmallow as ma
 
-from app.objects.secondclass.c_relationship import Relationship
 from app.utility.base_object import BaseObject
 
 
 class RequirementSchema(ma.Schema):
 
     module = ma.fields.String()
-    relationships = ma.fields.Function(lambda obj: [r.display for r in obj.relationships]) # temp - replace with Nested(RelationshipSchema)
+    relationship_match = ma.fields.List(ma.fields.Dict())
 
     @ma.post_load()
-    def build_source(self, data, **_):
+    def build_requirement(self, data, **_):
         return Requirement(**data)
 
 
@@ -22,12 +21,7 @@ class Requirement(BaseObject):
     def unique(self):
         return self.module
 
-    @classmethod
-    def from_json(cls, json):
-        relationships = [Relationship.from_json(r) for r in json['relationships']]
-        return cls(module=json['module'], relationships=relationships)
-
-    def __init__(self, module, relationships):
+    def __init__(self, module, relationship_match):
         super().__init__()
         self.module = module
-        self.relationships = relationships
+        self.relationship_match = relationship_match

--- a/app/objects/secondclass/c_requirement.py
+++ b/app/objects/secondclass/c_requirement.py
@@ -1,8 +1,22 @@
+import marshmallow as ma
+
 from app.objects.secondclass.c_relationship import Relationship
 from app.utility.base_object import BaseObject
 
 
+class RequirementSchema(ma.Schema):
+
+    module = ma.fields.String()
+    relationships = ma.fields.Function(lambda obj: [r.display for r in obj.relationships]) # temp - replace with Nested(RelationshipSchema)
+
+    @ma.post_load()
+    def build_source(self, data, **_):
+        return Requirement(**data)
+
+
 class Requirement(BaseObject):
+
+    schema = RequirementSchema()
 
     @property
     def unique(self):
@@ -12,10 +26,6 @@ class Requirement(BaseObject):
     def from_json(cls, json):
         relationships = [Relationship.from_json(r) for r in json['relationships']]
         return cls(module=json['module'], relationships=relationships)
-
-    @property
-    def display(self):
-        return dict(module=self.module, relationships=[r.display for r in self.relationships])
 
     def __init__(self, module, relationships):
         super().__init__()

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -12,7 +12,6 @@ from app.objects.c_planner import Planner
 from app.objects.c_plugin import Plugin
 from app.objects.c_source import Source
 from app.objects.secondclass.c_parser import Parser
-from app.objects.secondclass.c_relationship import Relationship
 from app.objects.secondclass.c_requirement import Requirement
 from app.service.interfaces.i_data_svc import DataServiceInterface
 from app.utility.base_service import BaseService

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -212,9 +212,7 @@ class DataService(DataServiceInterface, BaseService):
         rs = []
         for requirement in requirements:
             for module in requirement:
-                relation = [Relationship(source=r['source'], edge=r.get('edge'), target=r.get('target')) for r in
-                            requirement[module]]
-                rs.append(Requirement(module=module, relationships=relation))
+                rs.append(Requirement.load(dict(module=module, relationship_match=requirement[module])))
         ability = Ability(ability_id=ability_id, name=name, test=test, tactic=tactic,
                           technique_id=technique_id, technique=technique_name, code=code, language=language,
                           executor=executor, platform=platform, description=description, build_target=build_target,

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -149,7 +149,7 @@ class BasePlanningService(BaseService):
         """
         for req_inst in link.ability.requirements:
             if req_inst.module not in operation.planner.ignore_enforcement_modules:
-                requirements_info = dict(module=req_inst.module, enforcements=req_inst.relationships[0])
+                requirements_info = dict(module=req_inst.module, enforcements=req_inst.relationship_match[0])
                 requirement = await self.load_module('Requirement', requirements_info)
                 if not await requirement.enforce(link, operation):
                     return False


### PR DESCRIPTION
Added marshmallow schema to Requirement object and removed Relationships from Requirement and replaced with a dictionary to match against with mappings from source/edge/target to the expected traits. 
Requirement was previously using Relationship objects as a pattern to match against where a Relationship's source and target were strings. With Relationships now using Facts for source and target, Requirements would then need Relationship objects that have Facts with traits but no values. This has been replaced with a dictionary for pattern matching instead.

Related submodule PRs for this change:
mitre/stockpile#447
mitre/response#25