### PR TITLE
Add link details to link/completed event.

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -47,7 +47,7 @@ class ContactService(ContactServiceInterface, BaseService):
                 operation = await self.get_service('app_svc').find_op_with_link(result['id'])
                 access = operation.access if operation else self.Access.RED
                 await self.get_service('event_svc').fire_event('link/completed', agent=agent.display, pid=result['pid'],
-                                                               link=operation.chain[-1].display, access=access.value)
+                                                               link_id=result['id'], access=access.value)
             return agent, await self._get_instructions(agent)
         agent = await self.get_service('data_svc').store(
             Agent.load(dict(sleep_min=self.get_config(name='agents', prop='sleep_min'),

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -47,7 +47,7 @@ class ContactService(ContactServiceInterface, BaseService):
                 operation = await self.get_service('app_svc').find_op_with_link(result['id'])
                 access = operation.access if operation else self.Access.RED
                 await self.get_service('event_svc').fire_event('link/completed', agent=agent.display, pid=result['pid'],
-                                                               access=access.value)
+                                                               link=operation.chain[-1].display, access=access.value)
             return agent, await self._get_instructions(agent)
         agent = await self.get_service('data_svc').store(
             Agent.load(dict(sleep_min=self.get_config(name='agents', prop='sleep_min'),


### PR DESCRIPTION
Changes: 

- Add details about the completed link to the `link/completed` event.

I think this probably worthwhile by itself, but it will be useful for some work I'm doing with response & gameboard. 