### PR TITLE
Updated stream messages on config modification

### DIFF
--- a/templates/agents.html
+++ b/templates/agents.html
@@ -217,15 +217,15 @@
             stream('Great, looks like you have '+agentCnt+' agents. You can now go to the Operations tab.')
         }
         $("#agent-beacon").click(function(){
-            stream('Set the minimum and maximum seconds the agent will take to beacon home. Timer changes will affect agents after their next beacon.');
+            stream('Set the minimum and maximum seconds the agent will take to beacon home. Beacon timer changes will only affect new agents.');
             $("#agent-beacon-options").slideToggle();
         });
         $("#agent-watchdog").click(function(){
-            stream('Set the number of seconds to wait before killing the agent, once the server is unreachable. Set 0 for infinite. Timer changes will affect agents after their next beacon.');
+            stream('Set the number of seconds to wait before killing the agent, once the server is unreachable. Set 0 for infinite. Watchdog timer changes will only affect new agents.');
             $("#agent-watchdog-options").slideToggle();
         });
         $("#agent-untrusted").click(function(){
-            stream('Set the number of seconds the server will wait before marking a missing agent as untrusted. Timer changes will affect agents after their next beacon.');
+            stream('Set the number of seconds the server will wait before marking a missing agent as untrusted. Untrusted timer changes will affect all agents.');
             $("#agent-untrusted-options").slideToggle();
         });
         $("#agent-implant").click(function(){


### PR DESCRIPTION
## Description

Updated the stream messages for the timers on the agent page. The beacon and watchdog timers do not update running agents and the untrusted timer is applied to all agents globally.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Navigate to Campaign > Agents
1. Open beacon, watchdog, and untrusted timers in the sidebar to view stream messages

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

Documentation update: https://github.com/mitre/fieldmanual/pull/26