### PR TITLE
watch_ability_files bug fix

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -158,7 +158,7 @@ class AppService(AppServiceInterface, BaseService):
         plugins.append(Plugin(data_dir='data'))
         while True:
             for p in plugins:
-                files = (os.path.join(rt, fle) for rt, _, f in os.walk(p.data_dir) for fle in f if
+                files = (os.path.join(rt, fle) for rt, _, f in os.walk(p.data_dir+'/abilities') for fle in f if
                          time.time() - os.stat(os.path.join(rt, fle)).st_mtime < int(self.get_config('ability_refresh')))
                 for f in files:
                     self.log.debug('[%s] Reloading %s' % (p.name, f))


### PR DESCRIPTION
The _watch_ability_files function looked through the entire data directory. This resulted in errors where adversary files were treated as ability files. The bug fix limits the search to the abilities directory