### PR TITLE
Parser response filtering

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -138,7 +138,8 @@ class Link(BaseObject):
         for relationship in relationships:
             await self._save_fact(operation, relationship.source, relationship.score)
             await self._save_fact(operation, relationship.target, relationship.score)
-            self.relationships.append(relationship)
+            if all((relationship.source.trait, relationship.edge, relationship.target.trait)):
+                self.relationships.append(relationship)
 
     async def _save_fact(self, operation, fact, score):
         all_facts = operation.all_facts() if operation else self.facts

--- a/app/service/learning_svc.py
+++ b/app/service/learning_svc.py
@@ -66,9 +66,10 @@ class LearningService(LearningServiceInterface, BaseService):
             link.facts.append(fact)
 
     async def _build_relationships(self, link, facts):
+        sorted_facts = [f for f in facts if all((f.source.trait, f.target.trait, f.edge))]
         for relationship in self.model:
             matches = []
-            for fact in facts:
+            for fact in sorted_facts:
                 if fact.trait in relationship:
                     matches.append(fact)
             for pair in itertools.combinations(matches, r=2):

--- a/app/service/learning_svc.py
+++ b/app/service/learning_svc.py
@@ -66,10 +66,9 @@ class LearningService(LearningServiceInterface, BaseService):
             link.facts.append(fact)
 
     async def _build_relationships(self, link, facts):
-        sorted_facts = [f for f in facts if all((f.source.trait, f.target.trait, f.edge))]
         for relationship in self.model:
             matches = []
-            for fact in sorted_facts:
+            for fact in facts:
                 if fact.trait in relationship:
                     matches.append(fact)
             for pair in itertools.combinations(matches, r=2):


### PR DESCRIPTION
quick proposal of filtering parser created junk relationships just to pass facts back

background:
the legacy parsers that can be added on abilities return a list of relationships.  But sometimes just facts are specified to be parsed (just a source, no edge or target in the yaml configuration), so relationships are created that are not valid relationships.  The facts are pulled out of them and added to the link after filtering on whether they have traits and values.  Then all the relationships are added to the relationships on the link.  The relationships should be filtered to make sure they are valid as well..