### PR TITLE
Fixed ability select

### DIFF
--- a/static/js/ability.js
+++ b/static/js/ability.js
@@ -36,20 +36,29 @@ function populateTechniques(parentId, exploits){
     });
 }
 
-function populateAbilities(parentId, exploits){
-    exploits = addPlatforms(exploits);
-    let parent = $('#'+parentId);
-    $(parent).find('#ability-ability-filter').empty();
+/**
+ * Populate the abilities dropdown based on selected technique
+ * @param {string} parentId - Parent ID used to search for dropdowns
+ * @param {object[]} abilities - Abilities object array
+ */
+function populateAbilities (parentId, abilities) {
+    abilities = addPlatforms(abilities);
+    let parent = $('#' + parentId);
 
-    let showing = [];
-    let attack_id = $(parent).find('#ability-technique-filter').find(":selected").data('technique');
-    exploits.forEach(function(ability) {
-        if(attack_id === ability.technique_id) {
-            appendAbilityToList(parentId, ability);
-            showing += 1;
+    // Collect abilities matching technique
+    let techniqueAbilities = [];
+    let attack_id = $(parent).find('#ability-technique-filter').find(':selected').data('technique');
+    abilities.forEach(function (ability) {
+        if (attack_id === ability.technique_id) {
+            techniqueAbilities.push(ability)
         }
     });
-    $(parent).find('#ability-ability-filter').prepend("<option disabled='disabled' selected>"+showing.length+" abilities</option>");
+
+    // Clear, then populate the ability dropdown
+    $(parent).find('#ability-ability-filter').empty().append('<option disabled="disabled" selected>' + techniqueAbilities.length + ' abilities</option>');
+    techniqueAbilities.forEach(function (ability) {
+        appendAbilityToList(parentId, ability);
+    });
 }
 
 function appendTechniqueToList(parentId, tactic, value) {

--- a/static/js/ability.js
+++ b/static/js/ability.js
@@ -49,8 +49,8 @@ function populateAbilities (parentId, abilities) {
     let techniqueAbilities = [];
     let attack_id = $(parent).find('#ability-technique-filter').find(':selected').data('technique');
     abilities.forEach(function (ability) {
-        if (attack_id === ability.technique_id) {
-            techniqueAbilities.push(ability)
+        if (ability.technique_id === attack_id) {
+            techniqueAbilities.push(ability);
         }
     });
 


### PR DESCRIPTION
Bug: First ability in list is always selected the first time
Reproduction Steps:
1. Open Adversaries
1. Select "add ability"
1. Choose tactic, ex: "collection"
1. Choose technique, ex: "T1005 | Data from Local System"
1. Choose an ability that isn't the first ability in the dropdown, ex: "cURL socket address"
1. Note that the first ability in the dropdown is selected, ex: "Find IP addresses"

The issue seemed to be with prepending the disabled option with the text "X abilities", X being the number of abilities found in the technique. The select box had already selected the first ability by this point, and that ability would be selected the first time the onChange was fired.