### PR TITLE
Automatically update groups in the operation dropdown with new groups

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -474,6 +474,24 @@
                 }
             }
         }
+        function updateGroups(data) {
+            // Update the group dropdown list with new agent groups
+            var options = $('#queueGroup option');
+            var groups = $.map(options, function(option) {
+                if (option.value) {
+                    return option.value;
+                }
+            });
+            $.each(data, function(index, agent) {
+                if ($.inArray(agent.group, groups) === -1) {
+                    var newOption = $('<option></option>')
+                        .attr('id', 'qgroup-' + agent.group)
+                        .attr('value', agent.group)
+                        .text(agent.group);
+                    $('#queueGroup').append(newOption);
+                }
+            });
+        }
         let selectedOperationId = $('#operation-list option:selected').attr('value');
         if(selectedOperationId !== '') {
             let postData = selectedOperationId ? {'index':'operations','id': parseInt(selectedOperationId)} : null;
@@ -483,6 +501,7 @@
             stream('Go to the GameBoard plugin to see if the blue team can detect your activities.');
             restRequest('POST', postData, operationCallback, '/api/rest');
         }
+        restRequest('POST', {'index':'agents'}, updateGroups);
     }
 
     function applyOperationAgents(operation) {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -489,6 +489,7 @@
                         .attr('value', agent.group)
                         .text(agent.group);
                     $('#queueGroup').append(newOption);
+                    groups.push(agent.group);
                 }
             });
         }


### PR DESCRIPTION
Currently, in order to create an operation with a new group, the user has to close the entire operation box. The change automatically updates the dropdown with new groups, eliminating the need to close the entire section.