### PR TITLE
Making get_skipped_abilities_by_agent a public method

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -210,7 +210,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
                     step_report['output'] = self.decode_bytes(file_svc.read_result_file(step.unique))
                 agents_steps[step.paw]['steps'].append(step_report)
             report['steps'] = agents_steps
-            report['skipped_abilities'] = await self._get_skipped_abilities_by_agent(data_svc)
+            report['skipped_abilities'] = await self.get_skipped_abilities_by_agent(data_svc)
 
             return report
         except Exception:
@@ -263,7 +263,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
     async def _unfinished_links_for_agent(self, paw):
         return [l for l in self.chain if l.paw == paw and not l.finish and not l.can_ignore()]
 
-    async def _get_skipped_abilities_by_agent(self, data_svc):
+    async def get_skipped_abilities_by_agent(self, data_svc):
         abilities_by_agent = await self._get_all_possible_abilities_by_agent(data_svc)
         skipped_abilities = []
         for agent in self.agents:


### PR DESCRIPTION
## Description
Turning `_get_skipped_abilities_by_agent` method in `c_operation.py` into a public method `get_skipped_abilities_by_agent` so that other classes and plugins can easily obtain the skipped abilities in an operation.

## Type of change
- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
