### PR TITLE
Sanitize upload file name

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -63,7 +63,7 @@ class FileSvc(FileServiceInterface, BaseService):
                 field = await reader.next()
                 if not field:
                     break
-                filename = field.filename
+                _, filename = os.path.split(field.filename)
                 await self.save_file(filename, bytes(await field.read()), target_dir)
                 self.log.debug('Uploaded file %s/%s' % (target_dir, filename))
             return web.Response()


### PR DESCRIPTION
## Description

Sanitize file name on unauthenticated upload.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The following request was used for testing:

```
POST /file/upload HTTP/1.1
Host: 192.168.80.129:8888
Content-Type: multipart/form-data; boundary=----boundary
Content-Length: 154

------boundary
Content-Disposition: form-data; name="file"; filename="../../home/mitch/test.txt"
Content-Type: text/plain

_content_
------boundary--
```

Prior to this change, the file is written to `/tmp/d58ffd15-6aa0-44bc-83c2-20ef3f9983fa/../../../test.txt` (UUID is generated per request). After this change, the same request would result in a file being written to `/tmp/a24db421-aaa7-41b9-b842-8948b0d760e0/test.txt`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
