### PR TITLE
virts-1318

### DIFF
--- a/app/contacts/contact_html.py
+++ b/app/contacts/contact_html.py
@@ -14,14 +14,14 @@ class Contact(BaseWorld):
         self.contact_svc = services.get('contact_svc')
 
     async def start(self):
-        self.app_svc.application.router.add_route('GET', self.get_config('app.contact.html'), self._accept_beacon)
+        self.app_svc.application.router.add_route('*', self.get_config('app.contact.html'), self._accept_beacon)
 
     """ PRIVATE """
 
     @template('weather.html')
     async def _accept_beacon(self, request):
         try:
-            profile = json.loads(self.decode_bytes(request.query.get('profile')))
+            profile = json.loads(self.decode_bytes(await request.text()))
             profile['paw'] = profile.get('paw')
             profile['contact'] = 'html'
             agent, instructions = await self.contact_svc.handle_heartbeat(**profile)


### PR DESCRIPTION
Apart of VIRTS-1318 (fixing ragdoll bugs), ignore original branch name (as didnt know would end up fixing bunch of other stuff)
 
Changes to contact_html.py apply to these bugs:

(2)Another bug, the ragdoll agent is sending huge results payloads as GET query args in the URL. I think this is blowing up the server when it tries to handle it. As no beacon response is made after the agent sends a huge URL (10K chars) for the system processes ability.

  --> changed to POST requests
