### PR TITLE
Operation fixes

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -129,7 +129,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
     async def close(self, services):
         await self._cleanup_operation(services)
         await self._save_new_source(services)
-        await self.get_service('event_svc').fire_event('operation/completed', op=self.id)
+        await services.get('event_svc').fire_event('operation/completed', op=self.id)
         if self.state not in [self.states['FINISHED'], self.states['OUT_OF_TIME']]:
             self.state = self.states['FINISHED']
         self.finish = self.get_current_timestamp()

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -104,7 +104,7 @@
           </div>
           <div id="schedules-options" class="column sidebar-cutout" style="display: none;">
               <input type="time" id="schedule-time" onchange="checkOpformValid()">
-              <button id="scheduleBtn" type="button" style="opacity:0.5;width:40%;border-radius:0;" disabled="true"
+              <button id="scheduleBtn" type="button" style="opacity:0.5;" disabled="true"
               class="button-notready atomic-button" onclick="handleScheduleAction()">Schedule
                 </button>
           </div>

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -288,6 +288,7 @@
         $("#schedules").click(function(){
             stream('Schedule your operation to run every day.');
             $("#schedules-options").slideToggle("slow");
+            $('#opBtn').fadeToggle('slow');
         });
         $("#stealth").click(function(){
             stream('Stealth options will determine just how noticeable your operation is to the defense.');


### PR DESCRIPTION
* Removed a reference to `self.get_service()` which prevented operations from closing properly
* During operation creation, hide "Start" button when the "Schedule" button is showing
* During operation creation, increase the size of the "Schedule" button to match the "Start button"
* Write a debug message when a scheduled operation with the same name exists. Scheduled operations are uniqued based on the name, so these would silently fail when attempting to create a new scheduled operation with the same name. I considered adding an `id` attribute to the `Schedule` object (and using that for the `unique()` function) to allow multiple scheduled operations with the same name, but I really borked a couple operations by scheduling them at the same time... figured adding this debug message was less intrusive.