### PR TITLE
Sort facts by length descending when highlighting

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -669,6 +669,7 @@
         function loadResults(data){
             if (data) {
                 let res = atob(data.output);
+                data.link.facts.sort(function(a, b) { return b.value.length - a.value.length });
                 $.each(data.link.facts, function (k, v) {
                     let regex = new RegExp(String.raw`${v.value}`, "g");
                     res = res.replace(regex, "<span class='highlight'>" + v.value + "</span>");

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -671,8 +671,7 @@
                 let res = atob(data.output);
                 data.link.facts.sort(function(a, b) { return b.value.length - a.value.length });
                 $.each(data.link.facts, function (k, v) {
-                    let regex = new RegExp(String.raw`${v.value}`, "g");
-                    res = res.replace(regex, "<span class='highlight'>" + v.value + "</span>");
+                    res = res.replaceAll(v.value, "<span class='highlight'>" + v.value + "</span>");
                 });
                 $('#resultView').html(res);
             }


### PR DESCRIPTION
## Description

Sort facts by value length descending when highlighting. This should ensure that all facts are highlighted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run an ability that generates facts with overlapping strings. For example, a domain user collection ability in a domain with the users "bob" and "bob-admin". Without the change, highlighting may look like `bob` and `bob`-admin. With the change, highlighting will be `bob` and `bob-admin`.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
