### PR TITLE
VIRTS1660: origin link ID tracking for lateral movement

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -36,6 +36,7 @@ class AgentFieldsSchema(ma.Schema):
     links = ma.fields.List(ma.fields.Nested(LinkSchema()))
     proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()))
     proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()))
+    origin_link_id = ma.fields.Integer()
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
@@ -52,7 +53,7 @@ class AgentSchema(AgentFieldsSchema):
 class Agent(FirstClassObjectInterface, BaseObject):
 
     schema = AgentSchema()
-    load_schema = AgentSchema(partial=['paw'])
+    load_schema = AgentSchema(partial=['paw', 'origin_link_id'])
 
     RESERVED = dict(server='#{server}', group='#{group}', agent_paw='#{paw}', location='#{location}',
                     exe_name='#{exe_name}', payload=re.compile('#{payload:(.*?)}', flags=re.DOTALL))
@@ -68,7 +69,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
     def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
-                 proxy_receivers=None, proxy_chain=None):
+                 proxy_receivers=None, proxy_chain=None, origin_link_id=0):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
         self.host = host
@@ -96,6 +97,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.access = self.Access.BLUE if group == 'blue' else self.Access.RED
         self.proxy_receivers = proxy_receivers if proxy_receivers else dict()
         self.proxy_chain = proxy_chain if proxy_chain else []
+        self.origin_link_id = origin_link_id
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -60,6 +60,8 @@ class Link(BaseObject):
     load_schema = LinkSchema(exclude=['decide', 'pid', 'facts', 'unique', 'collect', 'finish', 'visibility',
                                       'output'])
 
+    RESERVED = dict(origin_link_id='#{origin_link_id}')
+
     @property
     def unique(self):
         return self.hash('%s' % self.id)
@@ -104,6 +106,12 @@ class Link(BaseObject):
         self._pin = pin
         self.output = False
 
+    def __eq__(self, other):
+        if isinstance(other, Link):
+            return other.paw == self.paw and other.ability.ability_id == self.ability.ability_id \
+                   and other.used == self.used
+        return False
+
     async def parse(self, operation, result):
         try:
             if self.status != 0:
@@ -119,9 +127,14 @@ class Link(BaseObject):
     def apply_id(self, host):
         self.id = self.generate_number()
         self.host = host
+        self.replace_origin_link_id()
 
     def can_ignore(self):
         return self.status in [self.states['DISCARD'], self.states['HIGH_VIZ']]
+
+    def replace_origin_link_id(self):
+        decoded_cmd = self.decode_bytes(self.command)
+        self.command = self.encode_string(decoded_cmd.replace(self.RESERVED['origin_link_id'], str(self.id)))
 
     """ PRIVATE """
 

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -93,7 +93,7 @@ class TestRestSvc:
                      'executors': ['pwsh', 'psh'], 'ppid': 0, 'sleep_min': 2, 'server': '://None:None',
                      'platform': 'windows', 'host': 'unknown', 'paw': '123', 'pid': 0,
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
-                     'proxy_receivers': {}, 'proxy_chain': []}],
+                     'proxy_receivers': {}, 'proxy_chain': [], 'origin_link_id': 0}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)


### PR DESCRIPTION
## Description

adds in the capability for caldera to track lateral movement via the originLinkID. This is passed in as an optional command line argument when executing an agent (https://github.com/mitre/gocat/pull/34).

Edits to `base_planning_svc` include a fix that caused a link ID to be applied more than once.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update - most likely will be addressed in https://github.com/mitre/fieldmanual/pull/29

## How Has This Been Tested?

- win 10 box and server 2016 box (domain controller)
- lateral movement adversary https://github.com/mitre/stockpile/pull/496

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
