### PR TITLE
Virts 1218 and virts 1219

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -24,30 +24,39 @@ class RestService(RestServiceInterface, BaseService):
         self.loop = asyncio.get_event_loop()
 
     async def persist_adversary(self, access, data):
-        data['atomic_ordering'] = [list(ab_dict.values())[0] for ab_dict in data['atomic_ordering']]
-        if not data['id']:
-            data['id'] = str(uuid.uuid4())
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % data['id'], location='data')
-        if file_path:
-            # exists
-            current_adversary = (await self.get_service('data_svc').locate('adversaries', dict(adversary_id=data['id'])))[0]
-            allowed = current_adversary.access
-            current_adversary = dict(current_adversary.display)
-            current_adversary['id'] = current_adversary.pop('adversary_id')   # match on-disk yaml format
-            current_adversary.update(data)
-            data = current_adversary
-        else:
-            # new
-            file_path = 'data/adversaries/%s.yml' % data['id']
-            allowed = self._get_allowed_from_access(access)
-            data['objective'] = data.get('objective',
-                                         (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump(data))
-            f.truncate()
-        await self._services.get('data_svc').load_adversary_file(file_path, allowed)
-        return [a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=data["id"]))]
+        """
+        TODO:  Are objectives required? Existing code seems to enforce an objective be set
+        on an adversary before being written to disk. Also they were blindly pulled from
+        loaded adverary, meaning it blows up if objective is missing.
+        """
+        if not isinstance(data, list):
+            data = [data]
+        r = []
+        for adv in data:
+            adv['atomic_ordering'] = [list(ab_dict.values())[0] for ab_dict in adv['atomic_ordering']]
+            if not adv['id']:
+                adv['id'] = str(uuid.uuid4())
+            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % adv['id'], location='data')
+            if file_path:
+                # exists
+                current_adv = dict(self.strip_yml(file_path)[0])
+                allowed = (await self.get_service('data_svc').locate('adversaries', dict(adversary_id=adv['id'])))[0].access
+                current_adv.update(adv)
+                final = current_adv
+            else:
+                # new
+                file_path = 'data/adversaries/%s.yml' % adv['id']
+                allowed = self._get_allowed_from_access(access)
+                adv['objective'] = adv.get('objective',
+                                            (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
+                final = adv
+            with open(file_path, 'w+') as f:
+                f.seek(0)
+                f.write(yaml.dump(final))
+                f.truncate()
+            await self._services.get('data_svc').load_adversary_file(file_path, allowed)
+            r.extend([a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))])
+        return r
 
     async def update_planner(self, data):
         planner = (await self.get_service('data_svc').locate('planners', dict(name=data['name'])))[0]
@@ -61,68 +70,83 @@ class RestService(RestServiceInterface, BaseService):
         await self.get_service('data_svc').store(planner)
 
     async def persist_ability(self, access, data):
-        """[summary]
+        """Persist abilities.
 
-        The model/format of 'data' is most similar to the ability yaml file definition, with a few exceptions:
-            - 'platforms' sub-dict has sub executor keys split out versus a joined csv string; latter is how it is in yaml file
-            - 'platforms' executor sub-dicts dont have a 'parsers' field; currently parsers are not modifiable via UI
-            - 'platforms' executor sub-dicts have a 'timeout' field which is not present in yaml definition of ability
-        
-        'data' format is as it would be of the yaml ability file on disk, except the 'platforms' dict
-        is different, as the sub-keys are not koiend and the 'parsers' field is missing
+        The model/format of the incoming ability (i.e. 'data') is most similar to the ability
+        yaml file definition, with a few exceptions:
+          - 'platforms' sub-dict has sub executor keys split out versus a joined csv string
+          - 'platforms' executor sub-dicts dont have a 'parsers' field
+          - 'platforms' executor sub-dicts have a 'timeout' field
 
-        Since a defined ability (yaml file) is loaded and then split up to create as many ability versions as there are unique
-        (platform, executor) pairings, its easier to just load yaml ability file, update with what is supplied by 'data'.
-        Then reload ability yaml file, where it will be re-split and create multiple ability versions.
+        Update Strategy:
+            'new' ability is the ability dict that is supplied
+            'current' ability is the ability as read in directly from yaml file
+            ------------
+            - on new ability, stash executor timeouts and then drop
+            - on new ability, combine executors that are the same under common platform
+            - on current ability, stash parsers and then drop
+            - update current ability with new ability
+            - save current ability to disk, then re-load ability from file
+            - check/set executor timeouts on loaded abilities
         """
-        self.log.debug(f"\n>>> New is: {data}")
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % data.get('id'), location='data')
-        # remove added fields, i.e .those added once loaded and not in original yaml definition
-        if file_path:
-            # exists
-            # steps:
-            #  - on new, stash timeouts and then drop from new
-            #  - on new, combine executors that are the same under common platform
-            #  - on current, stash parsers and then drop from current
-            #  - update current with new
-            #  - on current, add back in parsers
-            #  - data =current
-            #  - save data to disk, load back in, reset timeouts on loaded abilities to that stored
-            current_ability_on_disk = dict(self.strip_yml(file_path)[0][0])
-            allowed = (await self.get_service('data_svc').locate('abilities',
-                                                                 dict(ability_id=data.get('id'))))[0].access
-            self.log.debug(f"\n >>>Current is: {current_ability_on_disk}")
-            current_ability_on_disk.update(data)
-            data = current_ability_on_disk
-        else:
-            # new
-            d = 'data/abilities/%s' % data.get('tactic')
-            if not os.path.exists(d):
-                os.makedirs(d)
-            file_path = '%s/%s.yml' % (d, data.get('id'))
-            allowed = self._get_allowed_from_access(access)
-        self.log.debug(f"\nfinal is {data}\n")
-        return
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump([data]))
-        await self.get_service('data_svc').remove('abilities', dict(ability_id=data.get('id')))    # Why does it have to be removed first
-        await self.get_service('data_svc').load_ability_file(file_path, allowed)
-        return [a.display for a in
-                await self.get_service('data_svc').locate('abilities', dict(ability_id=data.get('id')))]
+        if not isinstance(data, list):
+            data = [data]
+        r = []
+        for ab in data:
+            self.log.debug(f"\n>>> New is: {ab}")
+            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % ab.get('id'), location='data')
+            if file_path:
+                # exists
+                current_ability = dict(self.strip_yml(file_path)[0][0])
+                self.log.debug(f"\n >>>Current is: {current_ability}")
+                allowed = (await self.get_service('data_svc').locate('abilities',
+                                                                    dict(ability_id=ab.get('id'))))[0].access
+                new_ability, new_ability_exec_timeouts = self._prep_new_ability(ab)
+                current_ability, current_parsers = self._strip_parsers_from_ability(current_ability)
+                current_ability.update(new_ability)
+                final = self._add_parsers_to_ability(current_ability, current_parsers)
+            else:
+                # new
+                d = 'data/abilities/%s' % ab.get('tactic')
+                if not os.path.exists(d):
+                    os.makedirs(d)
+                file_path = '%s/%s.yml' % (d, ab.get('id'))
+                allowed = self._get_allowed_from_access(access)
+                final = ab
+            self.log.debug(f"\nfinal is {ab}\n")
+            with open(file_path, 'w+') as f:
+                f.seek(0)
+                f.write(yaml.dump([final]))
+            await self.get_service('data_svc').remove('abilities', dict(ability_id=final.get('id')))    # Why does it have to be removed first
+            await self.get_service('data_svc').load_ability_file(file_path, allowed)
+            self._restore_exec_timeouts(final.get('id'), new_ability_exec_timeouts)
+            r.extend([a.display for a in
+                    await self.get_service('data_svc').locate('abilities', dict(ability_id=final.get('id')))])
+        return r
 
     async def persist_source(self, access, data):
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % data.get('id'), location='data')
-        if not file_path:
-            file_path = 'data/sources/%s.yml' % data.get('id')
-            allowed = self._get_allowed_from_access(access)
-        else:
-            allowed = (await self.get_service('data_svc').locate('sources', dict(id=data.get('id'))))[0].access
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump(data))
-        await self._services.get('data_svc').load_source_file(file_path, allowed)
-        return [s.display for s in await self._services.get('data_svc').locate('sources', dict(id=data.get('id')))]
+        if not isinstance(data, list):
+            data = [data]
+        r = []
+        for source in data:
+            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % source['id'], location='data')
+            if file_path:
+                # exists
+                current_source = dict(self.strip_yml(file_path)[0])
+                allowed = (await self.get_service('data_svc').locate('sources', dict(id=source['id'])))[0].access
+                current_source.update(source)
+                final = source
+            else:
+                # new
+                file_path = 'data/sources/%s.yml' % source['id']
+                allowed = self._get_allowed_from_access(access)
+                final = source
+            with open(file_path, 'w+') as f:
+                f.seek(0)
+                f.write(yaml.dump(final))
+            await self._services.get('data_svc').load_source_file(file_path, allowed)
+            r.extend([s.display for s in await self._services.get('data_svc').locate('sources', dict(id=final['id']))])
+        return r
 
     async def delete_agent(self, data):
         await self.get_service('data_svc').remove('agents', data)
@@ -365,10 +389,10 @@ class RestService(RestServiceInterface, BaseService):
                 adv['atomic_ordering'] = [ab.display for ab_id in adv['atomic_ordering'] for ab in
                                           await self.get_service('data_svc').locate('abilities',
                                                                                     match=dict(ability_id=ab_id))]
-                adv['objective'] = [ab.display for ab in
-                                    await self.get_service('data_svc').locate('objectives',
-                                                                              match=dict(id=adv['objective']))][0]
-
+                if adv['objective']:
+                    adv['objective'] = [ob.display for ob in
+                                        await self.get_service('data_svc').locate('objectives',
+                                                                                  match=dict(id=adv['objective']))][0]
         return results
 
     async def _delete_data_from_memory_and_disk(self, ram_key, identifier, data):
@@ -380,3 +404,69 @@ class RestService(RestServiceInterface, BaseService):
         if os.path.exists(file_path):
             os.remove(file_path)
         return 'Delete action completed'
+
+    async def _prep_new_ability(self, ability):
+        """Take an ability dict, supplied by frontend, extract executor timeouts,
+        and combine executor sub-dicts that are equivalent under a single CSV
+        formed key under the parent platform.
+
+        Return modified ability dict, and a seperate dict of the executor timeouts.
+        """
+        exec_timeouts = {}
+        for platform, executors in ability["platforms"].items():
+            exec_timeouts[platform] = {}
+            for executor, d in executors.items():
+                exec_timeouts[platform][executor] = d["timeout"]
+                del ability["platforms"][platform][executor]["timeout"]
+
+        platforms = {}
+        for platform, executors in ability["platforms"].items():
+            platforms[platform] = {}
+            for executor, d in executors.items():
+                match = False
+                for executor_1, d_1 in platforms[platform].items():
+                    if d == d_1:
+                        match = executor_1
+                        break
+                if match:
+                    combined_key = ",".join([match, executor])
+                    platforms[platform][combined_key] = d
+                else:
+                    platforms[platform][executor] = d
+        ability["platforms"] = platforms
+        
+        return ability, exec_timeouts
+
+    async def _strip_parsers_from_ability(self, ability):
+        """Remove the parsers sub-dict from an ability (where the
+        ability is not an ability object but just the loaded dict from
+        yaml ability file)
+
+        Return ability (minus parsers) and parsers as seperate dict
+        """
+        parsers = {}
+        for platform, executors in ability["platforms"].items():
+            parsers[platform] = {}
+            for executor, d in executors.items():
+                parsers[platform][executor] = d["parsers"]
+                del ability["platforms"][platform][executor]["parsers"]
+        return ability, parsers
+    
+    async def _add_parsers_to_ability(self, ability, parsers):
+        """Add parsers back into an ability (where the
+        ability is not an ability object but just the loaded dict from
+        yaml ability file)
+        """
+        for platform, executors in ability["platforms"].items():
+            parsers[platform] = {}
+            for executor, d in executors.items():
+                ability[platform][executor]["parsers"] = parsers[platform][executor]
+        return ability
+
+    async def _restore_exec_timeouts(self, ability_id, exec_timeouts):
+        """[summary]
+        """
+        abilities = await self.get_service('data_svc').locate('abilities', dict(ability_id=ability_id))
+        for ab in abilities:
+            ab.timeout = exec_timeouts[ab.platform][ab.executor]
+            self.get_service('data_svc').store(ab)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -28,7 +28,7 @@ class RestService(RestServiceInterface, BaseService):
         For bulk, supply dict of form {"bulk": [{<adversary>}, {<adversary>},...]}.
         """
         if data.get('bulk', False):
-            data = data['bulk'] 
+            data = data['bulk']
         else:
             data = [data]
         r = []
@@ -52,7 +52,7 @@ class RestService(RestServiceInterface, BaseService):
         For bulk, supply dict of form {"bulk": [{<ability>}, {<ability>},...]}.
         """
         if data.get('bulk', False):
-            data = data['bulk'] 
+            data = data['bulk']
         else:
             data = [data]
         r = []
@@ -65,7 +65,7 @@ class RestService(RestServiceInterface, BaseService):
         For bulk, supply dict of form {"bulk": [{<sourc>}, {<source>},...]}.
         """
         if data.get('bulk', False):
-            data = data['bulk'] 
+            data = data['bulk']
         else:
             data = [data]
         r = []
@@ -355,7 +355,7 @@ class RestService(RestServiceInterface, BaseService):
             file_path = 'data/adversaries/%s.yml' % adv['id']
             allowed = self._get_allowed_from_access(access)
             adv['objective'] = adv.get('objective',
-                                        (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
+                                       (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
             final = adv
         # verfiy objective is valid
         if len(await self.get_service('data_svc').locate('objectives', match=dict(id=final['objective']))) == 0:
@@ -369,7 +369,7 @@ class RestService(RestServiceInterface, BaseService):
 
     async def _persist_ability(self, access, ab):
         """Persist ability.
-        
+
         The model/format of the incoming ability (i.e. 'ab') is most similar to the ability
         yaml file definition, with a few exceptions:
           - 'platforms' sub-dict has sub executor keys split out versus a joined csv string
@@ -396,7 +396,7 @@ class RestService(RestServiceInterface, BaseService):
             # exists
             current_ability = dict(self.strip_yml(file_path)[0][0])
             allowed = (await self.get_service('data_svc').locate('abilities',
-                                                                dict(ability_id=ab['id'])))[0].access
+                                                                 dict(ability_id=ab['id'])))[0].access
             current_ability, current_parsers = await self._strip_parsers_from_ability(current_ability)
             current_ability.update(new_ability)
             final = await self._add_parsers_to_ability(current_ability, current_parsers)
@@ -415,7 +415,7 @@ class RestService(RestServiceInterface, BaseService):
         await self.get_service('data_svc').load_ability_file(file_path, allowed)
         await self._restore_exec_timeouts(final['id'], new_ability_exec_timeouts)
         return [a.display for a in
-                    await self.get_service('data_svc').locate('abilities', dict(ability_id=final['id']))]
+                await self.get_service('data_svc').locate('abilities', dict(ability_id=final['id']))]
 
     async def _persist_source(self, access, source):
         if not source.get('id') or not source['id']:
@@ -471,7 +471,6 @@ class RestService(RestServiceInterface, BaseService):
                 else:
                     platforms[platform][executor] = d
         ability['platforms'] = platforms
-        
         return ability, exec_timeouts
 
     async def _strip_parsers_from_ability(self, ability):
@@ -497,7 +496,7 @@ class RestService(RestServiceInterface, BaseService):
         """
         for platform, executors in ability['platforms'].items():
             if parsers.get(platform, False):
-                for executor, d in executors.items():
+                for executor, _ in executors.items():
                     if parsers[platform].get(executor, False):
                         ability['platforms'][platform][executor]['parsers'] = parsers[platform][executor]
         return ability

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -24,38 +24,16 @@ class RestService(RestServiceInterface, BaseService):
         self.loop = asyncio.get_event_loop()
 
     async def persist_adversary(self, access, data):
+        """Persist adversaries. Accepts single adversary or bulk set of adversaries.
+        For bulk, supply dict of form {"bulk": [{<adversary>}, {<adversary>},...]}.
         """
-        TODO:  Are objectives required? Existing code seems to enforce an objective be set
-        on an adversary before being written to disk. Also they were blindly pulled from
-        loaded adverary, meaning it blows up if objective is missing.
-        """
-        if not isinstance(data, list):
+        if data.get('bulk', False):
+            data = data['bulk'] 
+        else:
             data = [data]
         r = []
         for adv in data:
-            adv['atomic_ordering'] = [list(ab_dict.values())[0] for ab_dict in adv['atomic_ordering']]
-            if not adv['id']:
-                adv['id'] = str(uuid.uuid4())
-            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % adv['id'], location='data')
-            if file_path:
-                # exists
-                current_adv = dict(self.strip_yml(file_path)[0])
-                allowed = (await self.get_service('data_svc').locate('adversaries', dict(adversary_id=adv['id'])))[0].access
-                current_adv.update(adv)
-                final = current_adv
-            else:
-                # new
-                file_path = 'data/adversaries/%s.yml' % adv['id']
-                allowed = self._get_allowed_from_access(access)
-                adv['objective'] = adv.get('objective',
-                                            (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
-                final = adv
-            with open(file_path, 'w+') as f:
-                f.seek(0)
-                f.write(yaml.dump(final))
-                f.truncate()
-            await self._services.get('data_svc').load_adversary_file(file_path, allowed)
-            r.extend([a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))])
+            r.extend(await self._persist_adversary(access, adv))
         return r
 
     async def update_planner(self, data):
@@ -70,82 +48,29 @@ class RestService(RestServiceInterface, BaseService):
         await self.get_service('data_svc').store(planner)
 
     async def persist_ability(self, access, data):
-        """Persist abilities.
-
-        The model/format of the incoming ability (i.e. 'data') is most similar to the ability
-        yaml file definition, with a few exceptions:
-          - 'platforms' sub-dict has sub executor keys split out versus a joined csv string
-          - 'platforms' executor sub-dicts dont have a 'parsers' field
-          - 'platforms' executor sub-dicts have a 'timeout' field
-
-        Update Strategy:
-            'new' ability is the ability dict that is supplied
-            'current' ability is the ability as read in directly from yaml file
-            ------------
-            - on new ability, stash executor timeouts and then drop
-            - on new ability, combine executors that are the same under common platform
-            - on current ability, stash parsers and then drop
-            - update current ability with new ability
-            - save current ability to disk, then re-load ability from file
-            - check/set executor timeouts on loaded abilities
+        """Persist abilities. Accepts single ability or bulk set of abilities.
+        For bulk, supply dict of form {"bulk": [{<ability>}, {<ability>},...]}.
         """
-        if not isinstance(data, list):
+        if data.get('bulk', False):
+            data = data['bulk'] 
+        else:
             data = [data]
         r = []
         for ab in data:
-            self.log.debug(f"\n>>> New is: {ab}")
-            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % ab.get('id'), location='data')
-            if file_path:
-                # exists
-                current_ability = dict(self.strip_yml(file_path)[0][0])
-                self.log.debug(f"\n >>>Current is: {current_ability}")
-                allowed = (await self.get_service('data_svc').locate('abilities',
-                                                                    dict(ability_id=ab.get('id'))))[0].access
-                new_ability, new_ability_exec_timeouts = self._prep_new_ability(ab)
-                current_ability, current_parsers = self._strip_parsers_from_ability(current_ability)
-                current_ability.update(new_ability)
-                final = self._add_parsers_to_ability(current_ability, current_parsers)
-            else:
-                # new
-                d = 'data/abilities/%s' % ab.get('tactic')
-                if not os.path.exists(d):
-                    os.makedirs(d)
-                file_path = '%s/%s.yml' % (d, ab.get('id'))
-                allowed = self._get_allowed_from_access(access)
-                final = ab
-            self.log.debug(f"\nfinal is {ab}\n")
-            with open(file_path, 'w+') as f:
-                f.seek(0)
-                f.write(yaml.dump([final]))
-            await self.get_service('data_svc').remove('abilities', dict(ability_id=final.get('id')))    # Why does it have to be removed first
-            await self.get_service('data_svc').load_ability_file(file_path, allowed)
-            self._restore_exec_timeouts(final.get('id'), new_ability_exec_timeouts)
-            r.extend([a.display for a in
-                    await self.get_service('data_svc').locate('abilities', dict(ability_id=final.get('id')))])
+            r.extend(await self._persist_ability(access, ab))
         return r
 
     async def persist_source(self, access, data):
-        if not isinstance(data, list):
+        """Persist sources. Accepts single srouce or bulk set of sources.
+        For bulk, supply dict of form {"bulk": [{<sourc>}, {<source>},...]}.
+        """
+        if data.get('bulk', False):
+            data = data['bulk'] 
+        else:
             data = [data]
         r = []
         for source in data:
-            _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % source['id'], location='data')
-            if file_path:
-                # exists
-                current_source = dict(self.strip_yml(file_path)[0])
-                allowed = (await self.get_service('data_svc').locate('sources', dict(id=source['id'])))[0].access
-                current_source.update(source)
-                final = source
-            else:
-                # new
-                file_path = 'data/sources/%s.yml' % source['id']
-                allowed = self._get_allowed_from_access(access)
-                final = source
-            with open(file_path, 'w+') as f:
-                f.seek(0)
-                f.write(yaml.dump(final))
-            await self._services.get('data_svc').load_source_file(file_path, allowed)
-            r.extend([s.display for s in await self._services.get('data_svc').locate('sources', dict(id=final['id']))])
+            r.extend(await self._persist_source(access, source))
         return r
 
     async def delete_agent(self, data):
@@ -405,6 +330,108 @@ class RestService(RestServiceInterface, BaseService):
             os.remove(file_path)
         return 'Delete action completed'
 
+    async def _persist_adversary(self, access, adv):
+        """
+        Current policy for 'objective' field of adversary: If there isn't an
+        objective when an adversary is loaded from disk, it gets assigned a
+        default one, which will then get written out if the adversary is
+        explicitly saved. Newly created adversaries will also be given default
+        objective if created without one.
+        """
+        obj_default = (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0]
+        adv['atomic_ordering'] = [list(ab_dict.values())[0] for ab_dict in adv['atomic_ordering']]
+        if not adv['id']:
+            adv['id'] = str(uuid.uuid4())
+        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % adv['id'], location='data')
+        if file_path:
+            # exists
+            current_adv = dict(self.strip_yml(file_path)[0])
+            allowed = (await self.get_service('data_svc').locate('adversaries', dict(adversary_id=adv['id'])))[0].access
+            current_adv.update(adv)
+            final = current_adv
+        else:
+            # new
+            file_path = 'data/adversaries/%s.yml' % adv['id']
+            allowed = self._get_allowed_from_access(access)
+            adv['objective'] = adv.get('objective',
+                                        (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
+            final = adv
+        # verfiy objective is valid
+        if len(await self.get_service('data_svc').locate('objectives', match=dict(id=final['objective']))) == 0:
+            final['objective'] = obj_default.id
+        with open(file_path, 'w+') as f:
+            f.seek(0)
+            f.write(yaml.dump(final))
+            f.truncate()
+        await self._services.get('data_svc').load_adversary_file(file_path, allowed)
+        return [a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))]
+
+    async def _persist_ability(self, access, ab):
+        """Persist ability
+        
+        The model/format of the incoming ability (i.e. 'data') is most similar to the ability
+        yaml file definition, with a few exceptions:
+          - 'platforms' sub-dict has sub executor keys split out versus a joined csv string
+          - 'platforms' executor sub-dicts dont have a 'parsers' field
+          - 'platforms' executor sub-dicts have a 'timeout' field
+
+        Update Strategy:
+            'new' ability is the ability dict that is supplied
+            'current' ability is the ability as read in directly from yaml file
+            ------------
+            - on new ability, stash executor timeouts and then drop
+            - on new ability, combine executors that are the same under common platform
+            - on current ability, stash parsers and then drop
+            - update current ability with new ability
+            - save current ability to disk, then re-load ability from file
+            - check/set executor timeouts on loaded abilities
+        """
+        new_ability, new_ability_exec_timeouts = await self._prep_new_ability(ab)
+        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % ab.get('id'), location='data')
+        if file_path:
+            # exists
+            current_ability = dict(self.strip_yml(file_path)[0][0])
+            allowed = (await self.get_service('data_svc').locate('abilities',
+                                                                dict(ability_id=ab.get('id'))))[0].access
+            current_ability, current_parsers = await self._strip_parsers_from_ability(current_ability)
+            current_ability.update(new_ability)
+            final = await self._add_parsers_to_ability(current_ability, current_parsers)
+        else:
+            # new
+            d = 'data/abilities/%s' % new_ability.get('tactic')
+            if not os.path.exists(d):
+                os.makedirs(d)
+            file_path = '%s/%s.yml' % (d, new_ability.get('id'))
+            allowed = self._get_allowed_from_access(access)
+            final = ab
+        with open(file_path, 'w+') as f:
+            f.seek(0)
+            f.write(yaml.dump([final]))
+        await self.get_service('data_svc').remove('abilities', dict(ability_id=final.get('id')))    # Why does it have to be removed first
+        await self.get_service('data_svc').load_ability_file(file_path, allowed)
+        await self._restore_exec_timeouts(final.get('id'), new_ability_exec_timeouts)
+        return [a.display for a in
+                    await self.get_service('data_svc').locate('abilities', dict(ability_id=final.get('id')))]
+
+    async def _persist_source(self, access, source):
+        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % source['id'], location='data')
+        if file_path:
+            # exists
+            current_source = dict(self.strip_yml(file_path)[0])
+            allowed = (await self.get_service('data_svc').locate('sources', dict(id=source['id'])))[0].access
+            current_source.update(source)
+            final = source
+        else:
+            # new
+            file_path = 'data/sources/%s.yml' % source['id']
+            allowed = self._get_allowed_from_access(access)
+            final = source
+        with open(file_path, 'w+') as f:
+            f.seek(0)
+            f.write(yaml.dump(final))
+        await self._services.get('data_svc').load_source_file(file_path, allowed)
+        return [s.display for s in await self._services.get('data_svc').locate('sources', dict(id=final['id']))]
+
     async def _prep_new_ability(self, ability):
         """Take an ability dict, supplied by frontend, extract executor timeouts,
         and combine executor sub-dicts that are equivalent under a single CSV
@@ -431,6 +458,8 @@ class RestService(RestServiceInterface, BaseService):
                 if match:
                     combined_key = ",".join([match, executor])
                     platforms[platform][combined_key] = d
+                    # and remove previous single key in set
+                    del platforms[platform][match]
                 else:
                     platforms[platform][executor] = d
         ability["platforms"] = platforms
@@ -445,11 +474,12 @@ class RestService(RestServiceInterface, BaseService):
         Return ability (minus parsers) and parsers as seperate dict
         """
         parsers = {}
-        for platform, executors in ability["platforms"].items():
+        for platform, executors in ability['platforms'].items():
             parsers[platform] = {}
             for executor, d in executors.items():
-                parsers[platform][executor] = d["parsers"]
-                del ability["platforms"][platform][executor]["parsers"]
+                if d.get('parsers', False):
+                    parsers[platform][executor] = d['parsers']
+                    del ability["platforms"][platform][executor]['parsers']
         return ability, parsers
     
     async def _add_parsers_to_ability(self, ability, parsers):
@@ -457,10 +487,11 @@ class RestService(RestServiceInterface, BaseService):
         ability is not an ability object but just the loaded dict from
         yaml ability file)
         """
-        for platform, executors in ability["platforms"].items():
-            parsers[platform] = {}
-            for executor, d in executors.items():
-                ability[platform][executor]["parsers"] = parsers[platform][executor]
+        for platform, executors in ability['platforms'].items():
+            if parsers.get(platform, False):
+                for executor, d in executors.items():
+                    if parsers[platform].get(executor, False):
+                        ability[platform][executor]['parsers'] = parsers[platform][executor]
         return ability
 
     async def _restore_exec_timeouts(self, ability_id, exec_timeouts):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -488,7 +488,7 @@ class RestService(RestServiceInterface, BaseService):
                     parsers[platform][executor] = d['parsers']
                     del ability["platforms"][platform][executor]['parsers']
         return ability, parsers
-    
+
     async def _add_parsers_to_ability(self, ability, parsers):
         """Add parsers back into an ability (where the ability is
         not an ability object but just the loaded dict from yaml

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -321,7 +321,7 @@
         listing.forEach(function(entry){
             abilities.push({"id": entry._element.id})});
         restRequest('PUT', {"name":name,"description":description,"atomic_ordering":abilities,"index":"adversaries",
-            'i': identifier,"objective":objective}, saveAdversaryCallback);
+            'id': identifier,"objective":objective}, saveAdversaryCallback);
     }
 
     function saveAdversaryCallback(data) {


### PR DESCRIPTION
- persist functions can take partial object updates
- persist functions also handle bulk updates (of same object type). core rest api able to not be affected at all so no problems with breaking changes.