### PR TITLE
C2 support for deadman abilities

### DIFF
--- a/app/objects/secondclass/c_instruction.py
+++ b/app/objects/secondclass/c_instruction.py
@@ -10,6 +10,7 @@ class InstructionSchema(ma.Schema):
     executor = ma.fields.String()
     timeout = ma.fields.Int()
     payloads = ma.fields.List(ma.fields.String())
+    deadman = ma.fields.Boolean()
 
     @ma.post_load
     def build_instruction(self, data, **_):
@@ -23,9 +24,9 @@ class Instruction(BaseObject):
     @property
     def display(self):
         return self.clean(dict(id=self.id, sleep=self.sleep, command=self.command, executor=self.executor,
-                               timeout=self.timeout, payloads=self.payloads))
+                               timeout=self.timeout, payloads=self.payloads, deadman=self.deadman))
 
-    def __init__(self, id, command, executor, payloads=None, sleep=0, timeout=60):
+    def __init__(self, id, command, executor, payloads=None, sleep=0, timeout=60, deadman=False):
         super().__init__()
         self.id = id
         self.sleep = sleep
@@ -33,3 +34,4 @@ class Instruction(BaseObject):
         self.executor = executor
         self.timeout = timeout
         self.payloads = payloads if payloads else []
+        self.deadman = deadman

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -34,6 +34,7 @@ class LinkSchema(ma.Schema):
     visibility = ma.fields.Nested(VisibilitySchema)
     host = ma.fields.String(missing=None)
     output = ma.fields.String()
+    deadman = ma.fields.Boolean()
 
     @ma.pre_load()
     def fix_ability(self, link, **_):
@@ -86,7 +87,7 @@ class Link(BaseObject):
                     TIMEOUT=124)
 
     def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0,
-                 host=None):
+                 host=None, deadman=False):
         super().__init__()
         self.id = id
         self.command = command
@@ -108,6 +109,7 @@ class Link(BaseObject):
         self.visibility = Visibility()
         self._pin = pin
         self.output = False
+        self.deadman = deadman
 
     def __eq__(self, other):
         if isinstance(other, Link):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -57,7 +57,11 @@ class ContactService(ContactServiceInterface, BaseService):
         )
         await self._add_agent_to_operation(agent)
         self.log.debug('First time %s beacon from %s' % (agent.contact, agent.paw))
-        await agent.bootstrap(self.get_service('data_svc'))
+        data_svc = self.get_service('data_svc')
+        await agent.bootstrap(data_svc)
+        if agent.deadman_enabled:
+            self.log.debug("Agent %s can accept deadman abilities. Will return any available deadman abilities." % agent.paw)
+            await agent.deadman(data_svc)
         return agent, await self._get_instructions(agent)
 
     async def build_filename(self):
@@ -125,7 +129,8 @@ class ContactService(ContactServiceInterface, BaseService):
                            command=link.command,
                            executor=link.ability.executor,
                            timeout=link.ability.timeout,
-                           payloads=payloads)
+                           payloads=payloads,
+                           deadman=link.deadman)
 
     async def _add_agent_to_operation(self, agent):
         """Determine which operation(s) incoming agent belongs to and


### PR DESCRIPTION
Users can now specify deadman abilities in the agents.yml file by adding them under the `deadman_abilities` label, just like for `bootstrap_abilities`. 

The C2 server will send the deadman instructions to agents that indicate support for deadman abilities. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Made some changes to the sandcat agent to support running deadman instructions, and I tested some simple abilities (such as creating a staging directory) to make sure that they run right before the agent terminates.  I made sure the abilities ran after killing the agent via the web GUI and when having the agent auto-self-terminate after losing connection to the C2 server.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
