### PR TITLE
Passing access on response event

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -44,7 +44,10 @@ class ContactService(ContactServiceInterface, BaseService):
             self.log.debug('Incoming %s beacon from %s' % (agent.contact, agent.paw))
             for result in results:
                 await self._save(Result(**result))
-                await self.get_service('event_svc').fire_event('link/completed', agent=agent.display, pid=result['pid'])
+                operation = await self.get_service('app_svc').find_op_with_link(result['id'])
+                access = operation.access if operation else self.Access.RED
+                await self.get_service('event_svc').fire_event('link/completed', agent=agent.display, pid=result['pid'],
+                                                               access=access.value)
             return agent, await self._get_instructions(agent)
         agent = await self.get_service('data_svc').store(
             Agent.load(dict(sleep_min=self.get_config(name='agents', prop='sleep_min'),


### PR DESCRIPTION
If the link being processed is hidden, the response link fired as a result of the red link should also be hidden.
This PR is linked with https://github.com/mitre/response/pull/45, but this one needs to come first.

This functionality is to be used by an in-development 'Hunt' plugin