### PR TITLE
queued abilities now have a question button to display command to be run

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -463,6 +463,7 @@
                         'onclick="findResults(this,'+lnk+')"' +
                         'data-encoded-cmd="'+OPERATION.chain[i].command+'"></span>' +
                         '<span id="'+OPERATION.chain[i].id+'-rm" style="font-size:11px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+', -2)">&#x274C;</span>' +
+                        '<span id="'+OPERATION.chain[i].id+'-cm" style="font-size:11px;float:right;" onclick="showCommand(\''+OPERATION.chain[i].command+'\')">&#x2754;</span>' +
                         '<span id="'+OPERATION.chain[i].id+'-add" style="font-size:22px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+',-3)">&#x002B;</span></div>');
                     refreshUpdatableFields(OPERATION.chain[i], template, true);
 
@@ -623,6 +624,7 @@
                 resultStar.addClass('tactic-no-facts');
             }
             div.find('#'+chain.id+'-rm').remove();
+            div.find('#'+chain.id+'-cm').remove();
         }
         if(chain.status === 0) {
             applyTimelineColor(div, 'success');
@@ -724,6 +726,11 @@
         if ($('#togBtnOp').is(':checked')) {
             $('#opBtn').addClass('separated-button');
         }
+    }
+
+    function showCommand(command){
+        document.getElementById('more-modal').style.display='block';
+        $('#resultCmd').html(atob(command));
     }
     //# sourceURL=operations.js
 </script>


### PR DESCRIPTION
## Description

Newly added links to operations only displayed their names and the agent to be run on. An option to delete the link is provided, but there is sometimes not enough information to make that decision. This feature now allows users to see the command to be run before it is picked up by the agent.

## Type of change

- [+] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually by running operations.