### PR TITLE
Align navigation bar text vertically. Remove navbar blank space.

### DIFF
--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -629,17 +629,6 @@ table.dataTable input[type=text] {
 .ability-order {
     color: var(--secondary-font-color);
 }
-.version {
-    height: 20px;
-    border-radius: 10px;
-    background-color: green;
-    text-align: center;
-    line-height: 20px;
-    color: white;
-    padding-right: 10px;
-    padding-left: 10px;
-    border: 1px solid white;
-}
 
 #info-list {
     min-width: 50%;

--- a/static/css/navbar.css
+++ b/static/css/navbar.css
@@ -3,8 +3,6 @@
   width:100%;
   top:0;
   z-index:1001;
-  right:5px;
-  left:5px;
 }
 .navbar {
   overflow: hidden;
@@ -35,7 +33,7 @@
   overflow: hidden;
 }
 .subnavbtn {
-  font-size: 15px;
+  font-size: 16px;
   border: none;
   outline: none;
   color: white;
@@ -78,6 +76,17 @@
 }
 .subnav-right:hover .subnav-content {
   display: block;
+}
+.version {
+    height: 17px;
+    border-radius: 10px;
+    background-color: green;
+    text-align: center;
+    line-height: 17px;
+    color: white;
+    padding-right: 10px;
+    padding-left: 10px;
+    border: 1px solid white;
 }
 .footer {
    position: fixed;


### PR DESCRIPTION
Align navigation bar text vertically. Remove the blank space to the left of the navbar.

* Move .version CSS from basic.css to navbar.css (for consistency) and reduce its height (the larger height caused the red bar below buttons)
* Remove left and right declarations from .navbar-buffer. This centers the navbar and removes the black space between the left side of the navbar and the side of the screen.
* Set font size for .subnavbtn to 16px to match '.navbar a'. This makes the fonts consistent.