### PR TITLE
Command output wraps when viewed in an operation

### DIFF
--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -561,6 +561,9 @@ table.dataTable input[type=text] {
   line-height: 30px; /* To center it vertically */
   color: black;
 }
+#resultCmd {
+    overflow-wrap: anywhere;
+}
 .dotted {
     border: 1px solid white;
 }


### PR DESCRIPTION
Long strings in commands will overflow the popup. The change just wraps this text.