### PR TITLE
Added getter/setter for created to base_object

### DIFF
--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -57,6 +57,10 @@ class BaseObject(BaseWorld):
         return self._access
 
     @property
+    def created(self):
+        return self._created
+
+    @property
     def display(self):
         if self.display_schema:
             dumped = self.display_schema.dump(self)
@@ -69,6 +73,10 @@ class BaseObject(BaseWorld):
     @access.setter
     def access(self, value):
         self._access = value
+
+    @created.setter
+    def created(self, value):
+        self._created = value
 
     def replace_app_props(self, encoded_string):
         if encoded_string:


### PR DESCRIPTION
## Description

Added `created` getter and setter to `base_object` to get the `_created` timestamp. 

`created` property will be used in the Debrief plugin for visualizing actions over time.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Registered new agents, ran test operations, downloaded JSON op report

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
