### PR TITLE
Ability buckets need to be lists, not just strings

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -170,7 +170,7 @@ class DataService(DataServiceInterface, BaseService):
 
     @staticmethod
     async def _classify(ability, tactic):
-        return ability.pop('buckets', tactic).lower()
+        return ability.pop('buckets', [tactic])
 
     async def _load_sources(self, plugin):
         for filename in glob.iglob('%s/sources/*.yml' % plugin.data_dir, recursive=False):


### PR DESCRIPTION
Buckets planner wasn't working right, turns out buckets need to be loaded as lists and not just strings