### PR TITLE
Validate operation form on View/Add toggle

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -310,6 +310,7 @@
             stream('Operation name required. Click the headers below to reveal optional properties.');
             showHide('.queueOption,#opBtn,#scheduleBtn', '#operation-list');
             $('#opBtn').addClass('separated-button');
+            checkOpformValid();
         } else {
             showHide('#operation-list', '.queueOption,#opBtn,#scheduleBtn');
             $('#opBtn').removeClass('separated-button');


### PR DESCRIPTION
## Description

Validate operation form on View/Add toggle. Start button will be green if the operation form is filled out correctly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Add an operation, toggle the button again to add a second operation. Note that with the fix, the "Start" button will start green.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [???] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
