### PR TITLE
VIRTS-1208: Adding hidden to access enum

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -242,13 +242,21 @@ class RestService(RestServiceInterface, BaseService):
         adversary = await self._construct_adversary_for_op(data.pop('adversary_id', ''))
         agents = await self.construct_agents_for_group(group)
         sources = await self.get_service('data_svc').locate('sources', match=dict(name=data.pop('source', 'basic')))
-        allowed = self.Access.BLUE if self.Access.BLUE in access['access'] else self.Access.RED
+        allowed = self._get_allowed_from_access(access)
 
         return Operation(name=name, planner=planner[0], agents=agents, adversary=adversary,
                          group=group, jitter=data.pop('jitter', '2/8'), source=next(iter(sources), None),
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          obfuscator=data.pop('obfuscator', 'plain-text'),
                          auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')))
+
+    def _get_allowed_from_access(self, access):
+        if self.Access.HIDDEN in access['access']:
+            return self.Access.HIDDEN
+        elif self.Access.BLUE in access['access']:
+            return self.Access.BLUE
+        else:
+            return self.Access.RED
 
     @staticmethod
     async def _read_from_yaml(file_path):

--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -163,6 +163,7 @@ class BaseWorld:
         APP = 0
         RED = 1
         BLUE = 2
+        HIDDEN = 3
 
     class Privileges(Enum):
         User = 0


### PR DESCRIPTION
Using the access enum to specify objects that should be hidden from the front end