### PR TITLE
.locate patch

### DIFF
--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -24,7 +24,7 @@ class BaseObject(BaseWorld):
             else:
                 if self.__getattribute__(k) == v:
                     criteria_matches.append(True)
-        if len(criteria_matches) == len(criteria) and all(criteria_matches):
+        if len(criteria_matches) >= len(criteria) and all(criteria_matches):
             return self
 
     def update(self, field, value):


### PR DESCRIPTION
Quick patch to fix scenario where requesting multiple matching objects doesn't return any.

Further example:

Adversary X:
Atomic Ordering:
- A
- B
- C
- A
- D
Old: Planner only sees [BCD]
Patch: Planner sees [ABCD]