### PR TITLE
Fixing operation not found on contact bug

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -96,7 +96,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.chain.append(link)
 
     def has_link(self, link_id):
-        return any(lnk.id == int(link_id) for lnk in self.potential_links + self.chain)
+        return any(str(lnk.id) == str(link_id) for lnk in self.potential_links + self.chain)
 
     def all_facts(self):
         seeded_facts = [f for f in self.source.facts] if self.source else []

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -92,7 +92,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.chain.append(link)
 
     def has_link(self, link_id):
-        return any(str(lnk.id) == link_id for lnk in self.potential_links + self.chain)
+        return any(lnk.id == int(link_id) for lnk in self.potential_links + self.chain)
 
     def all_facts(self):
         seeded_facts = [f for f in self.source.facts] if self.source else []

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -92,7 +92,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.chain.append(link)
 
     def has_link(self, link_id):
-        return any(lnk.id == link_id for lnk in self.potential_links + self.chain)
+        return any(str(lnk.id) == link_id for lnk in self.potential_links + self.chain)
 
     def all_facts(self):
         seeded_facts = [f for f in self.source.facts] if self.source else []

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -83,7 +83,7 @@ class ContactService(ContactServiceInterface, BaseService):
                     elif not operation:
                         loop.create_task(link.parse(None, result.output))
                     elif link.ability.parsers:
-                        loop.create_task(link.parse(operation[0], result.output))
+                        loop.create_task(link.parse(operation, result.output))
                     else:
                         loop.create_task(self.get_service('learning_svc').learn(operation[0].all_facts(), link, result.output))
             else:

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -149,10 +149,11 @@ class BasePlanningService(BaseService):
         """
         for req_inst in link.ability.requirements:
             if req_inst.module not in operation.planner.ignore_enforcement_modules:
-                requirements_info = dict(module=req_inst.module, enforcements=req_inst.relationship_match[0])
-                requirement = await self.load_module('Requirement', requirements_info)
-                if not await requirement.enforce(link, operation):
-                    return False
+                for rel_match in req_inst.relationship_match:
+                    requirements_info = dict(module=req_inst.module, enforcements=rel_match)
+                    requirement = await self.load_module('Requirement', requirements_info)
+                    if not await requirement.enforce(link, operation):
+                        return False
         return True
 
     async def _trim_by_limit(self, decoded_test, facts):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -149,11 +149,10 @@ class BasePlanningService(BaseService):
         """
         for req_inst in link.ability.requirements:
             if req_inst.module not in operation.planner.ignore_enforcement_modules:
-                for rel_match in req_inst.relationship_match:
-                    requirements_info = dict(module=req_inst.module, enforcements=rel_match)
-                    requirement = await self.load_module('Requirement', requirements_info)
-                    if not await requirement.enforce(link, operation):
-                        return False
+                requirements_info = dict(module=req_inst.module, enforcements=req_inst.relationship_match[0])
+                requirement = await self.load_module('Requirement', requirements_info)
+                if not await requirement.enforce(link, operation):
+                    return False
         return True
 
     async def _trim_by_limit(self, decoded_test, facts):


### PR DESCRIPTION
When an agent contacts the server after running a link, the server attempts to find the operation the link was part of by comparing link ids. However, links store ids as integers, while the agent returns a string. As this always fails, this fix ensures the two fields are compared as the same type.

Additionally, the function providing the operation is a generator (I think?) while the function requesting the operation treated the result as a list, causing an indexing error. This fix also addressed that.