### PR TITLE
VIRTS-1220/Objectives UI and API Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ data/facts/*yml
 !data/facts/.gitkeep
 data/sources/*
 !data/sources/.gitkeep
+data/objectives/*
+!data/objectives/.gitkeep
 .tox/
 
 # coverage reports

--- a/app/api/packs/advanced.py
+++ b/app/api/packs/advanced.py
@@ -15,6 +15,7 @@ class AdvancedPack(BaseWorld):
 
     async def enable(self):
         self.app_svc.application.router.add_route('GET', '/advanced/sources', self._section_sources)
+        self.app_svc.application.router.add_route('GET', '/advanced/objectives', self._section_objectives)
         self.app_svc.application.router.add_route('GET', '/advanced/planners', self._section_planners)
         self.app_svc.application.router.add_route('GET', '/advanced/contacts', self._section_contacts)
         self.app_svc.application.router.add_route('GET', '/advanced/obfuscators', self._section_obfuscators)
@@ -50,3 +51,9 @@ class AdvancedPack(BaseWorld):
     async def _section_sources(self, request):
         access = await self.auth_svc.get_permissions(request)
         return dict(sources=[s.display for s in await self.data_svc.locate('sources', match=dict(access=tuple(access)))])
+
+    @check_authorization
+    @template('objectives.html')
+    async def _section_objectives(self, request):
+        access = await self.auth_svc.get_permissions(request)
+        return dict(objectives=[o.display for o in await self.data_svc.locate('objectives', match=dict(access=tuple(access)))])

--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -82,6 +82,7 @@ class RestApi(BaseWorld):
                     adversaries=lambda d: self.rest_svc.persist_adversary(access, d),
                     abilities=lambda d: self.rest_svc.persist_ability(access, d),
                     sources=lambda d: self.rest_svc.persist_source(access, d),
+                    objectives=lambda d: self.rest_svc.persist_objective(access, d),
                     planners=lambda d: self.rest_svc.update_planner(d),
                     agents=lambda d: self.rest_svc.update_agent_data(d),
                     chain=lambda d: self.rest_svc.update_chain_data(d),

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -75,8 +75,6 @@ class ContactService(ContactServiceInterface, BaseService):
             link = await self.get_service('app_svc').find_link(result.id)
             if link:
                 link.pid = int(result.pid)
-                link.finish = self.get_service('data_svc').get_current_timestamp()
-                link.status = int(result.status)
                 if result.output:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link.ability)
@@ -91,6 +89,8 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(link.parse(operation, result.output))
                     else:
                         loop.create_task(self.get_service('learning_svc').learn(operation.all_facts(), link, result.output))
+                link.finish = self.get_service('data_svc').get_current_timestamp()
+                link.status = int(result.status)
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
         except Exception as e:

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -75,6 +75,8 @@ class ContactService(ContactServiceInterface, BaseService):
             link = await self.get_service('app_svc').find_link(result.id)
             if link:
                 link.pid = int(result.pid)
+                link.finish = self.get_service('data_svc').get_current_timestamp()
+                link.status = int(result.status)
                 if result.output:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link.ability)
@@ -89,8 +91,6 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(link.parse(operation, result.output))
                     else:
                         loop.create_task(self.get_service('learning_svc').learn(operation.all_facts(), link, result.output))
-                link.finish = self.get_service('data_svc').get_current_timestamp()
-                link.status = int(result.status)
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
         except Exception as e:

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -150,6 +150,12 @@ class DataService(DataServiceInterface, BaseService):
             source.access = access
             await self.store(source)
 
+    async def load_objective_file(self, filename, access):
+        for src in self.strip_yml(filename):
+            obj = Objective.load(src)
+            obj.access = access
+            await self.store(obj)
+
     """ PRIVATE """
 
     async def _load(self, plugins=()):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -220,10 +220,7 @@ class DataService(DataServiceInterface, BaseService):
 
     async def _load_planners(self, plugin):
         for filename in glob.iglob('%s/planners/*.yml' % plugin.data_dir, recursive=False):
-            for planner in self.strip_yml(filename):
-                planner = Planner.load(planner)
-                planner.access = plugin.access
-                await self.store(planner)
+            await self.load_yaml_file(Planner, filename, plugin.access)
 
     async def _load_extensions(self):
         for entry in self._app_configuration['payloads']['extensions']:

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -151,9 +151,9 @@ class DataService(DataServiceInterface, BaseService):
         warnings.warn("Function deprecated and will be removed in a future update. Use load_yaml_file", DeprecationWarning)
         await self.load_yaml_file(Objective, filename, access)
 
-    async def load_yaml_file(self, cls, filename, access):
+    async def load_yaml_file(self, object_class, filename, access):
         for src in self.strip_yml(filename):
-            obj = cls.load(src)
+            obj = object_class.load(src)
             obj.access = access
             await self.store(obj)
 

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -4,6 +4,7 @@ import glob
 import os.path
 import pickle
 import shutil
+import warnings
 from base64 import b64encode
 
 from app.objects.c_ability import Ability
@@ -139,20 +140,20 @@ class DataService(DataServiceInterface, BaseService):
                                 await self._update_extensions(a)
 
     async def load_adversary_file(self, filename, access):
-        for adv in self.strip_yml(filename):
-            adversary = Adversary.load(adv)
-            adversary.access = access
-            await self.store(adversary)
+        warnings.warn("Function deprecated and will be removed in a future update. Use load_yaml_file", DeprecationWarning)
+        await self.load_yaml_file(Adversary, filename, access)
 
     async def load_source_file(self, filename, access):
-        for src in self.strip_yml(filename):
-            source = Source.load(src)
-            source.access = access
-            await self.store(source)
+        warnings.warn("Function deprecated and will be removed in a future update. Use load_yaml_file", DeprecationWarning)
+        await self.load_yaml_file(Source, filename, access)
 
     async def load_objective_file(self, filename, access):
+        warnings.warn("Function deprecated and will be removed in a future update. Use load_yaml_file", DeprecationWarning)
+        await self.load_yaml_file(Objective, filename, access)
+
+    async def load_yaml_file(self, cls, filename, access):
         for src in self.strip_yml(filename):
-            obj = Objective.load(src)
+            obj = cls.load(src)
             obj.access = access
             await self.store(obj)
 
@@ -179,7 +180,7 @@ class DataService(DataServiceInterface, BaseService):
 
     async def _load_adversaries(self, plugin):
         for filename in glob.iglob('%s/adversaries/**/*.yml' % plugin.data_dir, recursive=True):
-            await self.load_adversary_file(filename, plugin.access)
+            await self.load_yaml_file(Adversary, filename, plugin.access)
 
     async def _load_abilities(self, plugin):
         for filename in glob.iglob('%s/abilities/**/*.yml' % plugin.data_dir, recursive=True):
@@ -200,7 +201,7 @@ class DataService(DataServiceInterface, BaseService):
 
     async def _load_sources(self, plugin):
         for filename in glob.iglob('%s/sources/*.yml' % plugin.data_dir, recursive=False):
-            await self.load_source_file(filename, plugin.access)
+            await self.load_yaml_file(Source, filename, plugin.access)
 
     async def _load_objectives(self, plugin):
         for filename in glob.iglob('%s/objectives/*.yml' % plugin.data_dir, recursive=False):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -205,10 +205,7 @@ class DataService(DataServiceInterface, BaseService):
 
     async def _load_objectives(self, plugin):
         for filename in glob.iglob('%s/objectives/*.yml' % plugin.data_dir, recursive=False):
-            for src in self.strip_yml(filename):
-                objective = Objective.load(src)
-                objective.access = plugin.access
-                await self.store(objective)
+            await self.load_yaml_file(Objective, filename, plugin.access)
 
     async def _load_payloads(self, plugin):
         for filename in glob.iglob('%s/payloads/*.yml' % plugin.data_dir, recursive=False):

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -47,8 +47,8 @@ class FileSvc(FileServiceInterface, BaseService):
             display_name = file_path.replace('.xored', '')
         return file_path, contents, display_name
 
-    async def save_file(self, filename, payload, target_dir):
-        self._save(os.path.join(target_dir, filename), payload)
+    async def save_file(self, filename, payload, target_dir, encrypt=True):
+        self._save(os.path.join(target_dir, filename), payload, encrypt)
 
     async def create_exfil_sub_directory(self, dir_name):
         path = os.path.join(self.get_config('exfil_dir'), dir_name)
@@ -143,8 +143,8 @@ class FileSvc(FileServiceInterface, BaseService):
 
     """ PRIVATE """
 
-    def _save(self, filename, content):
-        if self.encryptor and self.encrypt_output:
+    def _save(self, filename, content, encrypt=True):
+        if encrypt and (self.encryptor and self.encrypt_output):
             content = bytes(FILE_ENCRYPTION_FLAG, 'utf-8') + self.encryptor.encrypt(content)
         with open(filename, 'wb') as f:
             f.write(content)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -373,17 +373,12 @@ class RestService(RestServiceInterface, BaseService):
             # new
             file_path = 'data/adversaries/%s.yml' % adv['id']
             allowed = self._get_allowed_from_access(access)
-            adv['objective'] = adv.get('objective',
-                                       (await self._services.get('data_svc').locate('objectives', match=dict(name='default')))[0])
+            adv['objective'] = adv.get('objective', obj_default)
             final = adv
         # verfiy objective is valid
         if len(await self.get_service('data_svc').locate('objectives', match=dict(id=final['objective']))) == 0:
             final['objective'] = obj_default.id
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump(final))
-            f.truncate()
-        await self._services.get('data_svc').load_yaml_file(Adversary, file_path, allowed)
+        await self._save_and_refresh_item(file_path, Adversary, final, allowed)
         return [a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))]
 
     async def _persist_ability(self, access, ab):
@@ -427,9 +422,7 @@ class RestService(RestServiceInterface, BaseService):
             file_path = '%s/%s.yml' % (d, new_ability['id'])
             allowed = self._get_allowed_from_access(access)
             final = new_ability
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump([final]))
+        await self.get_service('file_svc').save_file(file_path, yaml.dump([final], encoding='utf-8'), '', encrypt=False)
         await self.get_service('data_svc').remove('abilities', dict(ability_id=final['id']))
         await self.get_service('data_svc').load_ability_file(file_path, allowed)
         await self._restore_exec_timeouts(final['id'], new_ability_exec_timeouts)
@@ -437,44 +430,30 @@ class RestService(RestServiceInterface, BaseService):
                 await self.get_service('data_svc').locate('abilities', dict(ability_id=final['id']))]
 
     async def _persist_source(self, access, source):
-        if not source.get('id') or not source['id']:
-            source['id'] = str(uuid.uuid4())
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % source['id'], location='data')
-        if file_path:
-            # exists
-            current_source = dict(self.strip_yml(file_path)[0])
-            allowed = (await self.get_service('data_svc').locate('sources', dict(id=source['id'])))[0].access
-            current_source.update(source)
-            final = source
-        else:
-            # new
-            file_path = 'data/sources/%s.yml' % source['id']
-            allowed = self._get_allowed_from_access(access)
-            final = source
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump(final))
-        await self._services.get('data_svc').load_yaml_file(Source, file_path, allowed)
-        return [s.display for s in await self._services.get('data_svc').locate('sources', dict(id=final['id']))]
+        return await self._persist_item(access, 'sources', Source, source)
 
     async def _persist_objective(self, access, objective):
-        if not objective.get('id') or not objective['id']:
-            objective['id'] = str(uuid.uuid4())
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % objective['id'], location='data')
+        return await self._persist_item(access, 'objectives', Objective, objective)
+
+    async def _persist_item(self, access, object_class_name, object_class, item):
+        if not item.get('id') or not item['id']:
+            item['id'] = str(uuid.uuid4())
+        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % item['id'], location='data')
         if file_path:
-            current_objective = dict(self.strip_yml(file_path)[0])
-            allowed = (await self.get_service('data_svc').locate('objectives', dict(id=objective['id'])))[0].access
-            current_objective.update(objective)
-            final = objective
+            current_item = dict(self.strip_yml(file_path)[0])
+            allowed = (await self.get_service('data_svc').locate(object_class_name, dict(id=item['id'])))[0].access
+            current_item.update(item)
+            final = item
         else:
-            file_path = 'data/objectives/%s.yml' % objective['id']
+            file_path = 'data/%s/%s.yml' % (object_class_name, item['id'])
             allowed = self._get_allowed_from_access(access)
-            final = objective
-        with open(file_path, 'w+') as f:
-            f.seek(0)
-            f.write(yaml.dump(final))
-        await self._services.get('data_svc').load_yaml_file(Objective, file_path, allowed)
-        return [o.display for o in await self._services.get('data_svc').locate('objectives', dict(id=final['id']))]
+            final = item
+        await self._save_and_refresh_item(file_path, object_class, final, allowed)
+        return [i.display for i in await self.get_service('data_svc').locate(object_class_name, dict(id=final['id']))]
+
+    async def _save_and_refresh_item(self, file_path, object_class, final, allowed):
+        await self.get_service('file_svc').save_file(file_path, yaml.dump(final, encoding='utf-8'), '', encrypt=False)
+        await self.get_service('data_svc').load_yaml_file(object_class, file_path, allowed)
 
     async def _prep_new_ability(self, ab):
         """Take an ability dict, supplied by frontend, extract executor timeouts,

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -10,7 +10,9 @@ import yaml
 from aiohttp import web
 
 from app.objects.c_adversary import Adversary
+from app.objects.c_objective import Objective
 from app.objects.c_operation import Operation
+from app.objects.c_source import Source
 from app.objects.c_schedule import Schedule
 from app.objects.secondclass.c_fact import Fact
 from app.service.interfaces.i_rest_svc import RestServiceInterface
@@ -381,7 +383,7 @@ class RestService(RestServiceInterface, BaseService):
             f.seek(0)
             f.write(yaml.dump(final))
             f.truncate()
-        await self._services.get('data_svc').load_adversary_file(file_path, allowed)
+        await self._services.get('data_svc').load_yaml_file(Adversary, file_path, allowed)
         return [a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))]
 
     async def _persist_ability(self, access, ab):
@@ -452,7 +454,7 @@ class RestService(RestServiceInterface, BaseService):
         with open(file_path, 'w+') as f:
             f.seek(0)
             f.write(yaml.dump(final))
-        await self._services.get('data_svc').load_source_file(file_path, allowed)
+        await self._services.get('data_svc').load_yaml_file(Source, file_path, allowed)
         return [s.display for s in await self._services.get('data_svc').locate('sources', dict(id=final['id']))]
 
     async def _persist_objective(self, access, objective):
@@ -471,7 +473,7 @@ class RestService(RestServiceInterface, BaseService):
         with open(file_path, 'w+') as f:
             f.seek(0)
             f.write(yaml.dump(final))
-        await self._services.get('data_svc').load_objective_file(file_path, allowed)
+        await self._services.get('data_svc').load_yaml_file(Objective, file_path, allowed)
         return [o.display for o in await self._services.get('data_svc').locate('objectives', dict(id=final['id']))]
 
     async def _prep_new_ability(self, ab):

--- a/server.py
+++ b/server.py
@@ -29,6 +29,7 @@ def setup_logger(level=logging.DEBUG):
             continue
         else:
             logging.getLogger(logger_name).setLevel(100)
+    logging.captureWarnings(True)
 
 
 async def start_server():

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -156,6 +156,14 @@
     text-align: left;
     padding-bottom: 20px;
 }
+.pane-header-editable input,
+.fillable-table input {
+    background-color: inherit;
+    border: none;
+    color: var(--font-color);
+    text-align: left;
+    padding: 0;
+}
 .op-selected {
     visibility: hidden;
 }

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -38,6 +38,7 @@
             <p>Advanced</p>
         </div>
         <a onclick="viewSection('sources', '/advanced/sources')">sources</a>
+        <a onclick="viewSection('objectives', '/advanced/objectives')">objectives</a>
         <a onclick="viewSection('planners', '/advanced/planners')">planners</a>
         <a onclick="viewSection('contacts', '/advanced/contacts')">contacts</a>
         <a onclick="viewSection('obfuscators', '/advanced/obfuscators')">obfuscators</a>

--- a/templates/objectives.html
+++ b/templates/objectives.html
@@ -54,25 +54,6 @@
     </div>
 </div>
 
-<div id="objective-modal" class="modal">
-    <form class="modal-content" style="width:50%;">
-        <div class="container modal-box">
-            <div class="row ability-viewer">
-                <span onclick="document.getElementById('objective-modal').style.display='none'" class="close" title="Close Modal">&times;</span>
-                <div class="column" style="flex:100%">
-                    <center>
-                        <span>Goals</span>
-                        <h3 id="goals-name" style="margin-top:2px;text-align:center"></h3>
-                        <ul id="objective-goals"></ul>
-                        <p style="color:white;text-align: right;" onclick="addGoalBlock()">&#10010;&nbsp;add goal</p>
-                        <p style="font-size:12px;text-align:right">* Goals run in top-down order, in the same way as iptables</p>
-                    </center>
-                </div>
-            </div>
-        </div>
-    </form>
-</div>
-
 <div id="assignments-modal" class="modal">
     <form class="modal-content" style="width:50%;">
         <div class="container modal-box">

--- a/templates/objectives.html
+++ b/templates/objectives.html
@@ -1,0 +1,252 @@
+<div id="objectives" class="section-profile">
+    <div class="advanced row">
+        <div class="topleft duk-icon"><img onclick="removeSection('objectives')" src="/gui/img/x.png"></div>
+        <div class="bottomright duk-icon"><img onclick="toggleSidebar('objectives-sidebar')" src="/gui/img/expand.png"></div>
+        <div id="objectives-sidebar"  class="column section-border" style="flex:25%">
+        <img src="/gui/img/facts.png">
+        <h4>Objectives</h4>
+        <br>
+        <div class="toggle">
+            <label class="switch"><input type="checkbox" id="togBtnSrc" onchange="toggleObjectiveView()">
+            <div class="slider round"><span class="on">ADD</span><span class="off">VIEW</span></div>
+            </label>
+            </div>
+        <br>
+        <p class="section-description">
+          Objectives are groups of goals that an adversary will accomplish.
+        </p>
+        <br>
+        <div id="viewObjective">
+            <select id="objective-list" style="margin-top:-15px" onchange="loadObjective();">
+                <option value="" disabled selected>Select an existing objective</option>
+                {% for o in objectives %}
+                    <option value="{{ o.id }}">{{ o.name }}</option>
+                {% endfor %}}
+            </select>
+        </div>
+        <div id="addObjective"></div>
+        <button id="objectiveBtn" type="button" class="button-success atomic-button"
+              onclick="viewAssignments()">View Adversary Assignments
+        </button>
+        <button id="saveObjectiveBtn" type="button" class="button-success atomic-button"
+              onclick="saveObjective()">Save
+        </button>
+        </div>
+        <div class="column pane-header-editable" style="flex:75%;text-align:left">
+            <input id="objective-name" type="text" name="objective-name" placeholder="enter an objective name" />
+            <input id="objective-description" type="text" name="objective-description" placeholder="enter a objective description" />
+            <hr/>
+            <table id="goalTbl" class="obfuscation-table fillable-table" border=1 frame=void rules=rows>
+                <thead>
+                    <tr>
+                        <td><b>target</b></td>
+                        <td><b>operator</b></td>
+                        <td><b>value</b></td>
+                        <td><b>count</b></td>
+                        <td></td>
+                    </tr>
+                </thead>
+            </table>
+            <p style="color:white;text-align:right;font-size:16px;" onclick="addGoalRow()">
+                &#10010;&nbsp;add row
+            </p>
+        </div>
+    </div>
+</div>
+
+<div id="objective-modal" class="modal">
+    <form class="modal-content" style="width:50%;">
+        <div class="container modal-box">
+            <div class="row ability-viewer">
+                <span onclick="document.getElementById('objective-modal').style.display='none'" class="close" title="Close Modal">&times;</span>
+                <div class="column" style="flex:100%">
+                    <center>
+                        <span>Goals</span>
+                        <h3 id="goals-name" style="margin-top:2px;text-align:center"></h3>
+                        <ul id="objective-goals"></ul>
+                        <p style="color:white;text-align: right;" onclick="addGoalBlock()">&#10010;&nbsp;add goal</p>
+                        <p style="font-size:12px;text-align:right">* Goals run in top-down order, in the same way as iptables</p>
+                    </center>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+<div id="assignments-modal" class="modal">
+    <form class="modal-content" style="width:50%;">
+        <div class="container modal-box">
+            <div class="row ability-viewer">
+                <span onclick="document.getElementById('assignments-modal').style.display='none'" class="close" title="Close Modal">&times;</span>
+                <div class="column" style="flex:100%">
+                    <center>
+                        <span>Adversary-Objective Assignments</span>
+                        <h3 id="assignment-name" style="margin-top:2px;text-align:center"></h3>
+                        <ul id="objective-assignments"></ul>
+                    </center>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+<li class="row-simple assignment-template" style="display: none;">
+    <div class="column">
+        <table frame=void rules=rows style="border-spacing:20px;width:100%">
+            <tr>
+                <td style="width:20%"><b>adversary:</b></td>
+                <td class="assignmentAdversary"></td>
+            </tr>
+            <tr>
+                <td style="width:20%"><b>objective:</b></td>
+                <td class="assignmentObjective"></td>
+            </tr>
+        </table>
+    </div>
+</li>
+
+<script>
+    $(document).ready(function () {
+        stream('New objectives will be created to automate adversary actions to achieve goals.')
+    });
+    let refresher = setInterval(refresh, 15000);
+    let adversariesinfo = setInterval(refresh, 15000);
+    $('.section-profile').bind('destroyed', function() {
+        console.log('objectives refresh off');
+        clearInterval(refresher);
+    });
+
+    function refresh(){
+        function objectiveCallback(data){
+            data.forEach(function(o) {
+                let found = false;
+                $("#objective-list > option").each(function() {
+                    if($(this).val() === o.id) {
+                        found = true;
+                    }
+                });
+                if(!found){
+                    $('#objective-list').append('<option value="'+o.id+'">'+o.name+'</option>');
+                }
+            });
+        }
+        restRequest('POST', {'index':'objectives'}, objectiveCallback, '/api/rest');
+    }
+
+    function toggleObjectiveView() {
+        $('#viewObjective').toggle();
+        $('#addObjective').toggle();
+        $('#objectiveBtn').toggle();
+        $('#objective-list').val('');
+        clearGoalCanvas();
+    }
+
+    function clearGoalCanvas(){
+        $('#goalTbl').find("tr:gt(0)").remove();
+        $('#objective-goals').empty();
+        $('#objective-name').data('id', null);
+        $('#objective-name').val('');
+        $('#objective-description').val('');
+    }
+
+    function loadObjective() {
+        function loadObjectiveCallback(data) {
+            clearGoalCanvas();
+            let objective = $('#objective-name');
+            data[0].goals.forEach(g => {
+                addGoalRow(g.target, g.operator, g.value, g.count);
+            });
+            objective.data('id', data[0].id);
+            objective.val(data[0].name);
+            $('#objective-description').val(data[0].description);
+        }
+        stream('Targets within goals can be used inside objectives as variables, which get replaced at runtime with their corresponding values.');
+        restRequest('POST', {'index':'objectives', 'id': $('#objective-list').val()}, loadObjectiveCallback);
+    }
+
+    function addGoalRow(target, operator, value, count) {
+        let resTarget = ((target) ? `<input type="text" placeholder="Enter target" name="target" value="${target}" required>` : '<input type="text" placeholder="Enter target" name="target" required>');
+        let resOperator = ((operator) ? `<input type="text" placeholder="Enter operator" value="${operator}" required>` : '<input type="text" placeholder="Enter operator" required>');
+        let resValue = ((value) ? `<input type="text" placeholder="Enter value" value="${value}" required>` : '<input type="text" placeholder="Enter value" required>');
+        let resCount = ((operator) ? `<input type="number" placeholder="Enter count" value="${count}" required>` : '<input type="number" placeholder="Enter count" required>');
+        $('#goalTbl tr:last').after(
+            '<tr>' +
+                `<td>${resTarget}</td>` +
+                `<td>${resOperator}</td>` +
+                `<td>${resValue}</td>` +
+                `<td>${resCount}</td>` +
+                '<td><p onclick="$(this).parent().parent().remove()">&#x274C;</p></td>'+
+            '</tr>'
+        )
+    }
+
+    function saveObjective(){
+        function saveObjectiveCallback(data) {
+            stream('New objective saved!');
+        }
+        let objective = $('#objective-name');
+        let name = objective.val();
+        let id = objective.data('id');
+        let description = $('#objective-description');
+        if(!name){ warn('Please enter a name!'); return; }
+        if(!id) {
+            id = uuidv4();
+            objective.data('id', id);
+        }
+        let data = {};
+        data['index'] = 'objectives';
+        data['name'] = name;
+        data['description'] = description.val();
+        data['goals'] = [];
+
+        $("#goalTbl tr").not(":first").each(function (index, value) {
+            let rowdata = {
+                'target': this.cells[0].children[0].value,
+                'operator': this.cells[1].children[0].value,
+                'value': this.cells[2].children[0].value,
+                'count': this.cells[3].children[0].value
+            }
+            $.each(rowdata, function(key, val) {
+                console.log(`${key} = ${val}`)
+                if(!val) { warn(`Goal ${index+1} is missing ${key}`); return; }
+            })
+            data['goals'].push(rowdata);
+        });
+        if(data['goals'].length === 0) { warn('Please enter some goals!'); return; }
+
+        restRequest('PUT', data, saveObjectiveCallback);
+    }
+
+    function viewAssignments(){
+        populateAssignments();
+        document.getElementById("assignments-modal").style.display = "block";
+        let objectiveName = $('#objective-name').val();
+        $('#assignment-name').text(objectiveName);
+    }
+
+    function populateAssignments() {
+        $("#objective-assignments").empty();
+        function populateAssignmentsCallback(data) {
+            if(data.length == 0) {
+                $('#objective-assignments').append("<li>No assignments</li>");
+            }
+            data.forEach(adversary => {
+                let template = $(".assignment-template").clone();
+                template.removeClass("assignment-template");
+                template.data("adversary_id", adversary.adversary_id);
+                template.find(".assignmentAdversary").text(adversary.name);
+                template.find(".assignmentObjective").text(adversary.objective.id + " - " + adversary.objective.name);
+                template.show();
+                $('#objective-assignments').append(template);
+            });
+        }
+
+        let activeId = $("#objective-list").val()
+        if(activeId)
+            restRequest('POST', {'index':'adversaries', 'objective': activeId}, populateAssignmentsCallback);
+        else
+            restRequest('POST', {'index':'adversaries'}, populateAssignmentsCallback);
+    }
+
+    //# objectiveURL=objectives.js
+</script>

--- a/templates/objectives.html
+++ b/templates/objectives.html
@@ -176,6 +176,7 @@
         }
         let data = {};
         data['index'] = 'objectives';
+        data['id'] = id;
         data['name'] = name;
         data['description'] = description.val();
         data['goals'] = [];

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -113,14 +113,14 @@ class TestRestSvc:
     def test_persist_objective_single_new(self, loop, rest_svc, file_svc):
         internal_rest_svc = rest_svc(loop)
         req = {
-                "name": "test",
-                "description": "test objective",
-                "goals": [
+                'name': 'new objective',
+                'description': 'test new objective',
+                'goals': [
                     {
-                        "count": 1,
-                        "operator": "*",
-                        "target": "host.user.name",
-                        "value": "NA"
+                        'count': 1,
+                        'operator': '*',
+                        'target': 'host.user.name',
+                        'value': 'NA'
                     }
                 ]
             }
@@ -128,6 +128,29 @@ class TestRestSvc:
         # clear out subobject difference
         objs[0]['goals'][0].pop('achieved')
         assert req.items() <= objs[0].items()
+
+    def test_persist_objective_single_existing(self, loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(loop)
+        req = {
+                'name': 'new objective',
+                'description': 'test new objective',
+                'goals': [
+                    {
+                        'count': 1,
+                        'operator': '*',
+                        'target': 'host.user.name',
+                        'value': 'NA'
+                    }
+                ]
+            }
+        objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
+        # clear out subobject difference
+        objs[0]['goals'][0].pop('achieved')
+        assert req.items() <= objs[0].items()
+        # modify
+        modified_req = {'id': objs[0]['id'], 'description': 'modified objective'}
+        modified_objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, modified_req))
+        assert modified_req.items() <= modified_objs[0].items()
 
     def test_delete_adversary(self, loop, rest_svc, file_svc):
         internal_rest_svc = rest_svc(loop)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -110,6 +110,25 @@ class TestRestSvc:
         response = loop.run_until_complete(internal_rest_svc.delete_ability(data=dict(ability_id='123')))
         assert 'Delete action completed' == response
 
+    def test_persist_objective_single_new(self, loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(loop)
+        req = {
+                "name": "test",
+                "description": "test objective",
+                "goals": [
+                    {
+                        "count": 1,
+                        "operator": "*",
+                        "target": "host.user.name",
+                        "value": "NA"
+                    }
+                ]
+            }
+        objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
+        # clear out subobject difference
+        objs[0]['goals'][0].pop('achieved')
+        assert req.items() <= objs[0].items()
+
     def test_delete_adversary(self, loop, rest_svc, file_svc):
         internal_rest_svc = rest_svc(loop)
         data = """


### PR DESCRIPTION
Adds objectives dialog that allows users to create their own and modify existing objectives.
- Adds `encrypt` flag to `file_svc.save_file` to expands its usability.
- Adds generalized `rest_svc._persist_item` private function that replaces the majority of non-specialized object persistence functions. 
- Adds generalized `data_svc.load_yaml_file` function that will load a class' object YAML files into memory
- Deprecates `data_svc.load_adversary_file`, `load_source_file`, and `load_objective_file`. Functions are now stubs pointing to `load_yaml_file`