### PR TITLE
Added mapping to parserconfig for custom parser values

### DIFF
--- a/app/objects/secondclass/c_parserconfig.py
+++ b/app/objects/secondclass/c_parserconfig.py
@@ -11,6 +11,7 @@ class ParserConfigSchema(ma.Schema):
     source = ma.fields.String()
     edge = ma.fields.String(missing=None)
     target = ma.fields.String(missing=None)
+    custom_parser_vals = ma.fields.Mapping(keys=ma.fields.String(), values=ma.fields.String())
 
     @ma.pre_load
     def check_edge_target(self, in_data, **_):
@@ -28,6 +29,7 @@ class ParserConfigSchema(ma.Schema):
         data.source = data.source or ''
         data.edge = data.edge or ''
         data.target = data.target or ''
+        data.custom_parser_vals = data.custom_parser_vals or {}
         return data
 
 
@@ -35,10 +37,9 @@ class ParserConfig(BaseObject):
 
     schema = ParserConfigSchema()
 
-    def __init__(self, source, edge=None, target=None, **kwargs):
+    def __init__(self, source, edge=None, target=None, custom_parser_vals=None):
         super().__init__()
         self.source = source
         self.edge = edge
         self.target = target
-        for k, v in kwargs.items():
-            setattr(self, k, v)
+        self.custom_parser_vals = custom_parser_vals


### PR DESCRIPTION
Bug fix for extra parser values not appearing in ParserConfig (specifically `json_key` and `json_value` for abilities using the `json.py` parser). 

Although the `ParserConfig` schema has the setting to include unknown values, this does not propagate upwards when calling `load` on an object that does not have the setting. This occurs when new links are generated in the `planning_svc`, [L351](https://github.com/mitre/caldera/blob/master/app/service/planning_svc.py#L351).

This change will also provide a structured section for users to create their own parser values for abilities and custom parsers.

Related: https://github.com/mitre/stockpile/pull/478