### PR TITLE
Displaying agent proxy chain info in UI

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -35,6 +35,7 @@ class AgentFieldsSchema(ma.Schema):
     contact = ma.fields.String()
     links = ma.fields.List(ma.fields.Nested(LinkSchema()))
     proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()))
+    proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()))
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
@@ -67,7 +68,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
     def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
-                 proxy_receivers=None):
+                 proxy_receivers=None, proxy_chain=None):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
         self.host = host
@@ -94,6 +95,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.links = []
         self.access = self.Access.BLUE if group == 'blue' else self.Access.RED
         self.proxy_receivers = proxy_receivers if proxy_receivers else dict()
+        self.proxy_chain = proxy_chain if proxy_chain else []
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -136,6 +138,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.update('platform', kwargs.get('platform'))
         self.update('executors', kwargs.get('executors'))
         self.update('proxy_receivers', kwargs.get('proxy_receivers'))
+        self.update('proxy_chain', kwargs.get('proxy_chain'))
 
     async def gui_modification(self, **kwargs):
         loaded = AgentFieldsSchema(only=('group', 'trusted', 'sleep_min', 'sleep_max', 'watchdog')).load(kwargs)

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -135,6 +135,10 @@
                         <td>Peer-to-Peer Proxy Receivers</td>
                         <td><p id="modal-peer_receivers"></p></td>
                     </tr>
+                    <tr>
+                        <td>Peer-to-Peer Proxy Chain</td>
+                        <td><p id="modal-peer_chain"></p></td>
+                    </tr>
                 </table>
                 <br>
                 <button type="button" class="button-warn" onclick="killAgent()">Kill Agent</button>
@@ -315,7 +319,8 @@
         function agentInfoCallback(data){
             let parent = $('#agent-modal');
             let agent = data[0];
-            let peer_receivers = "<table>";
+            let peer_receivers = "";
+            let peer_chain = "";
             parent.find('#modal-paw').html(agent['paw']);
             parent.find('#modal-contact').html(agent['contact']);
             parent.find('#modal-host').html(agent['host']);
@@ -332,20 +337,55 @@
             parent.find('#modal-ppid').html(agent['ppid']);
             parent.find('#modal-executors').html(JSON.stringify(agent['executors']));
             parent.find('#modal-watchdog').html(agent['watchdog']);
-            for (var key in agent['proxy_receivers']) {
-                peer_receivers += "<tr>";
-                peer_receivers += "<td><p>" + key + "  </p></td>";
-                peer_receivers += "<td><p></p></td>";
-                peer_receivers += "</tr>";
-                for (i = 0; i < agent['proxy_receivers'][key].length; i++) {
+
+            // Set up peer-to-peer proxy receiver information display.
+            if (Object.keys(agent['proxy_receivers']).length == 0) {
+                peer_receivers = "No local peer-to-peer proxy receivers active.";
+            } else {
+                peer_receivers = "<table>";
+                for (var key in agent['proxy_receivers']) {
                     peer_receivers += "<tr>";
+                    peer_receivers += "<td><i>" + key + "  </i></td>";
                     peer_receivers += "<td><p></p></td>";
-                    peer_receivers += "<td><p>" + agent['proxy_receivers'][key][i] + "</p></td>";
                     peer_receivers += "</tr>";
+                    for (i = 0; i < agent['proxy_receivers'][key].length; i++) {
+                        peer_receivers += "<tr>";
+                        peer_receivers += "<td><p></p></td>";
+                        peer_receivers += "<td><p>" + agent['proxy_receivers'][key][i] + "</p></td>";
+                        peer_receivers += "</tr>";
+                    };
                 };
+                peer_receivers += "</table>";
             };
-            peer_receivers += "</table>";
+
+            // Set up peer-to-peer proxy chain information display.
+            let proxy_chain_length = agent['proxy_chain'].length;
+            if (proxy_chain_length == 0) {
+                peer_chain = "Not using peer agents to reach C2.";
+            } else {
+                // Header row
+                peer_chain = "<table cellspacing=\"15\">";
+                peer_chain += "<tr>";
+                peer_chain += "<th style=\"color:white\"><i>Hop Index</i></th>"
+                peer_chain += "<th style=\"color:white\"><i>Peer Paw</i></th>"
+                peer_chain += "<th style=\"color:white\"><i>Peer Receiver Address</i></th>";
+                peer_chain += "<th style=\"color:white\"><i>Peer Receiver Protocol</i></th>";
+                peer_chain += "</tr>";
+
+                // Proxy chain rows
+                for (i = 0; i < proxy_chain_length; i++) {
+                    peer_chain += "<tr>";
+                    peer_chain += "<td style=\"text-align:center\"><i>" + i + "</i></td>"
+                    for (j = 0; j < agent['proxy_chain'][i].length; j++) {
+                        peer_chain += "<td><p>" + agent['proxy_chain'][i][j] + "</p></td>";
+                    }
+                    peer_chain += "</tr>";
+                };
+                peer_chain += "</table>";
+            };
+
             parent.find('#modal-peer_receivers').html(peer_receivers);
+            parent.find('#modal-peer_chain').html(peer_chain);
             parent.show();
         }
         restRequest('POST', {'index':'agents','paw':paw}, agentInfoCallback)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -93,7 +93,7 @@ class TestRestSvc:
                      'executors': ['pwsh', 'psh'], 'ppid': 0, 'sleep_min': 2, 'server': '://None:None',
                      'platform': 'windows', 'host': 'unknown', 'paw': '123', 'pid': 0,
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
-                     'proxy_receivers': {}}],
+                     'proxy_receivers': {}, 'proxy_chain': []}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)


### PR DESCRIPTION
Add proxy_chain field to agent and include it in the UI. This field will contain the proxy hops that an agent  takes to communicate with the C2 - which peers it uses, which proxy protocols, and which peer receiver addresses