### PR TITLE
removing host from Link load exclusion

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -58,7 +58,7 @@ class Link(BaseObject):
     schema = LinkSchema()
     display_schema = LinkSchema(exclude=['jitter'])
     load_schema = LinkSchema(exclude=['decide', 'pid', 'facts', 'unique', 'collect', 'finish', 'visibility',
-                                      'host', 'output'])
+                                      'output'])
 
     @property
     def unique(self):


### PR DESCRIPTION
Manually applied links were missing host information due to the exclusion. This small PR fixes that.