### PR TITLE
Explicitly blacklist virtualenv 20.0.22 in testing env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ description = run tests
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     -rrequirements.txt
-    virtualenv!=20.0.2
+    virtualenv!=20.0.22
     pre-commit
     pytest
     pytest-aiohttp
@@ -32,7 +32,7 @@ description = run tests
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     -rrequirements.txt
-    virtualenv!=20.0.2
+    virtualenv!=20.0.22
     pre-commit
     pytest
     pytest-aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ description = run tests
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     -rrequirements.txt
+    virtualenv!=20.0.2
     pre-commit
     pytest
     pytest-aiohttp
@@ -31,6 +32,7 @@ description = run tests
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
     -rrequirements.txt
+    virtualenv!=20.0.2
     pre-commit
     pytest
     pytest-aiohttp


### PR DESCRIPTION
Blacklist virtualenv==20.0.22 due to https://github.com/pypa/virtualenv/issues/1857