### PR TITLE
Allow source code files for builder abilities

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -119,7 +119,7 @@ class DataService(DataServiceInterface, BaseService):
                             'command') else None
                         cleanup_cmd = b64encode(info['cleanup'].strip().encode('utf-8')).decode() if info.get(
                             'cleanup') else None
-                        if info.get('code') and info.get('code').strip():
+                        if info.get('code') and info['code'].strip():
                             try:
                                 _, source_code = await self.get_service('file_svc').read_file(info['code'].strip())
                                 encoded_code = self.encode_string(source_code.decode('utf-8').strip())

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -120,11 +120,13 @@ class DataService(DataServiceInterface, BaseService):
                         cleanup_cmd = b64encode(info['cleanup'].strip().encode('utf-8')).decode() if info.get(
                             'cleanup') else None
                         if info.get('code') and info['code'].strip():
-                            try:
-                                _, source_code = await self.get_service('file_svc').read_file(info['code'].strip())
-                                encoded_code = self.encode_string(source_code.decode('utf-8').strip())
-                            except FileNotFoundError:
-                                encoded_code = self.encode_string(info['code'].strip())
+                            cleaned_code = info['code'].strip()
+                            _, code_path = await self.get_service('file_svc').find_file_path(cleaned_code)
+                            if code_path:
+                                _, code_data = await self.get_service('file_svc').read_file(cleaned_code)
+                                encoded_code = self.encode_string(code_data.decode('utf-8').strip())
+                            else:
+                                encoded_code = self.encode_string(cleaned_code)
                         else:
                             encoded_code = None
                         payloads = ab.pop('payloads', []) if encoded_code else info.get('payloads')

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -119,7 +119,14 @@ class DataService(DataServiceInterface, BaseService):
                             'command') else None
                         cleanup_cmd = b64encode(info['cleanup'].strip().encode('utf-8')).decode() if info.get(
                             'cleanup') else None
-                        encoded_code = self.encode_string(info['code'].strip()) if info.get('code') else None
+                        if info.get('code') and info.get('code').strip():
+                            try:
+                                _, source_code = await self.get_service('file_svc').read_file(info['code'].strip())
+                                encoded_code = self.encode_string(source_code.decode('utf-8').strip())
+                            except FileNotFoundError:
+                                encoded_code = self.encode_string(info['code'].strip())
+                        else:
+                            encoded_code = None
                         payloads = ab.pop('payloads', []) if encoded_code else info.get('payloads')
                         for e in name.split(','):
                             for pl in platforms.split(','):


### PR DESCRIPTION
## Description

Allows defining a filename in the `code` attribute, which source code will be read from. 

Note that this will result in file lookups for all abilities containing `code`. This might not be the best solution, but it doesn't involve adding another attribute and setting priority between YAML code and source code files.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Using an existing Donut ability, set the code attribute to a filename. Create that file in the payloads directory of the plugin and paste in the code previously in the YAML file. Run.

Test cases available in a private repo.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

I will add documentation to fieldmanual when this is merged.