### PR TITLE
Fix _check_reason_skipped() call

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -272,7 +272,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
             agent_ran = set([link.ability.display['ability_id'] for link in self.chain if link.paw == agent.paw])
             for ab in abilities_by_agent[agent.paw]['all_abilities']:
                 skipped = self._check_reason_skipped(agent=agent, ability=ab, agent_executors=agent_executors,
-                                                     op_facts=[f.display for f in self.all_facts()],
+                                                     op_facts=[f.trait for f in self.all_facts()],
                                                      state=self.state, agent_ran=agent_ran)
                 if skipped:
                     if agent_skipped[skipped['ability_id']]:


### PR DESCRIPTION
The function would check variable names in the command against the full
dictionary display of the fact rather than just the name. This fixes it
so the report will correctly give the cause of skippage. For example, I
had an ability get skipped because my agent wasn't privileged but the
report said a fact dependency wasn't fulfilled.