### PR TITLE
Changing agent proxy receiver storage to dict

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -34,7 +34,7 @@ class AgentFieldsSchema(ma.Schema):
     watchdog = ma.fields.Integer()
     contact = ma.fields.String()
     links = ma.fields.List(ma.fields.Nested(LinkSchema()))
-    proxy_receivers = ma.fields.List(ma.fields.List(ma.fields.String()))
+    proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()))
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
@@ -93,7 +93,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.contact = contact
         self.links = []
         self.access = self.Access.BLUE if group == 'blue' else self.Access.RED
-        self.proxy_receivers = proxy_receivers if proxy_receivers else []
+        self.proxy_receivers = proxy_receivers if proxy_receivers else dict()
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -85,7 +85,7 @@ class TestRestSvc:
                     {'trusted': True, 'architecture': 'unknown', 'watchdog': 0, 'contact': 'unknown', 'username': 'unknown',
                      'links': [], 'sleep_max': 8, 'exe_name': 'unknown', 'executors': ['pwsh', 'psh'], 'ppid': 0,
                      'sleep_min': 2, 'server': '://None:None', 'platform': 'windows', 'host': 'unknown', 'paw': '123',
-                     'pid': 0, 'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User', 'proxy_receivers': []}],
+                     'pid': 0, 'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User', 'proxy_receivers': {}}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(


### PR DESCRIPTION
Instead of having the agent's proxy receiver addresses stored in a list of lists, store it in a dict with keys being the proxy protocol (e.g. HTTP, SmbPipe), and the value being the list of receiver addresses for each protocol.