### PR TITLE
Agents now get added properly to operations with no specified group

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -138,5 +138,5 @@ class ContactService(ContactServiceInterface, BaseService):
         which the planner needs to be aware of.
         """
         for op in await self.get_service('data_svc').locate('operations', match=dict(finish=None)):
-            if op.group == agent.group or op.group is None:
+            if op.group == agent.group or not op.group:
                 await op.update_operation(self.get_services())


### PR DESCRIPTION
Before, when running an operation with no specified group (in order to include all agents), new agents would not get added to the operation.