### PR TITLE
virts 1650-b

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -35,6 +35,7 @@ class AbilitySchema(ma.Schema):
     additional_info = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.String())
     access = ma.fields.Nested(AccessSchema, missing=None)
     test = ma.fields.String(missing=None)
+    singleton = ma.fields.Bool(missing=None)
 
     @ma.post_load
     def build_ability(self, data, **_):
@@ -46,7 +47,8 @@ class AbilitySchema(ma.Schema):
 class Ability(FirstClassObjectInterface, BaseObject):
 
     schema = AbilitySchema()
-    display_schema = AbilitySchema(exclude=['repeatable', 'language', 'code', 'build_target'])  # may need to fix for id=self.unique
+    # may need to fix for id=self.unique
+    display_schema = AbilitySchema(exclude=['repeatable', 'language', 'code', 'build_target', 'singleton'])
 
     RESERVED = dict(payload='#{payload}')
     HOOKS = dict()
@@ -70,7 +72,8 @@ class Ability(FirstClassObjectInterface, BaseObject):
     def __init__(self, ability_id, tactic=None, technique_id=None, technique=None, name=None, test=None,
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,
-                 variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None, **kwargs):
+                 variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None,
+                 singleton=False, **kwargs):
         super().__init__()
         self._test = test
         self.ability_id = ability_id
@@ -93,6 +96,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.build_target = build_target
         self.variations = get_variations(variations)
         self.buckets = buckets if buckets else []
+        self.singleton = singleton
         if access:
             self.access = self.Access(access)
         self.additional_info = additional_info or dict()

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -113,6 +113,7 @@ class DataService(DataServiceInterface, BaseService):
                 ability_name = ab.pop('name', '')
                 privilege = ab.pop('privilege', None)
                 repeatable = ab.pop('repeatable', False)
+                singleton = ab.pop('singleton', False)
                 requirements = ab.pop('requirements', [])
                 for platforms, executors in ab.pop('platforms', dict()).items():
                     for name, info in executors.items():
@@ -146,7 +147,8 @@ class DataService(DataServiceInterface, BaseService):
                                                                requirements=requirements, privilege=privilege,
                                                                buckets=await self._classify(ab, tactic),
                                                                access=access, repeatable=repeatable,
-                                                               variations=info.get('variations', []), **ab)
+                                                               variations=info.get('variations', []),
+                                                               singleton=singleton, **ab)
                                 await self._update_extensions(a)
 
     async def load_adversary_file(self, filename, access):
@@ -251,7 +253,8 @@ class DataService(DataServiceInterface, BaseService):
     async def _create_ability(self, ability_id, tactic=None, technique_name=None, technique_id=None, name=None,
                               test=None, description=None, executor=None, platform=None, cleanup=None, payloads=None,
                               parsers=None, requirements=None, privilege=None, timeout=60, access=None, buckets=None,
-                              repeatable=False, code=None, language=None, build_target=None, variations=None, **kwargs):
+                              repeatable=False, code=None, language=None, build_target=None, variations=None,
+                              singleton=False, **kwargs):
         ps = []
         for module in parsers:
             ps.append(Parser.load(dict(module=module, parserconfigs=parsers[module])))
@@ -264,7 +267,7 @@ class DataService(DataServiceInterface, BaseService):
                           executor=executor, platform=platform, description=description, build_target=build_target,
                           cleanup=cleanup, payloads=payloads, parsers=ps, requirements=rs,
                           privilege=privilege, timeout=timeout, repeatable=repeatable,
-                          variations=variations, buckets=buckets, **kwargs)
+                          variations=variations, buckets=buckets, singleton=singleton, **kwargs)
         ability.access = access
         return await self.store(ability)
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -172,8 +172,10 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         if agent:
             links.extend(await self.generate_and_trim_links(agent, operation, abilities, trim))
         else:
+            agent_links = []
             for agent in operation.agents:
-                links.extend(await self.generate_and_trim_links(agent, operation, abilities, trim))
+                agent_links.append(await self.generate_and_trim_links(agent, operation, abilities, trim))
+            links = self._cross_check_agents_for_duplicate_singletons(agent_links)
         self.log.debug('Generated %s usable links' % (len(links)))
         return await self.sort_links(links)
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -175,7 +175,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
             agent_links = []
             for agent in operation.agents:
                 agent_links.append(await self.generate_and_trim_links(agent, operation, abilities, trim))
-            links = self._cross_check_agents_for_duplicate_singletons(agent_links)
+            links = self._remove_links_of_duplicate_singletons(agent_links)
         self.log.debug('Generated %s usable links' % (len(links)))
         return await self.sort_links(links)
 

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -49,7 +49,8 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
-                relevant_facts = await self._build_relevant_facts([x for x in variables if '_' not in x], facts)
+                relevant_facts = await self._build_relevant_facts([x for x in variables if len(x.split('.')) > 2],
+                                                                  facts)
                 if all(relevant_facts):
                     good_facts = [await RuleSet(rules=rules).apply_rules(facts=fact_set) for fact_set in relevant_facts]
                     valid_facts = [await self._trim_by_limit(decoded_test, g_fact[0]) for g_fact in good_facts]

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -134,7 +134,7 @@ class BasePlanningService(BaseService):
     async def _build_relevant_facts(variables, facts):
         """
         Create a list of facts which are relevant to the given ability's defined variables
-        
+
         Returns: (list) of lists, with each inner list providing all known values for the corresponding fact trait
         """
         relevant_facts = []

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -80,15 +80,13 @@ class BasePlanningService(BaseService):
         :param agent:
         :return: updated list of links
         """
-        completed_links = [(l.command_hash if l.command_hash else l.command) for l in operation.chain
-                           if l.paw == agent.paw and (l.finish or l.can_ignore())]
-
         completed_links = [lnk for lnk in operation.chain if lnk.paw == agent.paw and (lnk.finish or lnk.can_ignore())]
 
         singleton_links = BasePlanningService._list_historic_duplicate_singletons(operation)
 
         return [lnk for lnk in links if lnk.ability.repeatable or
-                (lnk not in completed_links and lnk not in singleton_links)]
+                (lnk not in completed_links and
+                 not any([lnk.command_hash == x.command_hash for x in singleton_links]))]
 
     @staticmethod
     async def remove_links_missing_facts(links):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -131,7 +131,7 @@ class BasePlanningService(BaseService):
         return [x for x in singleton if x]
 
     @staticmethod
-    def _cross_check_agents_for_duplicate_singletons(agent_links):
+    def _remove_links_of_duplicate_singletons(agent_links):
         """
         Filter links across agents
         :param agent_links: array of agent links

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -86,7 +86,7 @@ class BasePlanningService(BaseService):
 
         return [lnk for lnk in links if lnk.ability.repeatable or
                 (lnk not in completed_links and
-                 not any([lnk.command_hash == x.command_hash for x in singleton_links]))]
+                 not any([lnk.command == x.command for x in singleton_links]))]
 
     @staticmethod
     async def remove_links_missing_facts(links):

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 
-from app.utility.payload_encoder import xor_file
 from tests import AsyncMock
 from asyncio import Future
 

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -259,7 +259,7 @@ class TestPlanningService:
         assert 1 == len(filt)
 
         # test parallel filtering
-        flat_fil = planning_svc._cross_check_agents_for_duplicate_singletons([[l0, l1, l2, l3],
-                                                                              [l0, l1, l2, l3],
-                                                                              [l0, l1, l2, l3]])
+        flat_fil = planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
+                                                                       [l0, l1, l2, l3],
+                                                                       [l0, l1, l2, l3]])
         assert 7 == len(flat_fil)


### PR DESCRIPTION
## Description

This merge is a revised version of the virts-1650 bug fix, which strives to prevent duplicated lateral movement. This is now accomplished by limiting certain abilities using the keyword 'singleton'. 'singleton' abilities now can only be run successfully once during an operation, and can only be run from one agent at a time. Please note, atomic does not benefit from this protection, as it retrieves abilities on a per agent basis, rather than across all available agents, which is required for the filtering to work. This merge has a sister dependency [here](https://github.com/mitre/stockpile/pull/503).

## Type of change

Please delete options that are not relevant.

- Bug fix 
- This change may require a small update to the documentation, depends on how much we endorse the new field at this point (prior to certain upcoming changes in the planner)

## How Has This Been Tested?

This has been tested by running operations with both the atomic and batch planners, with batch properly pruning duplicate movement, and atomic not, as expected. Individual components were directly tested using the testing framework (new tests added).


## Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ~] I have made corresponding changes to the documentation
- [ X] I have added tests that prove my fix is effective or that my feature works
