### PR TITLE
Allow decode_bytes() to skip stripping newlines

### DIFF
--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -44,8 +44,9 @@ class BaseWorld:
             BaseWorld._app_configuration[name][prop] = value
 
     @staticmethod
-    def decode_bytes(s):
-        return b64decode(s).decode('utf-8', errors='ignore').replace('\n', '')
+    def decode_bytes(s, strip_newlines=True):
+        decoded = b64decode(s).decode('utf-8', errors='ignore')
+        return decoded.replace('\r\n', '').replace('\n', '') if strip_newlines else decoded
 
     @staticmethod
     def encode_string(s):


### PR DESCRIPTION
## Description

Added a new parameter to `decode_bytes()` to change the newline stripping behavior.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This should not affect current calls to the function. Implemented in a PR in builder.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
