### PR TITLE
Sources table edits

### DIFF
--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -302,11 +302,14 @@
 #factTbl {
     table-layout: fixed;
 }
+#factTbl th {
+    text-align: left;
+}
 #factTbl th:nth-child(1) {
-    width: 15%;
+    width: 20;
 }
 #factTbl th:nth-child(2) {
-    width: 80%;
+    width: 75%;
 }
 #factTbl th:nth-child(3) {
     width: 5%;

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -306,7 +306,7 @@
     text-align: left;
 }
 #factTbl th:nth-child(1) {
-    width: 20;
+    width: 20%;
 }
 #factTbl th:nth-child(2) {
     width: 75%;

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -299,6 +299,22 @@
 #pack-phases td {
     padding: 5px 8px;
 }
+#factTbl {
+    table-layout: fixed;
+}
+#factTbl th:nth-child(1) {
+    width: 15%;
+}
+#factTbl th:nth-child(2) {
+    width: 80%;
+}
+#factTbl th:nth-child(3) {
+    width: 5%;
+}
+#factTbl td p {
+    overflow-wrap: anywhere;
+    word-break: break-all;
+}
 #source-rules li {
     list-style-type:none;
 }

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -199,7 +199,7 @@
             '<tr>' +
                 '<td><p contenteditable="true">' + trait + '</p></td>' +
                 '<td><p contenteditable="true">' + value + '</p></td>' +
-                '<td><p onclick="$(this).parent().parent().remove()">&#x274C;</p></td>'+
+                '<td><p onclick="$(this).closest(\'tr\').remove()">&#x274C;</p></td>'+
             '</tr>'
         )
     }

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -41,11 +41,13 @@
         <table id="factTbl" class="obfuscation-table" border=1 frame=void rules=rows>
             <thead>
                 <tr>
-                    <td><b>trait</b></td>
-                    <td><b>value</b></td>
-                    <td></td>
+                    <th><b>trait</b></th>
+                    <th><b>value</b></th>
+                    <th></th>
                 </tr>
             </thead>
+            <tbody>
+            </tbody>
         </table>
         <p style="color:white;text-align:right;font-size:16px;" onclick="addFactRow('Enter trait', 'Enter value')">
             &#10010;&nbsp;add row
@@ -168,7 +170,7 @@
     }
 
     function clearFactCanvas(){
-        $('#factTbl').find("tr:gt(0)").remove();
+        $('#factTbl tbody tr').remove();
         $('#source-rules').empty();
         $('#source-relationships').empty();
         if($('#source-name').data('id')){
@@ -193,10 +195,10 @@
     }
 
     function addFactRow(trait, value){
-        $('#factTbl tr:last').after(
+        $('#factTbl tbody').append(
             '<tr>' +
-                '<td><p contenteditable="true">'+trait+'</p></td>' +
-                '<td><p contenteditable="true">'+value+'</p></td>' +
+                '<td><p contenteditable="true">' + trait + '</p></td>' +
+                '<td><p contenteditable="true">' + value + '</p></td>' +
                 '<td><p onclick="$(this).parent().parent().remove()">&#x274C;</p></td>'+
             '</tr>'
         )
@@ -222,7 +224,7 @@
         data['rules'] = [];
         data['relationships'] = []
 
-        $("#factTbl tr").not(":first").each(function () {
+        $('#factTbl tbody tr').each(function () {
             let trait = $(this.cells[0]).text();
             let value = $(this.cells[1]).text();
             data['facts'].push({'trait':trait,'value':value});

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -50,7 +50,7 @@
             </tbody>
         </table>
         <p style="color:white;text-align:right;font-size:16px;" onclick="addFactRow('Enter trait', 'Enter value')">
-            &#10010;&nbsp;add row
+            &#10010;&nbsp;add fact
         </p>
     </div>
   </div>


### PR DESCRIPTION
Long facts cause the X to be pushed offscreen. Lack of wrapping makes it difficult to view long strings. Made the table fixed width to keep each column in place. Added text wrapping.

Example fact:

```
9HPeFn2d2sfZlXAweDltLLN1ZJvOWszbKsagqm53FKDmAHami55boc56MjDE8SLSWJ+65h2kUuy7dXKXume4PC6KK6XLEqFdkbAFQW935TJp1n5WhARxjInoYQBxuiEZSby1L3fz9QgoW\IxJB8bDDEiMvTRbA51NSj2yPi5FTu1sLEYgZ1r6WQEPrVne5hpdu94OtjTnziOlrLuZTNnvvU6mjEQ4gycEIKyFIgpZDmddjeiiA\5lfWOYo+L90UqrzsLHAIQJ9dDZtKDayhzybMeRYRr0Hg7mLdYBOO1yNFQttC8mGMWUKsxzVHtYehsfCHH\4sHI9NSRKjyds5xc3fRYsDaTd8GTgxOaoYS7h07b\bh99AI1VxRL3H5PfHp6IdMBXPHaAJ7UGieACAhMkwjByzbPKhvkWHx7tWEkDvAhSINIb+GEPEzWnOq9dzaqTCUQRBSMbXUJQsjWIdLgkgAHHPtTYQTf5Oalxk35NZjky4Kjr6ECrGotEp\5lWVqYensi8IaVXnm3MslrqAYBgMNhVYKiufg0h3KyoPDcK1sjzHEJndioi22QFHcLr9V+1tgflvR7TnHGMwdZOS0VnTAnbor1vlv\NvomChf1udu2AfP7QgBpyAs6UPpmieGSbxPxDcYMLoy3JUasVT+TM5ofEZYtMWI6QQZgcQ6QfvCwR0rQq6RSEGTZmSciL39EIYkz2\V9iDT3U2eksHkxqwlUlH800p3Rz8fpi+3OZe0isOpycFPJsJ5Z1hoMiAWqOo8GGtrWj4IRAapkZeoapLjkJhryvIyGdThBFvgqZSTPqwqCmIr4EW9+pUNFZeNu\CGXEQSon0O2CK8UACjtV8EK6tMuwqOqaX1USfEua==
```

Also modified the JS to refresh the entire `tbody`, instead of removing rows but the first (the header).