### PR TITLE
Fix bucket planner execution

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -64,7 +64,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         :return: True if planner stopping conditions are met
         :rtype: bool
         """
-        await self._bucket_execute(operation, planner, link_ids, condition_stop)
+        await self._bucket_execute(operation, planner, link_ids)
         return await self._stop_bucket_exhaustion(planner, operation, condition_stop)
 
     async def default_next_bucket(self, current_bucket, state_machine):

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -38,7 +38,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         """
         l_ids = []
         while True:
-            links =  await self.get_links(operation, [bucket], agent)
+            links = await self.get_links(operation, [bucket], agent)
             if len(links) == 0:
                 break
             for l in links:


### PR DESCRIPTION
An extra argument was passed to bucket execution method, causing bucket planner to crash.