### PR TITLE
packer not available log message

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -42,8 +42,11 @@ class FileSvc(FileServiceInterface, BaseService):
         if payload in self.special_payloads:
             payload, display_name = await self.special_payloads[payload](headers)
         file_path, contents = await self.read_file(payload)
-        if packer and packer in self.packers:
-            file_path, contents = await self.get_payload_packer(packer).pack(file_path, contents)
+        if packer:
+            if packer in self.packers:
+                file_path, contents = await self.get_payload_packer(packer).pack(file_path, contents)
+            else:
+                self.log.warning('packer <%s> not available for payload <%s>, returning unpacked' % (packer, payload))
         if headers.get('xor_key'):
             xor_key = headers['xor_key']
             contents = xor_bytes(contents, xor_key.encode())


### PR DESCRIPTION
## Description

adding a message if a packer is not available but specified to be used

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

requested a file for a non-existant packer and made sure it printed a line to the caldera server log

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code