### PR TITLE
Add delay to navbar disappearing

### DIFF
--- a/static/css/navbar.css
+++ b/static/css/navbar.css
@@ -62,11 +62,6 @@
   background-color: black;
   color: white;
 }
-
-.subnav:hover .subnav-content {
-  display: block;
-}
-
 .subnav-right {
   float: right;
   overflow: hidden;
@@ -75,9 +70,6 @@
   float: right;
   color: black;
   text-decoration: none;
-}
-.subnav-right:hover .subnav-content {
-  display: block;
 }
 .footer {
    position: fixed;

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -165,3 +165,51 @@ function display_errors(errors){
         add_element("no errors to view", 0);
     }
 }
+
+/* Nav bar */
+
+$('.subnav').hover(
+    function() {
+        // Open subnav on hover
+        // Check status using the nav-hovering class, z-index for priority
+        $(this).addClass('nav-hovering');
+        var subnav = $(this).find('.subnav-content');
+        $(subnav).css('zIndex', parseInt($(subnav).css('zIndex')) + 1);
+
+        $(subnav).css('display', 'block');
+    }, function() {
+        // Close subav after 150 ms if no longer hovering
+        $(this).removeClass('nav-hovering');
+        var subnav = $(this).find('.subnav-content');
+        $(subnav).css('zIndex', parseInt($(subnav).css('zIndex')) - 1);
+        
+        setTimeout(function(nav) {
+            if (!$(nav).hasClass('nav-hovering')) {
+                $(nav).find('.subnav-content').css('display', 'none');
+            }
+        }, 100, this);
+    }
+);
+
+$('.subnav-right').hover(
+    function() {
+        // Open subnav on hover
+        // Check status using the nav-hovering class, z-index for priority
+        $(this).addClass('nav-hovering');
+        var subnav = $(this).find('.subnav-content');
+        $(subnav).css('zIndex', parseInt($(subnav).css('zIndex')) + 1);
+
+        $(subnav).css('display', 'block');
+    }, function() {
+        // Close subav after 150 ms if no longer hovering
+        $(this).removeClass('nav-hovering');
+        var subnav = $(this).find('.subnav-content');
+        $(subnav).css('zIndex', parseInt($(subnav).css('zIndex')) - 1);
+        
+        setTimeout(function(nav) {
+            if (!$(nav).hasClass('nav-hovering')) {
+                $(nav).find('.subnav-content').css('display', 'none');
+            }
+        }, 100, this);
+    }
+);


### PR DESCRIPTION
Add a delay to the navigation bar disappearing, for example, when moving between "Campaign" and "Operations". This will prevent the subnav bar from immediately disappearing, giving the mouse some time to move between the options.