### PR TITLE
update ldap3 to 2.8.1 which pins pyasn1 greater than 0.4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ dirhash==0.1.1
 docker==4.2.0
 donut-shellcode==0.9.2
 marshmallow-enum==1.5.1
-ldap3==2.7
+ldap3==2.8.1


### PR DESCRIPTION
Fixes #1854 