### PR TITLE
WIP: VIRTS 1456: Allow users to remove user-privilege agents from an operation after spawning privileged agents

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -35,6 +35,7 @@ class AbilitySchema(ma.Schema):
     additional_info = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.String())
     access = ma.fields.Nested(AccessSchema, missing=None)
     test = ma.fields.String(missing=None)
+    allow_privesc_exit = ma.fields.Bool()
 
     @ma.post_load
     def build_ability(self, data, **_):
@@ -66,7 +67,8 @@ class Ability(FirstClassObjectInterface, BaseObject):
     def __init__(self, ability_id, tactic=None, technique_id=None, technique=None, name=None, test=None,
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,
-                 variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None, **kwargs):
+                 variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None,
+                 allow_privesc_exit=False, **kwargs):
         super().__init__()
         self._test = test
         self.ability_id = ability_id
@@ -89,6 +91,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.build_target = build_target
         self.variations = get_variations(variations)
         self.buckets = buckets if buckets else []
+        self.allow_privesc_exit = allow_privesc_exit
         if access:
             self.access = self.Access(access)
         self.additional_info = additional_info or dict()

--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -35,7 +35,7 @@ class AbilitySchema(ma.Schema):
     additional_info = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.String())
     access = ma.fields.Nested(AccessSchema, missing=None)
     test = ma.fields.String(missing=None)
-    allow_privesc_exit = ma.fields.Bool()
+    spawns_elevated_agent = ma.fields.Bool()
 
     @ma.post_load
     def build_ability(self, data, **_):
@@ -68,7 +68,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,
                  variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None,
-                 allow_privesc_exit=False, **kwargs):
+                 spawns_elevated_agent=False, **kwargs):
         super().__init__()
         self._test = test
         self.ability_id = ability_id
@@ -91,7 +91,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.build_target = build_target
         self.variations = get_variations(variations)
         self.buckets = buckets if buckets else []
-        self.allow_privesc_exit = allow_privesc_exit
+        self.spawns_elevated_agent = spawns_elevated_agent
         if access:
             self.access = self.Access(access)
         self.additional_info = additional_info or dict()

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -84,7 +84,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
         # Allow nonelevated agents to exit the operation after certain privilege escalation abilities.
         self.allow_privesc_exit = allow_privesc_exit
-        self.exited_agent_paws = [] # Agents that have left the operation and cannot re-join.
+        self.exited_agent_paws = []  # Agents that have left the operation and cannot re-join.
         if source:
             self.rules = source.rules
 

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -60,7 +60,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, name, agents, adversary, id=None, jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True,
-                 visibility=50, access=None, allow_privesc_exit=True):
+                 visibility=50, access=None, allow_privesc_exit=False):
         super().__init__()
         self.id = id
         self.start, self.finish = None, None

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -154,7 +154,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
     async def wait_for_links_completion(self, link_ids):
         """
         Wait for started links to be completed.
-        Remove nonprivileged agents from the operation if requested.
+        Remove nonelevated agents from the operation if requested and if they spawned new elevated agents via
+        privilege escalation.
 
         :param link_ids:
         :return: None
@@ -166,14 +167,13 @@ class Operation(FirstClassObjectInterface, BaseObject):
                 await asyncio.sleep(5)
                 if not member.trusted:
                     break
-        await self.prune_privesc_agents(link_ids)
+        await self.prune_nonelevated_privesc_agents(link_ids)
 
-    async def prune_privesc_agents(self, link_ids):
+    async def prune_nonelevated_privesc_agents(self, link_ids):
         """
-        If the operation is set to prune nonprivileged agents after successfully completing
-        privilege escalation abilities that spawn new agents, go through each provided completed link, check if the associated
-        ability allows the calling agent to exit the operation,
-        and remove the agent from the operation if requested.
+        If the operation is set to prune non-elevated agents after successfully spawning new elevated agents,
+        go through each provided completed link, check if the associated ability spawns elevated agents,
+        and remove the calling agent from the operation if the calling agent is non-elevated.
         """
         if self.allow_privesc_exit:
             for link_id in link_ids:

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -138,5 +138,5 @@ class ContactService(ContactServiceInterface, BaseService):
         which the planner needs to be aware of.
         """
         for op in await self.get_service('data_svc').locate('operations', match=dict(finish=None)):
-            if op.group == agent.group or op.group is None:
+            if op.group == agent.group or not op.group:
                 await op.update_operation(self.get_services())

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -112,7 +112,7 @@ class DataService(DataServiceInterface, BaseService):
                 privilege = ab.pop('privilege', None)
                 repeatable = ab.pop('repeatable', False)
                 requirements = ab.pop('requirements', [])
-                allow_privesc_exit = ab.pop('allow_privesc_exit', False)
+                spawns_elevated_agent = ab.pop('spawns_elevated_agent', False)
                 for platforms, executors in ab.pop('platforms', dict()).items():
                     for name, info in executors.items():
                         encoded_test = b64encode(info['command'].strip().encode('utf-8')).decode() if info.get(
@@ -137,7 +137,7 @@ class DataService(DataServiceInterface, BaseService):
                                                                buckets=await self._classify(ab, tactic),
                                                                access=access, repeatable=repeatable,
                                                                variations=info.get('variations', []),
-                                                               allow_privesc_exit=allow_privesc_exit, **ab)
+                                                               spawns_elevated_agent=spawns_elevated_agent, **ab)
                                 await self._update_extensions(a)
 
     async def load_adversary_file(self, filename, access):
@@ -233,7 +233,7 @@ class DataService(DataServiceInterface, BaseService):
                               test=None, description=None, executor=None, platform=None, cleanup=None, payloads=None,
                               parsers=None, requirements=None, privilege=None, timeout=60, access=None, buckets=None,
                               repeatable=False, code=None, language=None, build_target=None, variations=None,
-                              allow_privesc_exit=False, **kwargs):
+                              spawns_elevated_agent=False, **kwargs):
         ps = []
         for module in parsers:
             ps.append(Parser.load(dict(module=module, parserconfigs=parsers[module])))
@@ -246,7 +246,7 @@ class DataService(DataServiceInterface, BaseService):
                           executor=executor, platform=platform, description=description, build_target=build_target,
                           cleanup=cleanup, payloads=payloads, parsers=ps, requirements=rs,
                           privilege=privilege, timeout=timeout, repeatable=repeatable,
-                          variations=variations, buckets=buckets, allow_privesc_exit=allow_privesc_exit, **kwargs)
+                          variations=variations, buckets=buckets, spawns_elevated_agent=spawns_elevated_agent, **kwargs)
         ability.access = access
         return await self.store(ability)
 

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -112,6 +112,7 @@ class DataService(DataServiceInterface, BaseService):
                 privilege = ab.pop('privilege', None)
                 repeatable = ab.pop('repeatable', False)
                 requirements = ab.pop('requirements', [])
+                allow_privesc_exit = ab.pop('allow_privesc_exit', False)
                 for platforms, executors in ab.pop('platforms', dict()).items():
                     for name, info in executors.items():
                         encoded_test = b64encode(info['command'].strip().encode('utf-8')).decode() if info.get(
@@ -135,7 +136,8 @@ class DataService(DataServiceInterface, BaseService):
                                                                requirements=requirements, privilege=privilege,
                                                                buckets=await self._classify(ab, tactic),
                                                                access=access, repeatable=repeatable,
-                                                               variations=info.get('variations', []), **ab)
+                                                               variations=info.get('variations', []),
+                                                               allow_privesc_exit=allow_privesc_exit, **ab)
                                 await self._update_extensions(a)
 
     async def load_adversary_file(self, filename, access):
@@ -230,7 +232,8 @@ class DataService(DataServiceInterface, BaseService):
     async def _create_ability(self, ability_id, tactic=None, technique_name=None, technique_id=None, name=None,
                               test=None, description=None, executor=None, platform=None, cleanup=None, payloads=None,
                               parsers=None, requirements=None, privilege=None, timeout=60, access=None, buckets=None,
-                              repeatable=False, code=None, language=None, build_target=None, variations=None, **kwargs):
+                              repeatable=False, code=None, language=None, build_target=None, variations=None,
+                              allow_privesc_exit=False, **kwargs):
         ps = []
         for module in parsers:
             ps.append(Parser.load(dict(module=module, parserconfigs=parsers[module])))
@@ -243,7 +246,7 @@ class DataService(DataServiceInterface, BaseService):
                           executor=executor, platform=platform, description=description, build_target=build_target,
                           cleanup=cleanup, payloads=payloads, parsers=ps, requirements=rs,
                           privilege=privilege, timeout=timeout, repeatable=repeatable,
-                          variations=variations, buckets=buckets, **kwargs)
+                          variations=variations, buckets=buckets, allow_privesc_exit=allow_privesc_exit, **kwargs)
         ability.access = access
         return await self.store(ability)
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -269,6 +269,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         :type links: list(string)
         """
         await operation.wait_for_links_completion(links)
+        await operation.prune_privesc_agents(links)
         await self.update_stopping_condition_met(planner, operation)
 
     async def _stop_bucket_exhaustion(self, planner, operation, condition_stop):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -249,7 +249,8 @@ class RestService(RestServiceInterface, BaseService):
                          group=group, jitter=data.pop('jitter', '2/8'), source=next(iter(sources), None),
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          obfuscator=data.pop('obfuscator', 'plain-text'),
-                         auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')))
+                         auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')),
+                         allow_privesc_exit=bool(int(data.pop('priv_esc_exit', 0))))
 
     def _get_allowed_from_access(self, access):
         if self.Access.HIDDEN in access['access']:

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -85,6 +85,17 @@
               </select>
           </div>
 
+          <div id="privesc" class="column sidebar-cutout sidebar-header">
+              <h5>PRIVILEGE ESCALATION</h5>
+          </div>
+          <div id="privesc-options" class="column sidebar-cutout" style="display: none;">
+              <select name="removeAfterPrivEsc" id="queueRemoveAfterPrivEsc" class="queueOption" style="opacity:0.5" disabled="true">
+                <option value="0" selected>Keep all agents after priv esc</option>
+                <option value="1">Remove non-privileged agent from operation after spawning an elevated agent.</option>
+              </select>
+          </div>
+
+
           <div id="stealth" class="column sidebar-cutout sidebar-header">
               <h5>STEALTH</h5>
           </div>
@@ -298,6 +309,10 @@
             stream('Autonomous options allow you to configure how much manual intervention you want.');
             $("#autonomous-options").slideToggle("slow");
         });
+        $("#privesc").click(function(){
+            stream('Privilege escalation options allow you to configure whether or not to keep an agent in the operation after elevating on the same host.');
+            $("#privesc-options").slideToggle("slow");
+        });
     });
 
     function toggleOperationView() {
@@ -380,7 +395,8 @@
             "auto_close": document.getElementById("queueAutoClose").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
-            "visibility": document.getElementById("queueVisibility").value
+            "visibility": document.getElementById("queueVisibility").value,
+            "priv_esc_exit": document.getElementById("queueRemoveAfterPrivEsc").value
         };
     }
 

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -95,7 +95,7 @@ class TestRestSvc:
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
                      'proxy_receivers': {}, 'proxy_chain': []}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
-                'obfuscator': 'plain-text'}
+                'obfuscator': 'plain-text', 'exited_agent_paws': [], 'allow_privesc_exit': False}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),


### PR DESCRIPTION
Use case: agent A (user privilege) is on a host and performs a privilege escalation ability to spawn elevated agent B. Both agents are now active in the operation, provided that the groups match accordingly.  Suppose the operator wants just agent B to carry on with the rest of the operation and keep agent A idling in the background. Killing agent A would be too messy - what if the operator wants to start a later operation with that same agent A? Allowing agent A to continue with the operation may also be messy, as both agent A and agent B may end up performing the same abilities, causing duplication of effort.  One solution is to have agent A exit the operation after spawning agent B, so that only agent B will continue with the operation, and agent A is still alive for future activity outside of the current operation.

The PR adds new features to abilities and operations.  Ability YAML files now have a keyword "spawns_elevated_agent", which is set to "true" if the ability will spawn an elevated agent on success.  If omitted, this variable will be set to false in the Ability object. This setting allows Caldera to keep track of which abilities can potentially spawn elevated agents, in case the user wants to have the non-privileged calling agent exit the operation after the privilege escalation.

Operations now keep track of two new items:
- A list of agents that have exited the operation. The operation needs to know which agents to not allow back in, since agents will continue to beacon as long as they are still alive, and Caldera will attempt to place the agents into an operation when possible.
- A boolean variable that determines whether or not to have agents exit after spawning elevated agents via privilege escalation. This setting can be toggled via the operation UI modal when users create their operations.  By default, the setting is toggled to "keep all agents after privilege escalation". In other words, even if an ability spawns an elevated agent, all agents involved will continue to stay in the operation. If the user toggles the setting to "remove non-privileged agent from operation after spawning an elevated agent", then the operation will remove the user-privileged agent when it successfully performs an ability where "spawns_elevated_agent" is set to true.