### PR TITLE
use String.raw to escape special regex characters in facts

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -630,7 +630,7 @@
             if (data) {
                 let res = atob(data.output);
                 $.each(data.link.facts, function (k, v) {
-                    let regex = new RegExp(v.value, "g");
+                    let regex = new RegExp(String.raw`${v.value}`, "g");
                     res = res.replace(regex, "<span class='highlight'>" + v.value + "</span>");
                 });
                 $('#resultView').html(res);


### PR DESCRIPTION
regex can break if a fact with some special characters in it is learned. 

changes:
- use String.raw to ensure special regex characters are escaped in front-end

REF: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw 