### PR TITLE
VIRTS1091: Configurable C2 address in deploy agent modal

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -97,7 +97,8 @@ class RestApi(BaseWorld):
                     configuration=lambda d: self.rest_svc.update_config(d),
                     link=lambda d: self.rest_svc.get_potential_links(**d),
                     operation=lambda d: self.rest_svc.update_operation(**d),
-                    task=lambda d: self.rest_svc.task_agent_with_ability(**d)
+                    task=lambda d: self.rest_svc.task_agent_with_ability(**d),
+                    agent_configuration=lambda d: self.rest_svc.get_agent_configuration(d)
                 )
             )
             if index not in options[request.method]:

--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -63,6 +63,10 @@ class Ability(FirstClassObjectInterface, BaseObject):
     def unique(self):
         return '%s%s%s' % (self.ability_id, self.platform, self.executor)
 
+    @property
+    def raw_command(self):
+        return self.decode_bytes(self._test)
+
     def __init__(self, ability_id, tactic=None, technique_id=None, technique=None, name=None, test=None,
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,

--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -114,7 +114,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         existing.update('technique_name', self.technique_name)
         existing.update('technique_id', self.technique_id)
         existing.update('name', self.name)
-        existing.update('_test', self.test)
+        existing.update('_test', self._test)
         existing.update('description', self.description)
         existing.update('cleanup', self.cleanup)
         existing.update('executor', self.executor)

--- a/app/objects/secondclass/c_variation.py
+++ b/app/objects/secondclass/c_variation.py
@@ -21,6 +21,10 @@ class Variation(BaseObject):
     def command(self):
         return self.replace_app_props(self._command)
 
+    @property
+    def raw_command(self):
+        return self.decode_bytes(self._command)
+
     def __init__(self, description, command):
         super().__init__()
         self.description = description

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -13,6 +13,7 @@ from app.objects.c_adversary import Adversary
 from app.objects.c_objective import Objective
 from app.objects.c_operation import Operation
 from app.objects.c_source import Source
+from app.objects.c_plugin import Plugin
 from app.objects.c_schedule import Schedule
 from app.objects.secondclass.c_fact import Fact
 from app.service.interfaces.i_rest_svc import RestServiceInterface
@@ -248,6 +249,23 @@ class RestService(RestServiceInterface, BaseService):
         if obfuscator:
             operation[0].obfuscator = obfuscator
             self.log.debug('Updated operation=%s obfuscator to %s' % (op_id, operation[0].obfuscator))
+
+    async def get_agent_configuration(self, data):
+        plugins = [p for p in await self.get_service('data_svc').locate('plugins', dict(enabled=True)) if p.data_dir]
+        plugins.append(Plugin(data_dir='data'))
+        ab_yml = platforms = None
+        for p in plugins:
+            files = [os.path.join(rt, fle) for rt, _, f in os.walk(p.data_dir+'/abilities')
+                     for fle in f if data['ability_id'] in fle]
+            for f in files:
+                ab_yml = self.strip_yml(f)
+        for entries in ab_yml:
+            for ab in entries:
+                platforms = ab.get('platforms', dict())
+
+        app_config = {k: v for k, v in self.get_config().items() if k.startswith('app.')}
+
+        return dict(platforms=platforms, app_config=app_config)
 
     """ PRIVATE """
 

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -251,11 +251,16 @@ class RestService(RestServiceInterface, BaseService):
 
     async def get_agent_configuration(self, data):
         abilities = await self.get_service('data_svc').locate('abilities', data)
-        platforms = {ability.platform: {ability.executor: {'command': ability.raw_command}} for ability in abilities}
+
+        raw_abilities = [{'platform': ability.platform, 'executor': ability.executor,
+                          'description': ability.description, 'command': ability.raw_command,
+                          'variations': [{'description': v.description, 'command': v.raw_command}
+                                         for v in ability.variations]}
+                         for ability in abilities]
 
         app_config = {k: v for k, v in self.get_config().items() if k.startswith('app.')}
 
-        return dict(platforms=platforms, app_config=app_config)
+        return dict(abilities=raw_abilities, app_config=app_config)
 
     """ PRIVATE """
 

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -100,3 +100,45 @@ span.psw {
 #alert-modal {
     z-index: 120;
 }
+.tab-title {
+    font-weight: 500;
+    font-size: 20px;
+    line-height: 45px;
+    margin: 0px;
+    width: 200px;
+    cursor: pointer;
+}
+.tab-title:hover {
+    color: #750b20;
+}
+.tab-line {
+    height: 4px;
+    border-width: 0px;
+    background-color: transparent;
+    width: 85%;
+}
+.active {
+    color: #750b20;
+}
+
+hr.active {
+    background-color: #750b20;
+}
+.config-arg {
+    padding: 5px;
+    margin: 10px;
+    text-align: left;
+}
+label {
+    color: white;
+}
+.conf-arg {
+    vertical-align: initial;
+}
+.cmd-box {
+    padding: 10px;
+    margin: 10px;
+    border-style: solid;
+    border-width: thin;
+    border-color: rgba(255, 255, 255, 0.5);
+}

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -100,30 +100,6 @@ span.psw {
 #alert-modal {
     z-index: 120;
 }
-.tab-title {
-    font-weight: 500;
-    font-size: 20px;
-    line-height: 45px;
-    margin: 0px;
-    width: 200px;
-    cursor: pointer;
-}
-.tab-title:hover {
-    color: #750b20;
-}
-.tab-line {
-    height: 4px;
-    border-width: 0px;
-    background-color: transparent;
-    width: 85%;
-}
-.active {
-    color: #750b20;
-}
-
-hr.active {
-    background-color: #750b20;
-}
 .config-arg input {
     padding: 5px;
     margin: 5px;
@@ -136,21 +112,4 @@ hr.active {
 }
 .config-arg {
     vertical-align: initial;
-}
-.conf-icon {
-    height: 25px;
-}
-#conf-command {
-    padding: 10px;
-    background-color: rgba(170, 170, 170, 0.15);
-    color: white;
-    text-align: left;
-    font-size: 13px;
-    font-style: italic;
-}
-.conf-command {
-    margin: auto;
-    padding-left:65px;
-    border-spacing: 15px;
-    display: none;
 }

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -124,14 +124,33 @@ span.psw {
 hr.active {
     background-color: #750b20;
 }
-.config-arg {
+.config-arg input {
     padding: 5px;
-    margin: 10px;
+    margin: 5px;
     text-align: left;
+    font-size: 13px
 }
-label {
+.config-arg label {
     color: white;
+    font-size: 14px
 }
-.conf-arg {
+.config-arg {
     vertical-align: initial;
+}
+.conf-icon {
+    height: 25px;
+}
+#conf-command {
+    padding: 10px;
+    background-color: rgba(170, 170, 170, 0.15);
+    color: white;
+    text-align: left;
+    font-size: 13px;
+    font-style: italic;
+}
+.conf-command {
+    margin: auto;
+    padding-left:65px;
+    border-spacing: 15px;
+    display: none;
 }

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -113,3 +113,11 @@ span.psw {
 .config-arg {
     vertical-align: initial;
 }
+p.command {
+    padding: 10px;
+    width: 85%;
+    color: white;
+    font-size: 13px;
+    font-style:italic;
+    background-color: rgba(170, 170, 170, 0.15);
+}

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -135,10 +135,3 @@ label {
 .conf-arg {
     vertical-align: initial;
 }
-.cmd-box {
-    padding: 10px;
-    margin: 10px;
-    border-style: solid;
-    border-width: thin;
-    border-color: rgba(255, 255, 255, 0.5);
-}

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -161,58 +161,19 @@
             <div class="row">
                 <span onclick="document.getElementById('delivery-modal').style.display='none'" class="close" title="Close Modal">&times;</span>
                 <div class="column" style="flex:92%">
-                    <div style="display: flex; padding: 0px 50px;">
-                        <div>
-                            <h3 class="tab-title active" onclick="switchModalTab(this)" data-tab="modal-presets">Preset Commands</h3>
-                            <hr class="tab-line active">
-                        </div>
-                        <div>
-                            <h3 class="tab-title" onclick="switchModalTab(this)" data-tab="modal-configure">Configure</h3>
-                            <hr class="tab-line">
-                        </div>
-                    </div>
-                    <div id="tab-content">
-                        <div id="modal-presets" class="tab-page">
-                            <select id="chosen-agent" onchange="displayCommand()" style="width:33%;">
-                                <option disabled selected>Choose an agent</option>
-                                {% for i,a in abilities.items() %}
-                                <option value="{{ i }}">{{ a[0].name }}:&nbsp;&nbsp;{{ a[0].description }}</option>
-                                {% endfor %}}
-                            </select>
-                            <br>
-                            <select id="chosen-platform" onchange="filterCommands()" style="width:33%;">
-                                <option selected value="">All platforms</option>
-                            </select>
-                            <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
-                            <ul id="variations"></ul>
-                        </div>
-                        <div id="modal-configure" class="tab-page" style="display:none">
-                            <div id="modal-conf-type">
-                               <select id="conf-chosen-agent" onchange="selectAgent(this)" style="width:33%;">
-                                    <option disabled selected>Choose an agent</option>
-                                    {% for i,a in abilities.items() %}
-                                    <option value="{{ i }}">{{ a[0].name }}</option>
-                                    {% endfor %}}
-                                </select>
-                                <br>
-                                <select id="conf-chosen-platform" onchange=selectPlatform(this) style="width:33%;">
-                                    <option selected disabled>All platforms</option>
-                                </select>
-                                <br>
-                                <select id="conf-chosen-executor" onchange=selectExecutor(this) style="width:33%;">
-                                    <option selected disabled>All executors</option>
-                                </select>
-                                <table id="conf-arguments" style="margin:auto; padding: 25px 0px"></table>
-                                <table id="conf-command-box" class="conf-command">
-                                    <tr>
-                                        <td>
-                                            <img id="conf-platform-icon" class="golden conf-icon">
-                                        </td>
-                                        <td id="conf-command" contenteditable="true"></td>
-                                    </tr>
-                                </table>
-                            </div>
-                        </div>
+                    <select id="chosen-agent" onchange="displayCommand()" style="width:33%;">
+                        <option disabled selected>Choose an agent</option>
+                        {% for i,a in abilities.items() %}
+                        <option value="{{ i }}">{{ a[0].name }}:&nbsp;&nbsp;{{ a[0].description }}</option>
+                        {% endfor %}}
+                    </select>
+                    <br>
+                    <select id="chosen-platform" onchange="filterCommands()" style="width:33%;">
+                        <option selected value="">All platforms</option>
+                    </select>
+                    <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
+                    <table id="conf-arguments" style="margin:auto; padding: 25px 0px; display: none"></table>
+                    <ul id="variations"></ul>
                     </div>
                 </div>
             </div>
@@ -229,14 +190,14 @@
             </tr>
             <tr>
                 <td></td>
-                <td><p id="command" style="color:white;font-size:13px;font-style:italic;width:70%;"></p></td>
+                <td><p id="command" style="color:white;font-size:13px;font-style:italic;width:70%;" contenteditable="true"></p></td>
             </tr>
         </table>
     </div>
 </div>
 
 <script>
-    var agentData, appConfig;
+    var agentAbilityData, appConfig;
 
     let refresher = setInterval(refresh, 10000);
     $('.section-profile').bind('destroyed', function() {
@@ -445,18 +406,28 @@
 
     function displayCommand(){
         function displayMe(data){
-            data.forEach(function(ability) {
-                variations.append(buildAbilityTemplate(ability.platform, ability.executor, ability.description, ability.test));
-                ability.variations.forEach(function(v) {
-                    variations.append(buildAbilityTemplate(ability.platform, ability.executor, v.description, v.command));
+            agentAbilityData = data["abilities"];
+            appConfig = data["app_config"];
+            data["abilities"].forEach(function(ability, agentIdx) {
+                addConfigArguments(ability.command);
+                variations.append(buildAbilityTemplate(ability.platform, ability.executor, ability.description,
+                                                       ability.command, agentIdx, null));
+                ability.variations.forEach(function(v, variationIdx) {
+                    addConfigArguments(v.command);
+                    variations.append(buildAbilityTemplate(ability.platform, ability.executor, v.description,
+                                                           v.command, agentIdx, variationIdx));
                 });
             });
-            populatePlatforms(data);
+            replaceProps();
+            $("#conf-arguments").show();
+            populatePlatforms(data["abilities"]);
+
+
         }
-        function populatePlatforms(data){
+        function populatePlatforms(abilities){
             $("#chosen-platform").empty();
             $("#chosen-platform").append("<option selected value=''>All platforms</option>");
-            data.forEach(function(ability) {
+            abilities.forEach(function(ability) {
                 if ($("#chosen-platform option[value='" + ability.platform + "']").length == 0) {
                     $("#chosen-platform").append('<option value="' + ability.platform + '">' + ability.platform + '</option>')
                 }
@@ -464,7 +435,8 @@
         }
         let variations = $('#variations');
         variations.empty();
-        restRequest('POST', {'index':'abilities','ability_id':$('#chosen-agent option:selected').val()}, displayMe);
+        $("#conf-arguments").empty();
+        restRequest('POST', {'index':'agent_configuration','ability_id':$('#chosen-agent option:selected').val()}, displayMe);
     }
 
     function filterCommands(){
@@ -478,88 +450,52 @@
         });
     }
 
-    function buildAbilityTemplate(platform, executor, description, command){
+    function buildAbilityTemplate(platform, executor, description, command, agentIdx, variationIdx){
         let template = $('#variation-template').clone();
         template.attr('id', 'command-variation');
         template.find('#description').text(description + ' ('+executor+')');
-        template.find('#command').text(atob(command));
+        template.find('#command').text(command);
+        template.find('#command').addClass('command');
+        template.find('#command').data('agent-index', agentIdx);
+        template.find('#command').data('variation-index', variationIdx);
         template.find('#platform-icon').attr('src', '/gui/img/'+platform+'.png');
         template.data('platform', platform);
         template.show();
         return template;
     }
 
-    function switchModalTab(clickedTab) {
-        $(".tab-title").removeClass("active");
-        $(".tab-line").removeClass("active");
-        $(".tab-page").hide();
-        $(clickedTab).addClass("active");
-        $(clickedTab).parent().find(".tab-line").addClass("active");
-        $("#" + clickedTab.dataset.tab).show();
-    }
-
-    function selectAgent(agentSelect) {
-        function populatePlatforms(data){
-            $("#conf-chosen-platform").empty();
-            $("#conf-chosen-platform").append("<option selected disabled>All platforms</option>");
-            $("#conf-chosen-executor").empty();
-            $("#conf-chosen-executor").append("<option selected disabled>All executors</option>");
-            $("#conf-arguments").empty();
-            $("#conf-command-box").hide();
-            agentData = data['platforms'];
-            appConfig = data['app_config'];
-            for (var platform in agentData) {
-                if ($("#conf-chosen-platform option[value='" + platform + "']").length == 0) {
-                    $("#conf-chosen-platform").append('<option value="' + platform + '">' + platform + '</option>');
-                }
-            }
-        }
-        restRequest('POST', {'index': 'agent_configuration', 'ability_id': agentSelect.value}, populatePlatforms);
-    }
-
-    function selectPlatform(platformSelect) {
-        $("#conf-chosen-executor").empty();
-        $("#conf-chosen-executor").append("<option selected disabled >All executors</option>");
-        for (var executor in agentData[platformSelect.value]) {
-            if ($("#conf-chosen-executor option[value='" + executor + "']").length == 0) {
-                let optionHTML = $('<option value="' + executor + '">' + executor + '</option>')
-                $("#conf-chosen-executor").append(optionHTML);
-                if (Object.keys(agentData[platformSelect.value]).length == 1) {
-                    optionHTML.attr("selected", true);
-                    selectExecutor($("#conf-chosen-executor")[0]);
-                }
-            }
-        }
-        $('#conf-platform-icon').attr('src', '/gui/img/' + platformSelect.value + '.png');
-    }
-
-    function selectExecutor(executorSelect) {
-        let command = agentData[$("#conf-chosen-platform").val()][executorSelect.value]["command"];
-        let args = Array.from(command.matchAll(/#{(.+?)}/g));
-
-        if ($("#conf-arguments").html() == "") {
-            args.forEach(function(arg) {
-                let capturedGroup = arg[1];
-                let argHTML = "<tr class='config-arg'><td><label>" + capturedGroup + "</label></td><td>" +
-                    "<input placeholder='" + appConfig[capturedGroup] + "' oninput='replaceProps()'></td></tr>";
-                $("#conf-arguments").append(argHTML);
-            });
-        }
-        replaceProps();
-        $("#conf-command-box").show();
-    }
-
-    function replaceProps() {
-        let command = agentData[$("#conf-chosen-platform").val()][$("#conf-chosen-executor").val()]["command"];
+    function addConfigArguments(command) {
         let args = Array.from(command.matchAll(/#{(.+?)}/g));
         args.forEach(function(arg) {
             let capturedGroup = arg[1];
-            let input = $("#conf-arguments label:contains('" + capturedGroup + "')").closest("tr").find("input");
-            let inputValue = input.val() ? input.val() : input.attr("placeholder");
+            if ($(".config-arg[data-contact='" + capturedGroup + "']").length == 0) {
+                let argHTML = "<tr class='config-arg' data-contact='" + capturedGroup +"'><td><label>" + capturedGroup + "</label></td><td>" +
+                    "<input placeholder='" + appConfig[capturedGroup] + "' oninput='replaceProps()'></td></tr>";
+                $("#conf-arguments").append(argHTML);
+            }
+        });
+    }
 
-            command = command.replace(arg[0], inputValue);
+    function replaceProps() {
+        $(".command").each(function(i, elem) {
+            let command = "";
+            let agentIdx = $(elem).data("agent-index");
+            let variationIdx = $(elem).data("variation-index");
+            if ($(elem).data("variation-index") != null) {
+                command = agentAbilityData[agentIdx].variations[variationIdx].command;
+            }
+            else {
+                command = agentAbilityData[agentIdx].command;
+            }
+            let args = Array.from(command.matchAll(/#{(.+?)}/g));
+            args.forEach(function(arg) {
+                let capturedGroup = arg[1];
+                let input = $("#conf-arguments label:contains('" + capturedGroup + "')").closest("tr").find("input");
+                let inputValue = input.val() ? input.val() : input.attr("placeholder");
+                command = command.replace(arg[0], inputValue);
+            })
+            $(elem).html(command);
         })
-        $("#conf-command").html(command);
     }
 
     //# sourceURL=agents.js

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -172,7 +172,7 @@
                         <option selected value="">All platforms</option>
                     </select>
                     <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
-                    <table id="conf-arguments" style="margin:auto; padding: 25px 0px; display: none"></table>
+                    <table id="conf-arguments" style="margin:auto; padding-top: 25px; display: none"></table>
                     <ul id="variations"></ul>
                     </div>
                 </div>
@@ -190,7 +190,7 @@
             </tr>
             <tr>
                 <td></td>
-                <td><p id="command" style="color:white;font-size:13px;font-style:italic;width:70%;" contenteditable="true"></p></td>
+                <td><p id="command" contenteditable="true"></p></td>
             </tr>
         </table>
     </div>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -186,7 +186,7 @@
                             <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
                             <ul id="variations"></ul>
                         </div>
-                        <div id="modal-configure" class="tab-page" style="text-align: left; display:none">
+                        <div id="modal-configure" class="tab-page" style="display:none">
                             <div id="modal-conf-type">
                                <select id="conf-chosen-agent" onchange="selectAgent(this)" style="width:33%;">
                                     <option disabled selected>Choose an agent</option>
@@ -202,10 +202,15 @@
                                 <select id="conf-chosen-executor" onchange=selectExecutor(this) style="width:33%;">
                                     <option selected disabled>All executors</option>
                                 </select>
-                                <table id="conf-arguments" style="margin-left:10px;"></table>
-                                <div style="padding: 10px; margin: 10px">
-                                    <p id="conf-command" style="font-size: 13px; font-style: italic; color: white"></p>
-                                </div>
+                                <table id="conf-arguments" style="margin:auto; padding: 25px 0px"></table>
+                                <table id="conf-command-box" class="conf-command">
+                                    <tr>
+                                        <td>
+                                            <img id="conf-platform-icon" class="golden conf-icon">
+                                        </td>
+                                        <td id="conf-command" contenteditable="true"></td>
+                                    </tr>
+                                </table>
                             </div>
                         </div>
                     </div>
@@ -500,7 +505,7 @@
             $("#conf-chosen-executor").empty();
             $("#conf-chosen-executor").append("<option selected disabled>All executors</option>");
             $("#conf-arguments").empty();
-            $("#conf-command").empty();
+            $("#conf-command-box").hide();
             agentData = data['platforms'];
             appConfig = data['app_config'];
             for (var platform in agentData) {
@@ -515,8 +520,6 @@
     function selectPlatform(platformSelect) {
         $("#conf-chosen-executor").empty();
         $("#conf-chosen-executor").append("<option selected disabled >All executors</option>");
-        $("#conf-arguments").empty();
-        $("#conf-command").empty();
         for (var executor in agentData[platformSelect.value]) {
             if ($("#conf-chosen-executor option[value='" + executor + "']").length == 0) {
                 let optionHTML = $('<option value="' + executor + '">' + executor + '</option>')
@@ -527,21 +530,23 @@
                 }
             }
         }
+        $('#conf-platform-icon').attr('src', '/gui/img/' + platformSelect.value + '.png');
     }
 
     function selectExecutor(executorSelect) {
-        $("#conf-arguments").empty();
         let command = agentData[$("#conf-chosen-platform").val()][executorSelect.value]["command"];
         let args = Array.from(command.matchAll(/#{(.+?)}/g));
 
-        args.forEach(function(arg) {
-            let capturedGroup = arg[1];
-            let argHTML = "<tr class='conf-arg'><td><label>" + capturedGroup + "</label></td><td>" +
-                "<input class='config-arg' placeholder='" + appConfig[capturedGroup] + "' onchange='replaceProps()'></td></tr>";
-            $("#conf-arguments").append(argHTML);
-        });
-
+        if ($("#conf-arguments").html() == "") {
+            args.forEach(function(arg) {
+                let capturedGroup = arg[1];
+                let argHTML = "<tr class='config-arg'><td><label>" + capturedGroup + "</label></td><td>" +
+                    "<input placeholder='" + appConfig[capturedGroup] + "' oninput='replaceProps()'></td></tr>";
+                $("#conf-arguments").append(argHTML);
+            });
+        }
         replaceProps();
+        $("#conf-command-box").show();
     }
 
     function replaceProps() {

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -161,18 +161,54 @@
             <div class="row">
                 <span onclick="document.getElementById('delivery-modal').style.display='none'" class="close" title="Close Modal">&times;</span>
                 <div class="column" style="flex:92%">
-                    <select id="chosen-agent" onchange="displayCommand()" style="width:33%;">
-                        <option disabled selected>Choose an agent</option>
-                        {% for i,a in abilities.items() %}
-                            <option value="{{ i }}">{{ a[0].name }}:&nbsp;&nbsp;{{ a[0].description }}</option>
-                        {% endfor %}}
-                    </select>
-                    <br>
-                    <select id="chosen-platform" onchange="filterCommands()" style="width:33%;">
-                        <option selected value="">All platforms</option>
-                    </select>
-                    <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
-                    <ul id="variations"></ul>
+                    <div style="display: flex; padding: 0px 50px;">
+                        <div>
+                            <h3 class="tab-title active" onclick="switchModalTab(this)" data-tab="modal-presets">Preset Commands</h3>
+                            <hr class="tab-line active">
+                        </div>
+                        <div>
+                            <h3 class="tab-title" onclick="switchModalTab(this)" data-tab="modal-configure">Configure</h3>
+                            <hr class="tab-line">
+                        </div>
+                    </div>
+                    <div id="tab-content">
+                        <div id="modal-presets" class="tab-page">
+                            <select id="chosen-agent" onchange="displayCommand()" style="width:33%;">
+                                <option disabled selected>Choose an agent</option>
+                                {% for i,a in abilities.items() %}
+                                <option value="{{ i }}">{{ a[0].name }}:&nbsp;&nbsp;{{ a[0].description }}</option>
+                                {% endfor %}}
+                            </select>
+                            <br>
+                            <select id="chosen-platform" onchange="filterCommands()" style="width:33%;">
+                                <option selected value="">All platforms</option>
+                            </select>
+                            <p style="font-size:12px;color:white">** Variations of the deployment command will be shown for each supported operating system</p>
+                            <ul id="variations"></ul>
+                        </div>
+                        <div id="modal-configure" class="tab-page" style="text-align: left; display:none">
+                            <div id="modal-conf-type">
+                               <select id="conf-chosen-agent" onchange="selectAgent(this)" style="width:33%;">
+                                    <option disabled selected>Choose an agent</option>
+                                    {% for i,a in abilities.items() %}
+                                    <option value="{{ i }}">{{ a[0].name }}</option>
+                                    {% endfor %}}
+                                </select>
+                                <br>
+                                <select id="conf-chosen-platform" onchange=selectPlatform(this) style="width:33%;">
+                                    <option selected disabled>All platforms</option>
+                                </select>
+                                <br>
+                                <select id="conf-chosen-executor" onchange=selectExecutor(this) style="width:33%;">
+                                    <option selected disabled>All executors</option>
+                                </select>
+                                <table id="conf-arguments" style="margin-left:10px;"></table>
+                                <div id="cmd-box" class="cmd-box" style="display: none">
+                                    <code id="conf-command"></code>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -195,6 +231,8 @@
 </div>
 
 <script>
+    var agentData, appConfig;
+
     let refresher = setInterval(refresh, 10000);
     $('.section-profile').bind('destroyed', function() {
         clearInterval(refresher);
@@ -444,6 +482,82 @@
         template.data('platform', platform);
         template.show();
         return template;
+    }
+
+    function switchModalTab(clickedTab) {
+        $(".tab-title").removeClass("active");
+        $(".tab-line").removeClass("active");
+        $(".tab-page").hide();
+        $(clickedTab).addClass("active");
+        $(clickedTab).parent().find(".tab-line").addClass("active");
+        $("#" + clickedTab.dataset.tab).show();
+    }
+
+    function selectAgent(agentSelect) {
+        function populatePlatforms(data){
+            $("#conf-chosen-platform").empty();
+            $("#conf-chosen-platform").append("<option selected disabled>All platforms</option>");
+            $("#conf-chosen-executor").empty();
+            $("#conf-chosen-executor").append("<option selected disabled>All executors</option>");
+            $("#conf-arguments").empty();
+            $("#conf-command").empty();
+            $("#cmd-box").hide();
+            agentData = data['platforms'];
+            appConfig = data['app_config'];
+            for (var platform in agentData) {
+                if ($("#conf-chosen-platform option[value='" + platform + "']").length == 0) {
+                    $("#conf-chosen-platform").append('<option value="' + platform + '">' + platform + '</option>');
+                }
+            }
+        }
+        restRequest('POST', {'index': 'agent_configuration', 'ability_id': agentSelect.value}, populatePlatforms);
+    }
+
+    function selectPlatform(platformSelect) {
+        $("#conf-chosen-executor").empty();
+        $("#conf-chosen-executor").append("<option selected disabled >All executors</option>");
+        $("#conf-arguments").empty();
+        $("#conf-command").empty();
+        $("#cmd-box").hide();
+        for (var executor in agentData[platformSelect.value]) {
+            if ($("#conf-chosen-executor option[value='" + executor + "']").length == 0) {
+                let optionHTML = $('<option value="' + executor + '">' + executor + '</option>')
+                $("#conf-chosen-executor").append(optionHTML);
+                if (Object.keys(agentData[platformSelect.value]).length == 1) {
+                    optionHTML.attr("selected", true);
+                    selectExecutor($("#conf-chosen-executor")[0]);
+                }
+            }
+        }
+    }
+
+    function selectExecutor(executorSelect) {
+        $("#conf-arguments").empty();
+        let command = agentData[$("#conf-chosen-platform").val()][executorSelect.value]["command"];
+        let args = Array.from(command.matchAll(/#{(.+?)}/g));
+
+        args.forEach(function(arg) {
+            let capturedGroup = arg[1];
+            let argHTML = "<tr class='conf-arg'><td><label>" + capturedGroup + "</label></td><td>" +
+                "<input class='config-arg' placeholder='" + appConfig[capturedGroup] + "' onchange='replaceProps()'></td></tr>";
+            $("#conf-arguments").append(argHTML);
+        });
+
+        replaceProps();
+    }
+
+    function replaceProps() {
+        let command = agentData[$("#conf-chosen-platform").val()][$("#conf-chosen-executor").val()]["command"];
+        let args = Array.from(command.matchAll(/#{(.+?)}/g));
+        args.forEach(function(arg) {
+            let capturedGroup = arg[1];
+            let input = $("#conf-arguments label:contains('" + capturedGroup + "')").closest("tr").find("input");
+            let inputValue = input.val() ? input.val() : input.attr("placeholder");
+
+            command = command.replace(arg[0], inputValue);
+        })
+        $("#conf-command").html(command);
+        $("#cmd-box").show();
     }
 
     //# sourceURL=agents.js

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -203,8 +203,8 @@
                                     <option selected disabled>All executors</option>
                                 </select>
                                 <table id="conf-arguments" style="margin-left:10px;"></table>
-                                <div id="cmd-box" class="cmd-box" style="display: none">
-                                    <code id="conf-command"></code>
+                                <div style="padding: 10px; margin: 10px">
+                                    <p id="conf-command" style="font-size: 13px; font-style: italic; color: white"></p>
                                 </div>
                             </div>
                         </div>
@@ -501,7 +501,6 @@
             $("#conf-chosen-executor").append("<option selected disabled>All executors</option>");
             $("#conf-arguments").empty();
             $("#conf-command").empty();
-            $("#cmd-box").hide();
             agentData = data['platforms'];
             appConfig = data['app_config'];
             for (var platform in agentData) {
@@ -518,7 +517,6 @@
         $("#conf-chosen-executor").append("<option selected disabled >All executors</option>");
         $("#conf-arguments").empty();
         $("#conf-command").empty();
-        $("#cmd-box").hide();
         for (var executor in agentData[platformSelect.value]) {
             if ($("#conf-chosen-executor option[value='" + executor + "']").length == 0) {
                 let optionHTML = $('<option value="' + executor + '">' + executor + '</option>')
@@ -557,7 +555,6 @@
             command = command.replace(arg[0], inputValue);
         })
         $("#conf-command").html(command);
-        $("#cmd-box").show();
     }
 
     //# sourceURL=agents.js


### PR DESCRIPTION
- new configure tab in the modal for deploying an agent
- app.contact.http/tcp/html configurable via input
- resulting command printed for copy/paste
- new API endpoint for getting agent command from YML without populated variables

Future:
- customize agent group (54ndc47 only?)
- verbose/non-verbose output
- backgrounded/hidden window vs. visible 

![Screen Shot 2020-09-14 at 4 33 32 PM](https://user-images.githubusercontent.com/61020544/93135282-124a0180-f6a8-11ea-91bd-c67e61cdc5a1.png)
