### PR TITLE
Set operation progress to 0 instead of NaN

### DIFF
--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -548,12 +548,12 @@ table.dataTable input[type=text] {
 .legend .queued {
     background-color: grey;
 }
-#myProgress {
+#operationProgress {
   width: 75%;
   border-radius: 25px;
   background-color: grey;
 }
-#myBar {
+#operationProgressBar {
   width: 10%;
   height: 30px;
   border-radius: 25px;

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -133,8 +133,8 @@
             <br>
             <span title="Current Operation Status" class="op-control-text" id="op-control-state"></span>
             <br><br>
-            <div id="myProgress" style="text-align: left">
-              <div id="myBar">0%</div>
+            <div id="operationProgress" style="text-align: left">
+              <div id="operationProgressBar">0%</div>
             </div>
             <br>
             <table class="legend">
@@ -635,17 +635,22 @@
     }
 
     function changeProgress(finish, percent) {
-        if(percent >= 100) {
-            percent = 100;
-            if(!finish) {
-                percent = 99;
+        // Calculate percentage
+        if (percent >= 100) {
+            if (finish) {
+                percent = 100;
+            } else {
+                    percent = 99;
             }
+        } else if (isNaN(percent)) {
+            percent = 0;
         }
-        let elem = document.getElementById("myBar");
-        elem.style.width = percent + "%";
-        elem.innerHTML = percent + "%";
-    }
 
+        // Set progress bar
+        $('.operationProgressBar').width(percent + '%');
+        $('.operationProgressBar').html(percent + '%');
+    }
+    
     function resetMoreModal() {
         let modal = $('#more-modal');
         modal.hide();


### PR DESCRIPTION
Currently, operation progress is displayed as 'NaN' if no abilities are in the list. Check for NaN and change the percentage to 0. Also renamed classes.