### PR TITLE
Hide operation on adding new operation

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -314,6 +314,7 @@
     }
 
     function handleStartAction(){
+        $('.op-selected').css('visibility', 'hidden');
         restRequest('PUT', buildOperationObject(), handleStartActionCallback);
     }
 


### PR DESCRIPTION
## Description

Hide the operation view when adding a new operation. When operations have links that use the builder plugin, the display call will wait until the payloads have been built. This will cause the previous operation to be shown until all links have been built. The change is an alternative, which shows no operation.

An alternative would be to quickly generate links with builder abilities, so that they would show up faster. That would be harder and may cause situations where agents attempt to download payloads before they are built.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run an operation without builder abilities. Add a new operation with builder abilities. Previously, the old operation would continue showing until all links are generated. With the change, no operation is shown until links are generated.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
