### PR TITLE
Normalize agent's platform attribute to always be lowercase

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -74,7 +74,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.username = username
         self.group = group
         self.architecture = architecture
-        self.platform = platform
+        self.platform = platform.lower()
         url = urlparse(server)
         self.server = '%s://%s:%s' % (url.scheme, url.hostname, url.port)
         self.location = location


### PR DESCRIPTION
All link/operation checks assume that the agent's platform is lowercase but some platforms will report their platform with proper names. Ex: Python's `platform.system()` reports the linux platform as "Linux" and won't match any abilities.

Changes initialization of `agent` to normalize the input platform to lowercase.