### PR TITLE
Allow adding empty value for bootstrap abilities

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -353,7 +353,7 @@ class RestService(RestServiceInterface, BaseService):
         self.set_config(name='agents', prop='watchdog', value=watchdog)
         if implant_name:
             self.set_config(name='agents', prop='implant_name', value=implant_name)
-        if bootstrap_abilities:
+        if bootstrap_abilities is not None:
             abilities = []
             ability_ids = [ability_id.strip() for ability_id in bootstrap_abilities.split(',') if ability_id.strip()]
             for ability_id in ability_ids:


### PR DESCRIPTION
## Description

Explicitly check for `None` when changing bootstrap abilities. Allows a user to send an empty value to clear out bootstrap abilities from the Agents modal.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Submitted agent settings with blank value for bootstrap abilities.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
