### PR TITLE
Adversary updates

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -454,7 +454,7 @@ class RestService(RestServiceInterface, BaseService):
             return []
 
         # Validate tactic, used for directory creation
-        tactic_match = re.compile('^[a-zA-Z0-9\-]+$')
+        tactic_match = re.compile(r'^[a-zA-Z0-9\-]+$')
         if not ab.get('tactic') or not tactic_match.match(ab.get('tactic')):
             self.log.debug('Invalid ability tactic "{}". Tactics can only contain alphanumeric characters and hyphens.'
                            .format(ab.get('tactic')))

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -484,7 +484,7 @@ class RestService(RestServiceInterface, BaseService):
             tactic_dir = os.path.join('data', 'abilities', new_ability.get('tactic'))
             if not os.path.exists(tactic_dir):
                 os.makedirs(tactic_dir)
-            file_path = '%s/%s.yml' % (tactic_dir, new_ability['id'])
+            file_path = os.path.join(tactic_dir, '%s.yml' % new_ability['id'])
             final = new_ability
             # Get access
             allowed = self._get_allowed_from_access(access)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -449,15 +449,16 @@ class RestService(RestServiceInterface, BaseService):
             ab['id'] = str(uuid.uuid4())
 
         # Validate ID, used for file creation
-        if not self.is_uuid4(ab.get('id')):
-            self.log.debug('Invalid ability ID "{}". ID must be UUID4.'.format(ab.get('id')))
+        validator = re.compile(r'^[a-zA-Z0-9-_]+$')
+        if not ab.get('id') or not validator.match(ab.get('id')):
+            self.log.debug('Invalid ability ID "%s". IDs can only contain '
+                           'alphanumeric characters, hyphens, and underscores.' % ab.get('id'))
             return []
 
         # Validate tactic, used for directory creation
-        tactic_match = re.compile(r'^[a-zA-Z0-9\-]+$')
-        if not ab.get('tactic') or not tactic_match.match(ab.get('tactic')):
-            self.log.debug('Invalid ability tactic "{}". Tactics can only contain alphanumeric characters and hyphens.'
-                           .format(ab.get('tactic')))
+        if not ab.get('tactic') or not validator.match(ab.get('tactic')):
+            self.log.debug('Invalid ability tactic "%s". Tactics can only contain '
+                           'alphanumeric characters, hyphens, and underscores.' % ab.get('tactic'))
             return []
 
         # Validate platforms, ability will not be loaded if empty

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import uuid
 from datetime import time
+import re
 
 import yaml
 from aiohttp import web
@@ -436,27 +437,58 @@ class RestService(RestServiceInterface, BaseService):
             - add parsers back in to current ability
             - save current ability to disk, then re-load ability from file
             - check/set executor timeouts on loaded abilities
+        :param access: Current access list
+        :type access: dict
+        :param ab: Ability to add or
+        :type ab: dict
+        :return: Created / updated ability
+        :rtype: List(Ability)
         """
-        if not ab.get('id') or not ab['id']:
+        # Set ability ID if undefined
+        if not ab.get('id'):
             ab['id'] = str(uuid.uuid4())
+
+        # Validate ID, used for file creation
+        if not self.is_uuid4(ab.get('id')):
+            self.log.debug('Invalid ability ID "{}". ID must be UUID4.'.format(ab.get('id')))
+            return []
+
+        # Validate tactic, used for directory creation
+        tactic_match = re.compile('^[a-zA-Z0-9\-]+$')
+        if not ab.get('tactic') or not tactic_match.match(ab.get('tactic')):
+            self.log.debug('Invalid ability tactic "{}". Tactics can only contain alphanumeric characters and hyphens.'
+                           .format(ab.get('tactic')))
+            return []
+
+        # Validate platforms, ability will not be loaded if empty
+        if not ab.get('platforms'):
+            self.log.debug('At least one platform/executor is required to save ability.')
+            return []
+
+        # Create a new ability to be used for updating/creating
         new_ability, new_ability_exec_timeouts = await self._prep_new_ability(ab)
-        _, file_path = await self.get_service('file_svc').find_file_path('%s.yml' % ab['id'], location='data')
+
+        # Update or create ability
+        _, file_path = await self.get_service('file_svc').find_file_path('{}.yml'.format(ab['id']), location='data')
         if file_path:
-            # exists
+            # Ability exists, update
             current_ability = dict(self.strip_yml(file_path)[0][0])
-            allowed = (await self.get_service('data_svc').locate('abilities',
-                                                                 dict(ability_id=ab['id'])))[0].access
             current_ability, current_parsers = await self._strip_parsers_from_ability(current_ability)
             current_ability.update(new_ability)
             final = await self._add_parsers_to_ability(current_ability, current_parsers)
+            # Get access
+            found_abilities = await self.get_service('data_svc').locate('abilities', dict(ability_id=ab['id']))
+            allowed = found_abilities[0].access if found_abilities else self._get_allowed_from_access(access)
         else:
-            # new
-            d = 'data/abilities/%s' % new_ability.get('tactic')
-            if not os.path.exists(d):
-                os.makedirs(d)
-            file_path = '%s/%s.yml' % (d, new_ability['id'])
-            allowed = self._get_allowed_from_access(access)
+            # Create new ability, create file / directory
+            tactic_dir = os.path.join('data', 'abilities', new_ability.get('tactic'))
+            if not os.path.exists(tactic_dir):
+                os.makedirs(tactic_dir)
+            file_path = '%s/%s.yml' % (tactic_dir, new_ability['id'])
             final = new_ability
+            # Get access
+            allowed = self._get_allowed_from_access(access)
+
         await self.get_service('file_svc').save_file(file_path, yaml.dump([final], encoding='utf-8'), '', encrypt=False)
         await self.get_service('data_svc').remove('abilities', dict(ability_id=final['id']))
         await self.get_service('data_svc').load_ability_file(file_path, allowed)

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -792,6 +792,25 @@ table.dataTable input[type=text] {
     text-align: left;
 }
 
+#ability-manager .ability-fields {
+    flex: 60%;
+}
+
+#ability-manager .ability-additional-fields {
+    flex: 40%;
+}
+
+#ability-manager table {
+    border-spacing: 2px;
+    width: 100%;
+}
+
+
+#ability-manager table td:nth-child(1) {
+    width: 8em;
+    font-weight: bold;
+}
+
 #ability-button-row {
     float: right;
     width: 40%;

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -791,3 +791,17 @@ table.dataTable input[type=text] {
     visibility: hidden;
     text-align: left;
 }
+
+#ability-button-row {
+    float: right;
+    width: 40%;
+    padding-right: 5%;
+}
+
+#ability-button-row button {
+    padding: 0 20px;
+}
+
+#ttp-tests {
+    width: 100%;
+}

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -771,3 +771,23 @@ table.dataTable input[type=text] {
     height: 25px;
     border: 2px solid var(--navbar-color);
 }
+
+/* Adversaries/Profiles */
+
+.adversary-sidebar-option {
+    padding: 20px 0 0;
+}
+
+#profile-existing-name {
+    margin: 0 0 20px;
+}
+
+#adversary-add {
+    display: none;
+}
+
+#adversary-content {
+    flex: 75%;
+    visibility: hidden;
+    text-align: left;
+}

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -792,22 +792,71 @@ table.dataTable input[type=text] {
     text-align: left;
 }
 
-#ability-manager .ability-fields {
+#phase-modal .container > .column {
+    flex: 100%;
+}
+
+#ability-search-filter {
+    width: 60%;
+}
+
+#reset-ability-modal-button {
+    width: 115px;
+    height: 30px;
+    padding-top: 8px;
+    color: black;
+    background-color: firebrick;
+}
+
+#ability-manager-fields {
     flex: 60%;
 }
 
-#ability-manager .ability-additional-fields {
-    flex: 40%;
-}
-
-#ability-manager table {
+#ability-manager-fields table {
     border-spacing: 2px;
     width: 100%;
 }
 
-
-#ability-manager table td:nth-child(1) {
+#ability-manager-fields table td:nth-child(1) {
     width: 8em;
+    font-weight: bold;
+}
+
+#ability-manager-additional {
+    flex: 40%;
+}
+
+#ability-manager-additional #row-simple {
+    display: flex;
+    overflow: hidden;
+}
+
+#ability-manager-additional .column {
+    float: left;
+    flex: 20%;
+    margin: 0px;
+}
+
+#ability-manager-additional .column p {
+    padding-top: 4px;
+    text-align: center;
+    color: white;
+}
+
+#ability-manager-additional .column img {
+    cursor: pointer;
+}
+
+#ability-additional-info {
+    display: flex;
+    margin-top: 1em;
+}
+
+#ability-additional-info div {
+    display: flex;
+    flex: 5em;
+    justify-content: center;
+    align-items: center;
     font-weight: bold;
 }
 

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -186,3 +186,7 @@ function openNav() {
 function closeNav() {
   document.getElementById("mySidenav").style.width = "0";
 }
+
+function isUuid(data) {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89AB][0-9a-f]{3}-[0-9a-f]{12}$/i.test(data);
+}

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -186,7 +186,3 @@ function openNav() {
 function closeNav() {
   document.getElementById("mySidenav").style.width = "0";
 }
-
-function isUuid(data) {
-    return /^[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89AB][0-9a-f]{3}-[0-9a-f]{12}$/i.test(data);
-}

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -47,7 +47,7 @@
 <div id="phase-modal" class="modal">
     <form class="modal-content">
         <div class="container section-profile row ability-viewer modal-box">
-            <div class="column" style="flex:100%;">
+            <div class="column">
                 <select id="ability-tactic-filter" onchange="populateTechniques('phase-modal', exploits);">
                     <option disabled selected>Choose a tactic</option>
                     {% for tactic in tactics %}
@@ -60,11 +60,11 @@
                 <select id="ability-ability-filter" onchange="showAbility('phase-modal', exploits)">
                     <option disabled selected>0 abilities</option>
                 </select>
-                <input id="ability-search-filter" style="width:60%;" type="text" placeholder="Search for abilities..." onkeyup="searchAbilities('phase-modal', exploits);">
-                <button id="reset-ability-modal-button" type="button" class="atomic-button" style="width:115px;height:30px;padding-top:8px;color:black;background-color:firebrick" onclick="clearPhaseModal()">Reset Fields</button>
+                <input id="ability-search-filter" type="text" placeholder="Search for abilities..." onkeyup="searchAbilities('phase-modal', exploits);">
+                <button id="reset-ability-modal-button" type="button" class="atomic-button" onclick="clearPhaseModal()">Reset Fields</button>
                 <br><br>
                 <div id="ability-manager" class="ability-attack row-simple">
-                    <div class="column ability-fields">
+                    <div id="ability-manager-fields" class="column">
                         <table frame=void rules=rows>
                             <tr>
                                 <td>id:</td>
@@ -93,40 +93,39 @@
                         </table>
 
                     </div>
-                    <div class="column ability-additional-fields">
-                        <div id="ability-modifier-buttons row-simple" style="overflow: hidden; display: flex">
-                            <div class="column" style="float: left; margin: 0px; flex:20%">
+                    <div id="ability-manager-additional" class="column">
+                        <div id="row-simple">
+                            <div class="column">
                                 <div>
-                                    <img onclick="freshId()" style="cursor:pointer" src="/gui/img/recycle.png">
-                                    <p style="color:white;text-align: center; padding-top: 4px" onclick="freshId()">generate new id</p>
+                                    <img onclick="freshId()" src="/gui/img/recycle.png">
+                                    <p onclick="freshId()">generate new id</p>
                                 </div>
                             </div>
-                            <div class="column" style="float: left; margin: 0px; flex:20%">
+                            <div class="column">
                                 <div>
-                                    <img onclick="addExecutorBlock()" style="cursor:pointer" src="/gui/img/executor.png">
-                                    <p style="color:white;text-align: center; padding-top: 4px" onclick="addExecutorBlock()">add executor</p>
+                                    <img onclick="addExecutorBlock()" src="/gui/img/executor.png">
+                                    <p onclick="addExecutorBlock()">add executor</p>
                                 </div>
                             </div>
-                            <div class="column" style="float: left; margin: 0px; flex:20%">
+                            <div class="column">
                                 <div>
-                                    <label for="uploadPayloadFile"><img style="cursor:pointer" src="/gui/img/payload.png"></label>
+                                    <label for="uploadPayloadFile"><img src="/gui/img/payload.png"></label>
                                     <form id="uploadPayloadForm">
                                        <label id="uploadFileLabel" for="uploadPayloadFile"><br><br>upload payload</label>
                                        <input type="file" id="uploadPayloadFile" style="display: none">
                                     </form>
                                 </div>
                             </div>
-                            <div class="column" style="float: left; margin: 0px; flex:20%">
+                            <div class="column">
                                 <div>
-                                    <img onclick="addAdditionalInfo(); checkAbilityButtons()" style="cursor:pointer" src="/gui/img/additional-fields.png">
-                                    <p style="color:white;text-align: center; padding-top: 4px" onclick="addAdditionalInfo(); checkAbilityButtons()">add info</p>
+                                    <img onclick="addAdditionalInfo(); checkAbilityButtons()" src="/gui/img/additional-fields.png">
+                                    <p onclick="addAdditionalInfo(); checkAbilityButtons()">add info</p>
                                 </div>
                             </div>
                         </div>
-                        <br>
-                        <div id="ability-additional-info" style="display: flex">
-                            <div style="flex: 15%; display: flex; justify-content: center; align-items: center;"><b>Info:</b></div>
-                            <table id="additional-info-table" frame=void rules=rows style="flex:85%">
+                        <div id="ability-additional-info" style="display: none">
+                            <div>info:</div>
+                            <table id="additional-info-table" frame=void rules=rows>
                                 <tbody>
                                 </tbody>
                             </table>

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -64,36 +64,36 @@
                 <button id="reset-ability-modal-button" type="button" class="atomic-button" style="width:115px;height:30px;padding-top:8px;color:black;background-color:firebrick" onclick="clearPhaseModal()">Reset Fields</button>
                 <br><br>
                 <div id="ability-manager" class="ability-attack row-simple">
-                    <div class="column" style="flex:60%">
-                        <table frame=void rules=rows style="border-spacing:2px;width:100%">
+                    <div class="column ability-fields">
+                        <table frame=void rules=rows>
                             <tr>
-                                <td style="width:10%"><b>id:</b></td>
-                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" onkeyup="checkAbilityButtons()"></td>
+                                <td>id:</td>
+                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" onkeyup="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
-                                <td style="width:10%"><b>name:</b></td>
-                                <td><input type="text" id="ability-name" placeholder="Name (required)" onkeyup="checkAbilityButtons()"></td>
+                                <td>name:</td>
+                                <td><input type="text" id="ability-name" placeholder="Name (required)" onkeyup="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
-                                <td style="width:10%"><b>description:</b></td>
-                                <td><input type="text" id="ability-description" placeholder="Description (required)" onkeyup="checkAbilityButtons()"></td>
+                                <td>description:</td>
+                                <td><input type="text" id="ability-description" placeholder="Description (required)" onkeyup="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
-                                <td style="width:10%"><b>tactic:</b></td>
-                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic (required)" onkeyup="checkAbilityButtons()"></td>
+                                <td>tactic:</td>
+                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic (required)" onkeyup="checkAbilityButtons()" /></td>
                             <tr>
                             <tr>
-                                <td style="width:10%"><b>technique id:</b></td>
-                                <td><input type="text" id="ability-tech-id" placeholder="ATT&CK technique ID"></td>
+                                <td>technique id:</td>
+                                <td><input type="text" id="ability-tech-id" placeholder="ATT&CK technique ID" /></td>
                             </tr>
                             <tr>
-                                <td style="width:10%"><b>technique:</b></td>
-                                <td><input type="text" id="ability-tech-name" placeholder="ATT&CK technique name"></td>
+                                <td>technique:</td>
+                                <td><input type="text" id="ability-tech-name" placeholder="ATT&CK technique name" /></td>
                             </tr>
                         </table>
 
                     </div>
-                    <div class="column" style="flex:40%">
+                    <div class="column ability-additional-fields">
                         <div id="ability-modifier-buttons row-simple" style="overflow: hidden; display: flex">
                             <div class="column" style="float: left; margin: 0px; flex:20%">
                                 <div>

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -135,7 +135,7 @@
                 </div>
                 <div id="ability-button-row" class="row-simple">
                     <button id="ability-save" type="button" class="button-notready atomic-button" onclick="saveAbility()">Save</button>
-                    <button id="ability-add-to-adv" type="button" class="button-notready atomic-button" onclick="addAbilityToPhase()">Add to Adversary</button>
+                    <button id="ability-add-to-adv" type="button" class="button-notready atomic-button" onclick="saveAbility(true)">Add to Adversary</button>
                 </div>
                 <div class="row-simple">
                     <ul id="ttp-tests"></ul>
@@ -423,14 +423,18 @@
 
         // Platform / executor / command missing data
         if (valid) {
-            $('#ttp-tests > li').each(function() {
-                let platform = $(this).find('#ability-platform').val();
-                let executor = $(this).find('#ability-executor').val();
-                let command = $(this).find('#ability-command').val();
-                if (!command || !executor || !platform) {
-                    valid = false;
-                }
-            });
+            if ($('#ttp-tests > li').length) {
+                $('#ttp-tests > li').each(function() {
+                    let platform = $(this).find('#ability-platform').val();
+                    let executor = $(this).find('#ability-executor').val();
+                    let command = $(this).find('#ability-command').val();
+                    if (!command || !executor || !platform) {
+                        valid = false;
+                    }
+                });
+            } else {
+                valid = false;
+            }
         }
 
         // Additional info missing data
@@ -449,7 +453,7 @@
         return valid;
     }
 
-    function saveAbility() {
+    function saveAbility(addToAdversary=false) {
         if (!validateAbility()) {
             warn('Missing required data!');
             stream('Missing required data!');
@@ -500,10 +504,25 @@
         data['tactic'] = $('#ability-tactic-name').val();
         data['technique'] = {'attack_id': $('#ability-tech-id').val(), 'name': $('#ability-tech-name').val()};
         data['platforms'] = platforms;
-        restRequest('PUT', data, saveAbilityCallback);
+
+        $.ajax({
+           url: '/api/rest',
+           type: 'PUT',
+           contentType: 'application/json',
+           data: JSON.stringify(data),
+           success: function(data, status, options) {
+               saveAbilityCallback(data, addToAdversary);
+           },
+           error: function (xhr, ajaxOptions, thrownError) {
+               stream(thrownError);
+           }
+        });
     }
 
-    function saveAbilityCallback(data) {
+    function saveAbilityCallback(data, addToAdversary=false) {
+        if ($('#ability-identifier').val() === '') {
+            $('#ability-identifier').val(data[0].ability_id);
+        }
         let options = $('#phase-modal').find('#ability-ability-filter');
         let ability = options.find(':selected').data('ability');
         if (!ability || (ability && ability.ability_id != data[0].ability_id)) {
@@ -523,6 +542,18 @@
             loadAdversary();
         }
         stream('Ability saved!');
+
+        if (addToAdversary) {
+            addAbilityToAdversary();
+        }
+    }
+
+    function addAbilityToAdversary() {
+        let ability = $('#phase-modal').find('#ability-ability-filter').find(":selected").data('ability');
+        let abilityBox = buildAbility(ability);
+        g_grid.add(abilityBox[0]);
+        clearPhaseModal();
+        hidePhaseModal();
     }
 
     function appendToSelect(field, identifier, value, optionId) {
@@ -815,13 +846,9 @@
     }
 
     function clearPhaseModal() {
-        $('#ability-tactic-filter option:selected').removeAttr('selected');
-        $('#ability-tactic-filter option:first').remove();
-        $('#ability-tactic-filter').prepend('<option disabled selected>Choose a tactic</option>');
-        $('#ability-technique-filter').empty();
-        $('#ability-technique-filter').append('<option disabled selected>Choose a technique</option>');
-        $('#ability-ability-filter').empty();
-        $('#ability-ability-filter').append('<option disabled selected>0 abilities</option>');
+        $('#ability-tactic-filter option:first').prop('selected', true);
+        $('#ability-technique-filter').empty().append('<option disabled="disabled" selected>Choose a technique</option>');
+        $('#ability-ability-filter').empty().append('<option disabled="disabled" selected>0 abilities</option>');
         $('#ability-identifier').val('');
         $('#ability-name').val('');
         $('#ability-description').val('');
@@ -913,15 +940,6 @@
     function clearObjective() {
         $('#objective-select')[0].value = '';
         $('#objective-img')[0].style="display:none";
-    }
-
-    function addAbilityToPhase() {
-        saveAbility();
-        let ability = $('#phase-modal').find('#ability-ability-filter').find(":selected").data('ability');
-        let abilityBox = buildAbility(ability);
-        g_grid.add(abilityBox[0]);
-        clearPhaseModal();
-        hidePhaseModal();
     }
 
     function deleteProfile(){

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -134,10 +134,12 @@
                     </div>
                     <br><br>
                 </div>
-                <ul id="ttp-tests"></ul>
-                <div style="float:right;">
+                <div id="ability-button-row" class="row-simple">
                     <button id="ability-save" type="button" class="button-notready atomic-button" onclick="saveAbility()">Save</button>
                     <button id="ability-add-to-adv" type="button" class="button-notready atomic-button" onclick="addAbilityToPhase()">Add to Adversary</button>
+                </div>
+                <div class="row-simple">
+                    <ul id="ttp-tests"></ul>
                 </div>
             </div>
             <div class="imgcontainer">

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -33,11 +33,11 @@
     </div>
     <div id="adversary-content" class="column adversary-header">
         <div id="row">
-            <input id="profile-goal" type="text" placeholder="enter a profile name (required)" onkeyup="checkAdversaryButtons()">
+            <input id="profile-goal" type="text" placeholder="enter a profile name (required)" oninput="checkAdversaryButtons()">
             <img id='objective-img' style="display:none" src="/gui/img/compass.png" onclick="showObjectiveModal()">
         </div>
         <input id="objective-select" type="text" style="display:none" disabled>
-        <input id="profile-description" type="text" placeholder="enter a profile description (required)" onkeyup="checkAdversaryButtons()">
+        <input id="profile-description" type="text" placeholder="enter a profile description (required)" oninput="checkAdversaryButtons()">
         <br><br>
         <div id="dummy"></div>
     </div>
@@ -60,7 +60,7 @@
                 <select id="ability-ability-filter" onchange="showAbility('phase-modal', exploits)">
                     <option disabled selected>0 abilities</option>
                 </select>
-                <input id="ability-search-filter" type="text" placeholder="Search for abilities..." onkeyup="searchAbilities('phase-modal', exploits);">
+                <input id="ability-search-filter" type="text" placeholder="Search for abilities..." oninput="searchAbilities('phase-modal', exploits);">
                 <button id="reset-ability-modal-button" type="button" class="atomic-button" onclick="clearPhaseModal()">Reset Fields</button>
                 <br><br>
                 <div id="ability-manager" class="ability-attack row-simple">
@@ -68,19 +68,19 @@
                         <table frame=void rules=rows>
                             <tr>
                                 <td>id:</td>
-                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" onkeyup="checkAbilityButtons()" /></td>
+                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" oninput="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
                                 <td>name:</td>
-                                <td><input type="text" id="ability-name" placeholder="Name (required)" onkeyup="checkAbilityButtons()" /></td>
+                                <td><input type="text" id="ability-name" placeholder="Name (required)" oninput="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
                                 <td>description:</td>
-                                <td><input type="text" id="ability-description" placeholder="Description (required)" onkeyup="checkAbilityButtons()" /></td>
+                                <td><input type="text" id="ability-description" placeholder="Description (required)" oninput="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
                                 <td>tactic:</td>
-                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic (required)" onkeyup="checkAbilityButtons()" /></td>
+                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic (required)" oninput="checkAbilityButtons()" /></td>
                             <tr>
                             <tr>
                                 <td>technique id:</td>
@@ -230,7 +230,7 @@
 
 <table id="additional-info-row-template-holder" style="display:none">
     <tr id="additional-info-template">
-        <td><input type="text" class="additional-key" style="text-align: right; margin-left: -2px; padding-right: 22px;" placeholder="key" onkeyup="checkAbilityButtons()"></td>
+        <td><input type="text" class="additional-key" style="text-align: right; margin-left: -2px; padding-right: 22px;" placeholder="key" oninput="checkAbilityButtons()"></td>
         <td><b>:</b></td>
         <td><input type="text" class="additional-value" placeholder="value"></td>
         <td><div class="ability-remove">
@@ -275,7 +275,7 @@
         </tr>
         <tr>
             <td style="width:10%"><b>command:</b></td>
-            <td><textarea id="ability-command" spellcheck="false" contenteditable="true" placeholder="Enter a command to execute" onkeyup="checkAbilityButtons()"></textarea></td>
+            <td><textarea id="ability-command" spellcheck="false" contenteditable="true" placeholder="Enter a command to execute" oninput="checkAbilityButtons()"></textarea></td>
         </tr>
         <tr>
             <td style="width:10%"><b>cleanup:</b></td>
@@ -925,6 +925,7 @@
 
     function freshId(){
         $('#ability-identifier').val(uuidv4());
+        //checkAbilityButtons();
     }
 
     function uploadPayload() {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -68,7 +68,7 @@
                         <table frame=void rules=rows>
                             <tr>
                                 <td>id:</td>
-                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" oninput="checkAbilityButtons()" /></td>
+                                <td><input type="text" id="ability-identifier" placeholder="Unique identifier (default UUID)" oninput="checkAbilityButtons()" /></td>
                             </tr>
                             <tr>
                                 <td>name:</td>
@@ -389,17 +389,18 @@
 
     function validateAbility() {
         // Enable Save and Add to Adversary buttons if the ability has:
-        // - No ID, or GUID ID
+        // - No ID, or ID only contains valid characters
         // - Name
         // - Description
-        // - Tactic is not empty and only contains alphanumeric and hyphens
+        // - Tactic is not empty and only contains valid characters
         // - Platform / executor / command
         // - Unique, non-empty keys in additional info
         let valid = true;
+        let validator = /^[0-9a-z-_]+$/i;
 
         // Validate ID
         let abilityId = $('#ability-identifier').val();
-        if (abilityId.length !== 0 && !isUuid(abilityId)) {
+        if (abilityId.length !== 0 && !(validator.test(abilityId))) {
             valid = false;
         }
 
@@ -416,7 +417,7 @@
         // Validate tactic
         if (valid) {
             let abilityTactic = $('#ability-tactic-name').val();
-            if (abilityId.length !== 0 && !(/^[0-9a-z\-]+$/i.test(abilityTactic))) {
+            if (abilityTactic.length !== 0 && !(validator.test(abilityTactic))) {
                 valid = false;
             }
         }

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -530,16 +530,15 @@
             appendAbilityToList('phase-modal', a[0]);
             options.val(a[0].name);
         }
-        var $to_replace = -1;
+        var to_replace = -1;
         $.each(exploits, function(i, ab) {
             if (ab.ability_id === data[0].ability_id) {
-                $to_replace = i;
+                to_replace = i;
                 return false;
             }
         });
-        if ($to_replace != -1) {
-            exploits[$to_replace] = data[0];
-            loadAdversary();
+        if (to_replace != -1) {
+            exploits[to_replace] = data[0];
         }
         stream('Ability saved!');
 

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -242,7 +242,7 @@
 
 <li id="ttp-template" class="ttp-template" style="display: none">
     <div class="dotted">
-        <b><p style="color:white" onclick="removeBlock($(this)); checkAbilityButtons()">remove</p></b>
+        <p onclick="$(this).closest('li').remove(); checkAbilityButtons()">&#x274C;</p>
     </div>
     <table frame=void rules=rows style="border-spacing:5px;width:100%">
         <tr>
@@ -525,10 +525,6 @@
             loadAdversary();
         }
         alert('Ability saved!');
-    }
-
-    function removeBlock(element){
-        element.closest('li').remove();
     }
 
     function appendToSelect(field, identifier, value, optionId) {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -382,9 +382,9 @@
     function checkAbilityButtons() {
         // Enable / Disable Save and Add to Adversary buttons
         let valid = validateAbility()
-        console.log(valid);
+        let uniqueAbility = ($('#tempPhase1').find('#' + $('#ability-identifier').val()).length === 0);
         validateFormState(valid, '#ability-save');
-        validateFormState(valid, '#ability-add-to-adv');
+        validateFormState((valid && uniqueAbility), '#ability-add-to-adv');
     }
 
     function validateAbility() {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -381,8 +381,9 @@
 
     function checkAbilityButtons() {
         // Enable / Disable Save and Add to Adversary buttons
-        let valid = validateAbility()
-        let uniqueAbility = ($('#tempPhase1').find('#' + $('#ability-identifier').val()).length === 0);
+        let valid = validateAbility();
+        let uniqueAbility = ($('#ability-identifier').val() === "" ||
+                             $('#tempPhase1').find('#' + $('#ability-identifier').val()).length === 0);
         validateFormState(valid, '#ability-save');
         validateFormState((valid && uniqueAbility), '#ability-add-to-adv');
     }
@@ -500,12 +501,10 @@
         data['tactic'] = $('#ability-tactic-name').val();
         data['technique'] = {'attack_id': $('#ability-tech-id').val(), 'name': $('#ability-tech-name').val()};
         data['platforms'] = platforms;
-        $('#ability-save').text('WAIT...');
         restRequest('PUT', data, saveAbilityCallback);
     }
 
     function saveAbilityCallback(data) {
-        console.log(data);
         let options = $('#phase-modal').find('#ability-ability-filter');
         let ability = options.find(':selected').data('ability');
         if (!ability || (ability && ability.ability_id != data[0].ability_id)) {
@@ -524,7 +523,7 @@
             exploits[$to_replace] = data[0];
             loadAdversary();
         }
-        alert('Ability saved!');
+        stream('Ability saved!');
     }
 
     function appendToSelect(field, identifier, value, optionId) {
@@ -628,7 +627,7 @@
         }
         template.show();
         let phaseHeader = $('<h4 class="phase-headers"><span class="phase-title">Ordering</span>' +
-            '<span class="ability-add" onclick="showPhaseModal('+number+')">&#10010; add ability</span>'
+            '<span class="ability-add" onclick="showPhaseModal('+number+'); checkAbilityButtons()">&#10010; add ability</span>'
             +'<span class="ability-add" onclick="showProfileModal('+number+')" ' +
             'style="margin-right:5px;padding-right:5px;border-right:1px white solid;">&#10010; add adversary</span>' +
             '<span class="ability-add" onclick="showObjectiveModal()" ' +
@@ -918,6 +917,7 @@
     }
 
     function addAbilityToPhase() {
+        saveAbility();
         let ability = $('#phase-modal').find('#ability-ability-filter').find(":selected").data('ability');
         let abilityBox = buildAbility(ability);
         g_grid.add(abilityBox[0]);

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -523,32 +523,53 @@
         if ($('#ability-identifier').val() === '') {
             $('#ability-identifier').val(data[0].ability_id);
         }
-        let options = $('#phase-modal').find('#ability-ability-filter');
-        let ability = options.find(':selected').data('ability');
-        if (!ability || (ability && ability.ability_id != data[0].ability_id)) {
-            let a = addPlatforms([data[0]]);
-            appendAbilityToList('phase-modal', a[0]);
-            options.val(a[0].name);
+        let abilitySelector = $('#phase-modal').find('#ability-ability-filter');
+        let selectedAbility = abilitySelector.find(':selected').data('ability');
+
+        let newAbility = addPlatforms([data[0]])[0];
+        
+        if (!selectedAbility || selectedAbility.ability_id != newAbility.ability_id) {
+            appendAbilityToList('phase-modal', newAbility);
+        } else {
+            abilitySelector.find(':selected')
+                .attr('value', newAbility.name)
+                .data('ability', newAbility)
+                .text(newAbility.name);
         }
-        var to_replace = -1;
+        abilitySelector.val(newAbility.name);
+
+        var $to_replace = -1;
         $.each(exploits, function(i, ab) {
-            if (ab.ability_id === data[0].ability_id) {
-                to_replace = i;
+            if (ab.ability_id === newAbility.ability_id) {
+                $to_replace = i;
                 return false;
             }
         });
-        if (to_replace != -1) {
-            exploits[to_replace] = data[0];
+        if ($to_replace != -1) {
+            exploits[$to_replace] = newAbility;
         }
         stream('Ability saved!');
 
         if (addToAdversary) {
             addAbilityToAdversary();
+        } else {
+            replaceAbilityInAdversary();
+        }
+    }
+
+    function replaceAbilityInAdversary() {
+        let ability = $('#phase-modal').find('#ability-ability-filter').find(':selected').data('ability');
+        let abilityItem = $(g_grid.getElement()).children('#' + ability.ability_id);
+        if (abilityItem.length) {
+            let abilityIndex = parseInt($(abilityItem).find('.ability-order').text()) - 1;
+            g_grid.remove(g_grid.getItems(abilityIndex), { removeElements: true });
+            let abilityBox = buildAbility(ability);
+            g_grid.add(abilityBox[0], { index: abilityIndex });
         }
     }
 
     function addAbilityToAdversary() {
-        let ability = $('#phase-modal').find('#ability-ability-filter').find(":selected").data('ability');
+        let ability = $('#phase-modal').find('#ability-ability-filter').find(':selected').data('ability');
         let abilityBox = buildAbility(ability);
         g_grid.add(abilityBox[0]);
         clearPhaseModal();

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -925,7 +925,7 @@
 
     function freshId(){
         $('#ability-identifier').val(uuidv4());
-        //checkAbilityButtons();
+        checkAbilityButtons();
     }
 
     function uploadPayload() {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -768,7 +768,7 @@
     }
 
     function filterExecutors(elem) {
-        let ttpTable = $(elem).parent().parent().parent();
+        let ttpTable = $(elem).closest('table');
         let platform = $(elem).val();
         let executorSelect = $(ttpTable).find('#ability-executor');
         $(executorSelect).empty();

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -11,31 +11,33 @@
           <div class="slider round"><span class="on">ADD</span><span class="off">VIEW</span></div>
         </label>
       </div>
-      <br>
       <p class="section-description">
           Profiles are collections of ATT&CK TTPs, designed to create specific effects on a host or network. Profiles
           can be used for offensive or defensive use cases.
       </p>
-        <br>
-      <div id="viewAdversary">
-          <select id="profile-existing-name" style="margin-top:-15px" onchange="loadAdversary();">
-            <option value="" disabled selected>Select an existing profile</option>
-            {% for adv in adversaries %}
-                <option id="adversary-{{ adv.adversary_id}}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
-            {% endfor %}}
-          </select>
+      <div id="adversary-view" class="adversary-sidebar-option">
+        <select id="profile-existing-name" onchange="loadAdversary();">
+          <option value="" disabled selected>Select an existing profile</option>
+          {% for adv in adversaries %}
+              <option id="adversary-{{ adv.adversary_id}}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
+          {% endfor %}}
+        </select>
       </div>
-      <button id="advNewBtn" type="button" class="button-success atomic-button" onclick="saveAdversary()">Save</button>
+      <button id="adversary-save-button" type="button" class="button-notready atomic-button" onclick="saveAdversary()">Save</button>
       <hr>
-      <button type="button" class="button-success atomic-button" onclick="deleteProfile()">Delete profile</button>
+      <button id="adversary-delete-button" type="button" class="button-notready atomic-button" onclick="deleteProfile()">Delete</button>
+
+      <div id="adversary-add" class="adversary-sidebar-option">
+
+      </div>
     </div>
-    <div id="phases" class="column adversary-header" style="flex:75%;text-align: left">
+    <div id="adversary-content" class="column adversary-header">
         <div id="row">
-            <input id="profile-goal" type="text" placeholder="enter a profile name">
+            <input id="profile-goal" type="text" placeholder="enter a profile name (required)" onkeyup="checkAdversaryButtons()">
             <img id='objective-img' style="display:none" src="/gui/img/compass.png" onclick="showObjectiveModal()">
         </div>
         <input id="objective-select" type="text" style="display:none" disabled>
-        <input id="profile-description" type="text" placeholder="enter a profile description">
+        <input id="profile-description" type="text" placeholder="enter a profile description (required)" onkeyup="checkAdversaryButtons()">
         <br><br>
         <div id="dummy"></div>
     </div>
@@ -308,13 +310,41 @@
     })
 
     function toggleAdversaryView() {
-        $('#profile-existing-name option:eq(0)').prop('selected', true);
-        $('#profile-goal').val('');
-        $('#profile-description').val('');
-        $('.tempPhase').remove();
-        $('.phase-headers').remove();
-        loadAtomicOrder([]);
-        clearObjective();
+        // Change Add/View sidebar
+        $('#adversary-view').toggle();
+        $('#adversary-add').toggle();
+
+        // Clear content if switching to "Add"
+        if ($('#adversary-add').is(':visible')) {
+            clearAdversaryContent();
+        }
+
+        // Set content visibility and sidebar buttons enable
+        checkAdversaryContent();
+        checkAdversaryButtons();
+    }
+
+    function checkAdversaryContent() {
+        if ($('#adversary-add').is(':visible') || $('#profile-existing-name').val() !== null) {
+            $('#adversary-content').css('visibility', 'visible');
+        } else {
+            $('#adversary-content').css('visibility', 'hidden');
+        }
+    }
+
+    function checkAdversaryButtons() {
+        validateFormState(($('#profile-goal').val() !== '' && $('#profile-description').val() !== ''), '#adversary-save-button');
+        validateFormState(($('#profile-existing-name').val()), '#adversary-delete-button');
+    }
+
+    function clearAdversaryContent() {
+      $('#profile-existing-name option:eq(0)').prop('selected', true);
+      $('#profile-goal').val('');
+      $('#profile-description').val('');
+      $('.tempPhase').remove();
+      $('.phase-headers').remove();
+      loadAtomicOrder([]);
+      clearObjective();
     }
 
     function saveAdversary() {
@@ -338,9 +368,13 @@
 
     function saveAdversaryCallback(data) {
         stream('Adversary saved!');
-        appendToSelect('profile-existing-name', data[0].adversary_id, data[0].name, 'view-'+data[0].adversary_id);
+        appendToSelect('profile-existing-name', data[0].adversary_id, data[0].name, 'adversary-'+data[0].adversary_id);
         $('#profile-existing-name').val(data[0].adversary_id);
         appendToSelect('queueFlow', data[0].adversary_id, data[0].name, 'qflow-'+data[0].adversary_id);
+
+        if ($('#adversary-add').is(':visible')) {
+          $('#togBtnAdv').click();
+        }
     }
 
     function saveAbility() {
@@ -451,6 +485,8 @@
 
     function loadAdversaryCallback(data) {
         stream('Profiles contain abilities which will run in atomic order by default. It contains abilities, or TTPs.');
+
+        $('#adversary-content').css('visibility', 'visible');
         $('#profile-goal').val(data[0].name);
         $('#profile-description').val(data[0].description);
 
@@ -460,6 +496,8 @@
         $('#objective-existing')[0].value = data[0].objective.id;
         handleObjectiveSelection(data[0].objective.id);
         linkObjective();
+
+        checkAdversaryButtons();
     }
 
     function createMuuriGrid() {
@@ -707,8 +745,8 @@
     }
 
     function hidePhaseModal() {
-        $("body").off("keyup");
-        document.getElementById("phase-modal").style.display="none";
+        $('#phase-modal').hide();
+        $('#ability-search-filter').val('');
     }
 
     function clearPhaseModal() {
@@ -822,8 +860,10 @@
 
     function deleteProfile(){
         function deleteCallback(data){
-            $('#adversary-'+adversary_id).remove();
-            toggleAdversaryView();
+            $('#adversary-' + adversary_id).remove();
+            clearAdversaryContent();
+            checkAdversaryContent();
+            checkAdversaryButtons();
             stream(data);
         }
         let adversary_id = $('#profile-existing-name').val();

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -68,19 +68,19 @@
                         <table frame=void rules=rows style="border-spacing:2px;width:100%">
                             <tr>
                                 <td style="width:10%"><b>id:</b></td>
-                                <td><input type="text" id="ability-identifier" placeholder="Unique identifier"></td>
+                                <td><input type="text" id="ability-identifier" placeholder="Unique UUID identifier" onkeyup="checkAbilityButtons()"></td>
                             </tr>
                             <tr>
                                 <td style="width:10%"><b>name:</b></td>
-                                <td><input type="text" id="ability-name" placeholder="Name"></td>
+                                <td><input type="text" id="ability-name" placeholder="Name (required)" onkeyup="checkAbilityButtons()"></td>
                             </tr>
                             <tr>
                                 <td style="width:10%"><b>description:</b></td>
-                                <td><input type="text" id="ability-description" placeholder="Description"></td>
+                                <td><input type="text" id="ability-description" placeholder="Description (required)" onkeyup="checkAbilityButtons()"></td>
                             </tr>
                             <tr>
                                 <td style="width:10%"><b>tactic:</b></td>
-                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic"></td>
+                                <td><input type="text" id="ability-tactic-name" placeholder="ATT&CK tactic (required)" onkeyup="checkAbilityButtons()"></td>
                             <tr>
                             <tr>
                                 <td style="width:10%"><b>technique id:</b></td>
@@ -118,8 +118,8 @@
                             </div>
                             <div class="column" style="float: left; margin: 0px; flex:20%">
                                 <div>
-                                    <img onclick="addAdditionalInfo()" style="cursor:pointer" src="/gui/img/additional-fields.png">
-                                    <p style="color:white;text-align: center; padding-top: 4px" onclick="addAdditionalInfo()">add info</p>
+                                    <img onclick="addAdditionalInfo(); checkAbilityButtons()" style="cursor:pointer" src="/gui/img/additional-fields.png">
+                                    <p style="color:white;text-align: center; padding-top: 4px" onclick="addAdditionalInfo(); checkAbilityButtons()">add info</p>
                                 </div>
                             </div>
                         </div>
@@ -136,8 +136,8 @@
                 </div>
                 <ul id="ttp-tests"></ul>
                 <div style="float:right;">
-                    <button id="ability-save" type="button" class="button-success atomic-button" onclick="saveAbility()">Save</button>
-                    <button type="button" class="button-success atomic-button" onclick="addAbilityToPhase()">Add to Adversary</button>
+                    <button id="ability-save" type="button" class="button-notready atomic-button" onclick="saveAbility()">Save</button>
+                    <button id="ability-add-to-adv" type="button" class="button-notready atomic-button" onclick="addAbilityToPhase()">Add to Adversary</button>
                 </div>
             </div>
             <div class="imgcontainer">
@@ -229,7 +229,7 @@
 
 <table id="additional-info-row-template-holder" style="display:none">
     <tr id="additional-info-template">
-        <td><input type="text" class="additional-key" style="text-align: right; margin-left: -2px; padding-right: 22px;" placeholder="key"></td>
+        <td><input type="text" class="additional-key" style="text-align: right; margin-left: -2px; padding-right: 22px;" placeholder="key" onkeyup="checkAbilityButtons()"></td>
         <td><b>:</b></td>
         <td><input type="text" class="additional-value" placeholder="value"></td>
         <td><div class="ability-remove">
@@ -240,13 +240,13 @@
 
 <li id="ttp-template" class="ttp-template" style="display: none">
     <div class="dotted">
-        <b><p style="color:white" onclick="removeBlock($(this))">remove</p></b>
+        <b><p style="color:white" onclick="removeBlock($(this)); checkAbilityButtons()">remove</p></b>
     </div>
     <table frame=void rules=rows style="border-spacing:5px;width:100%">
         <tr>
             <td style="width:10%"><b>platform:</b></td>
             <td>
-              <select id="ability-platform" onchange="filterExecutors(this)">
+              <select id="ability-platform" onchange="filterExecutors(this); checkAbilityButtons()">
                 <option value="" disabled selected>Select a platform</option>
                     {% for platform, executors in platforms.items() %}
                         <option value="{{ platform }}">{{ platform }}</option>
@@ -257,7 +257,7 @@
         <tr>
             <td style="width:10%"><b>executor:</b></td>
             <td>
-              <select id="ability-executor">
+              <select id="ability-executor" onchange="checkAbilityButtons()">
                 <option value="" disabled selected>Select an executor</option>
               </select>
             </td>
@@ -274,7 +274,7 @@
         </tr>
         <tr>
             <td style="width:10%"><b>command:</b></td>
-            <td><textarea id="ability-command" spellcheck="false" contenteditable="true" placeholder="Enter a command to execute"></textarea></td>
+            <td><textarea id="ability-command" spellcheck="false" contenteditable="true" placeholder="Enter a command to execute" onkeyup="checkAbilityButtons()"></textarea></td>
         </tr>
         <tr>
             <td style="width:10%"><b>cleanup:</b></td>
@@ -377,19 +377,93 @@
         }
     }
 
+    function checkAbilityButtons() {
+        // Enable / Disable Save and Add to Adversary buttons
+        let valid = validateAbility()
+        console.log(valid);
+        validateFormState(valid, '#ability-save');
+        validateFormState(valid, '#ability-add-to-adv');
+    }
+
+    function validateAbility() {
+        // Enable Save and Add to Adversary buttons if the ability has:
+        // - No ID, or GUID ID
+        // - Name
+        // - Description
+        // - Tactic is not empty and only contains alphanumeric and hyphens
+        // - Platform / executor / command
+        // - Unique, non-empty keys in additional info
+        let valid = true;
+
+        // Validate ID
+        let abilityId = $('#ability-identifier').val();
+        if (abilityId.length !== 0 && !isUuid(abilityId)) {
+            valid = false;
+        }
+
+        // Ability details missing data
+        if (valid) {
+            if (
+                $('#ability-name').val().length === 0
+                || $('#ability-description').val().length === 0
+            ) {
+                valid = false;
+            }
+        }
+
+        // Validate tactic
+        if (valid) {
+            let abilityTactic = $('#ability-tactic-name').val();
+            if (abilityId.length !== 0 && !(/^[0-9a-z\-]+$/i.test(abilityTactic))) {
+                valid = false;
+            }
+        }
+
+        // Platform / executor / command missing data
+        if (valid) {
+            $('#ttp-tests > li').each(function() {
+                let platform = $(this).find('#ability-platform').val();
+                let executor = $(this).find('#ability-executor').val();
+                let command = $(this).find('#ability-command').val();
+                if (!command || !executor || !platform) {
+                    valid = false;
+                }
+            });
+        }
+
+        // Additional info missing data
+        if (valid) {
+            let additionalInfo = {};
+            $('#ability-additional-info').find('#additional-info-table tr').each(function() {
+                let key = $(this).find('.additional-key').val();
+                if (key !== '' && !(key in additionalInfo)) {
+                    additionalInfo[key] = $(this).find('.additional-value').val();
+                } else {
+                    valid = false;
+                }
+            });
+        }
+
+        return valid;
+    }
+
     function saveAbility() {
-        let name = $('#ability-name').val();
-        if(!name){ warn('Please enter an ability name!'); return; }
-        let description = $('#ability-description').val();
-        if(!description){ warn('Please enter a description!'); return; }
+        if (!validateAbility()) {
+            warn('Missing required data!');
+            stream('Missing required data!');
+            return;
+        }
 
         let data = {};
         let platforms = {};
-        let invalid = false;
+
+        let name = $('#ability-name').val();
+        let description = $('#ability-description').val();
+
         $('#ttp-tests > li').each(function() {
             let platform = $(this).find('#ability-platform').val();
 
-            if(platforms[platform] === undefined) {
+            if (platforms[platform] === undefined) {
                 platforms[platform] = {};
             }
 
@@ -399,33 +473,24 @@
             let cleanup = $(this).find('#ability-cleanup').val();
             let timeout = $(this).find('#ability-timeout').val();
 
-            if(!command || !executor || !platform) {
-                invalid = true;
-            }
             let ex = {'command': command};
-            if(payloads) {
+            if (payloads) {
                 ex['payloads'] = payloads;
             }
-            if(cleanup) {
+            if (cleanup) {
                 ex['cleanup'] = cleanup;
             }
-            if(timeout) {
+            if (timeout) {
                 ex['timeout'] = parseInt(timeout);
             }
             platforms[platform][executor] = ex;
         });
         $('#ability-additional-info').find('#additional-info-table tr').each(function() {
             let key = $(this).find('.additional-key').val();
-            if (key !== '' && !(key in data)){
+            if (key !== '' && !(key in data)) {
                 data[key] = $(this).find('.additional-value').val();
-            } else {
-                invalid = true;
             }
         });
-        if(invalid) {
-            alert('Missing required data!');
-            return;
-        }
         data['index'] = 'abilities';
         data['id'] = $('#ability-identifier').val();
         data['name'] = name;
@@ -438,9 +503,10 @@
     }
 
     function saveAbilityCallback(data) {
+        console.log(data);
         let options = $('#phase-modal').find('#ability-ability-filter');
-        let ability = options.find(":selected").data('ability');
-        if((!ability) || (ability && ability.ability_id != data[0].ability_id)) {
+        let ability = options.find(':selected').data('ability');
+        if (!ability || (ability && ability.ability_id != data[0].ability_id)) {
             let a = addPlatforms([data[0]]);
             appendAbilityToList('phase-modal', a[0]);
             options.val(a[0].name);
@@ -460,7 +526,7 @@
     }
 
     function removeBlock(element){
-        element.parent().parent().parent().remove();
+        element.closest('li').remove();
     }
 
     function appendToSelect(field, identifier, value, optionId) {
@@ -697,6 +763,8 @@
                 payloads.multiSelect('select', ability.payloads);
             }
         });
+
+        checkAbilityButtons();
     }
 
     function filterExecutors(elem) {
@@ -729,6 +797,7 @@
                 $('#ability-additional-info').hide();
             }
             $(this).parent().parent().remove();
+            checkAbilityButtons();
         });
         return $table_row;
     }

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -526,7 +526,8 @@
         let abilitySelector = $('#phase-modal').find('#ability-ability-filter');
         let selectedAbility = abilitySelector.find(':selected').data('ability');
 
-        let newAbility = addPlatforms([data[0]])[0];
+        let abilityData = data[0];
+        let newAbility = addPlatforms([abilityData])[0];
         
         if (!selectedAbility || selectedAbility.ability_id != newAbility.ability_id) {
             appendAbilityToList('phase-modal', newAbility);
@@ -540,15 +541,30 @@
 
         var $to_replace = -1;
         $.each(exploits, function(i, ab) {
-            if (ab.ability_id === newAbility.ability_id) {
+            if (ab.ability_id === abilityData.ability_id) {
                 $to_replace = i;
                 return false;
             }
         });
         if ($to_replace != -1) {
-            exploits[$to_replace] = newAbility;
+            exploits[$to_replace] = abilityData;
+        } else {
+            exploits.push(abilityData);
         }
         stream('Ability saved!');
+
+        let tactics = $.map($('#ability-tactic-filter option'), function(option) {
+            if (option.value) {
+                return option.value;
+            }
+        });
+        if ($.inArray(newAbility.tactic, tactics) === -1) {
+            var newTactic = $('<option></option>')
+                .attr('value', newAbility.tactic)
+                .attr('data-tactic', newAbility.tactic)
+                .text(newAbility.tactic);
+            $('#ability-tactic-filter').append(newTactic);
+        }
 
         if (addToAdversary) {
             addAbilityToAdversary();


### PR DESCRIPTION
- Only allow saving if name an description are filled out by disabling the save button. The other popup which displays the "you need a description" error can end up somewhere else in the page, which is confusing.
- Adversary view content is hidden / visible depending on Add/View toggle and selected adversary.
- Saving a new adversary closes the "Add" content and opens the newly-created adversary in the "View" content. This prevents creating multiple adversaries if the save button is hit multiple times during creation.
- Add validation to the front and back end when saving an ability. Phase modal Save / Add to Adversary buttons require required fields, disabled in UI if not validated.
- Populate executors field when selecting an ability in the phase modal, introduced in https://github.com/mitre/caldera/commit/adbe4ba9f1fb106190e05240101e6db043459c03
- Moved "Save" and "Add to Adversary" buttons to the top of the form when adding abilities, adjusted text
- Changed "remove" to X in phase modal
- Prevent duplicate ability entries from being added to an adversary
- Saves on "Add to Adversary"