### PR TITLE
Let long ability descriptions display correctly

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -244,7 +244,7 @@
                 </tr>
                 <tr>
                     <td><b>description:</b></td>
-                    <td><p id="potential-description"></td>
+                    <td><p id="potential-description" style="white-space:pre-wrap;font-family:monospace;font-size:13px;overflow:auto;display:block;"></td>
                 </tr>
                 <tr>
                     <td><b>command:</b></td>


### PR DESCRIPTION
## Description

https://github.com/mitre/access/pull/21 creates abilities with long descriptions and tables of options. This style fix will allow those descriptions to be displayed correctly.

## Type of change

- [x] Style fix

## How Has This Been Tested?

Tested locally in Firefox.
