### PR TITLE
Fix CI Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           env: TOXENV=py38,style,coverage-ci,safety
 
 install:
+    - pip freeze
     - pip install tox
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
           env: TOXENV=py38,style,coverage-ci,safety
 
 install:
-    - pip freeze
+    - pip install --upgrade virtualenv
     - pip install tox
 
 script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 tox
-pytest==5.4.2
+pytest
 pytest-aiohttp==0.3.0
 coverage
 pre-commit


### PR DESCRIPTION
Travis-CI's 3.6 venv has a very out of date version of virtualenv. This ensures that the latest is installed before tox begins generating the testing environment and running tests.