### PR TITLE
Show 'Bulding potential links...' message

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -535,6 +535,7 @@
         let paw = selectedAgent.split('-')[1];
         let postData = {"index":"link","op_id": parseInt(selectedOperationId), "paw": paw};
         restRequest('POST', postData, potentialLinksCallback, '/api/rest');
+        $('#potential-links-count').html('Building potential links...');
     }
 
     function potentialLinksCallback(data){


### PR DESCRIPTION
## Description

Show a message while building links. Abilities that use the Builder plugin will compile in order to get the command line arguments and properly display the commands. This can take a minute if a lot of abilities need to be compiled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Loaded a plugin that contains abilities that leverage the builder plugin, created an operation without an adversary, hit the '+ potential links' button, selected an agent from the dropdown. The message should show while the abilities are being built, and disappear once links are sent back from the server.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
