### PR TITLE
Select 'atomic' as the default planner.

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -75,7 +75,11 @@
               </select>
               <select name="planner" id="queuePlanner" class="queueOption" style="opacity:0.5;" disabled="true">
                 {% for p in planners %}
-                    <option value="{{ p.name }}">Use {{ p.name }} planner</option>
+                  {% if p.name == "atomic" %}
+                    <option value="{{ p.name }}" selected>Use {{ p.name }} planner</option>
+                  {% else %}
+                      <option value="{{ p.name }}">Use {{ p.name }} planner</option>
+                  {% endif %}
                 {% endfor %}
               </select>
               <select name="source" id="queueSource" class="queueOption" style="opacity:0.5" disabled="true">


### PR DESCRIPTION
## Description

Operation template now selects 'atomic' as the default planner.  This helps ensure consistent behavior when user's have different plugins installed -- previously installing a a new plugin could result in caldera preferring a planner from the plugin instead of atomic from stockpile which is confusing because the planner selection option is initially hidden on the operation launch page. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Launched caldera, verified UI change, launched operation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation

> no doc changes necessary 

- [ ] I have added tests that prove my fix is effective or that my feature works

> No tests added, this is a pure front-end change. 