### PR TITLE
Operation with manual link approval - ease of use

### DIFF
--- a/static/css/timeline.css
+++ b/static/css/timeline.css
@@ -173,3 +173,19 @@ a:hover {
 .cleanup .event:before {
   content: attr(data-host-name);
 }
+
+.loop-section {
+    border-bottom:3px solid #777;
+    margin:0 9;
+    margin-bottom:5px;
+}
+
+.hil-command {
+    width: 97%;
+    background-color: black;
+    border-radius: 10px;
+    padding: 5px;
+    padding-left: 10px;
+    margin: 5px;
+    margin-bottom: 15px;
+}

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -270,6 +270,20 @@
     </div>
   </div>
 </li>
+
+<div id="loop-template" class="loop-section" style="display:none">
+    <div style="display:flex">
+        <div class="column" style="flex:15%; margin:5px">
+            <button class="atomic-button button-success approve" type="button" onclick="submitHilChanges(this, -3)" style="margin: 5px">Approve</button>
+            <button class="atomic-button button-embedded discard" type="button" onclick="submitHilChanges(this, -2)" style="margin: 5px;margin-bottom: 15px">Discard</button>
+        </div>
+        <div class="column codearea" style="flex:85%; margin:5px">
+            <p class="hil-linkId" style="display:none"></p>
+            <div class="hil-command" role="textbox" contenteditable spellcheck="false"></div>
+        </div>
+    </div>
+</div>
+
 <script>
     let refresher = setInterval(refresh, 10000);
     $('.section-profile').bind('destroyed', function() {
@@ -440,14 +454,8 @@
             $('#currentObfuscation').val(OPERATION.obfuscator);
             applyOperationAgents(OPERATION);
             clearTimeline();
-            for(let i=0; i<OPERATION.chain.length; i++){
-                if(OPERATION.chain[i].status === -1) {
-                    $('#hil-linkId').html(OPERATION.chain[i].unique);
-                    $('#hil-paw').html(OPERATION.chain[i].paw);
-                    $('#hil-command').html(atob(OPERATION.chain[i].command));
-                    document.getElementById("loop-modal").style.display = "block";
-                    return;
-                } else if($("#op_id_" + OPERATION.chain[i].id).length === 0) {
+            for (let i=0; i<OPERATION.chain.length; i++) {
+                if ($("#op_id_" + OPERATION.chain[i].id).length === 0) {
                     let template = $("#link-template").clone();
                     let title = OPERATION.chain[i].ability.name;
                     if(OPERATION.chain[i].cleanup) {
@@ -465,11 +473,23 @@
                         'data-encoded-cmd="'+OPERATION.chain[i].command+'"></span>' +
                         '<span id="'+OPERATION.chain[i].id+'-rm" style="font-size:11px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+', -2)">&#x274C;</span>' +
                         '<span id="'+OPERATION.chain[i].id+'-add" style="font-size:22px;float:right;" onclick="updateLinkStatus2('+lnk+','+OPERATION.id+',-3)">&#x002B;</span></div>');
+
+                    if (OPERATION.chain[i].status === -1) {
+                        let loop_template = $("#loop-template").clone();
+                        loop_template.removeAttr('id');
+                        loop_template.find('.hil-linkId').html(OPERATION.chain[i].unique);
+                        loop_template.find('.hil-command').html(atob(OPERATION.chain[i].command));
+                        loop_template.css('display', 'block');
+                        loop_template.insertAfter(template.find(".member-infos"));
+                        template.find('#'+OPERATION.chain[i].id+'-rm').remove();
+                    }
+
                     refreshUpdatableFields(OPERATION.chain[i], template, true);
 
                     template.insertAfter("#time-start");
                     $(template.find("#inner-contents")).slideUp();
                     template.show();
+
                 } else {
                     let existing = $("#op_id_"+OPERATION.chain[i].id);
                     refreshUpdatableFields(OPERATION.chain[i], existing);
@@ -693,10 +713,11 @@
         modal.find('#resultView').text('');
     }
 
-    function submitHilChanges(status){
-        document.getElementById("loop-modal").style.display = "none";
-        let command = $('#hil-command').val();
-        updateLinkStatus($('#hil-linkId').html(), status, btoa(command));
+    function submitHilChanges(ability, status){
+        parent = $(ability).parent().parent();
+        let command = $(parent).find('.hil-command').val();
+        updateLinkStatus($(parent).find('.hil-linkId').html(), status, btoa(command));
+        $(parent).parent().parent().remove();
         refresh();
         return false;
     }

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -695,11 +695,11 @@
         modal.find('#resultView').text('');
     }
 
-    function submitHilChanges(ability, status){
-        parent = $(ability).parent().parent();
-        let command = $(parent).find('.hil-command').val();
-        updateLinkStatus($(parent).find('.hil-linkId').html(), status, btoa(command));
-        $(parent).parent().parent().remove();
+    function submitHilChanges(link_button, status){
+        link_loop = $(link_button).parent().parent();
+        let command = $(link_loop).find('.hil-command').val();
+        updateLinkStatus($(link_loop).find('.hil-linkId').html(), status, btoa(command));
+        $(link_loop).parent().parent().remove();
         refresh();
         return false;
     }

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -465,6 +465,7 @@
                         loop_template.css('display', 'block');
                         loop_template.insertAfter(template.find(".member-infos"));
                         template.find('#'+OPERATION.chain[i].id+'-rm').remove();
+                        template.find('#'+OPERATION.chain[i].id+'-cm').remove()
                     }
 
                     refreshUpdatableFields(OPERATION.chain[i], template, true);

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -206,24 +206,6 @@
     </div>
 </div>
 
-<div id="loop-modal" class="modal section-profile">
-    <form class="modal-content">
-        <div class="container modal-box">
-            <div class="row duk-modal">
-                <div class="column" style="flex:25%">
-                    <p id="hil-linkId"></p>
-                    <h5 id="hil-paw"></h5>
-                    <button class="atomic-button button-success approve" type="button" onclick="submitHilChanges(-3)">Approve</button>
-                    <button class="atomic-button button-embedded discard" type="button" onclick="submitHilChanges(-2)">Discard</button>
-                </div>
-                <div class="column codearea" style="flex:75%">
-                    <textarea id="hil-command" spellcheck="false"></textarea>
-                </div>
-            </div>
-        </div>
-    </form>
-</div>
-
 <li id="potential-link-template" class="potential-links" style="display: none;margin-bottom:-50px">
     <div class="row-simple">
         <div class="column">


### PR DESCRIPTION
## Description

Operations run in manual approval mode displayed a popup every ten seconds to obtain approval for a link. This covered up the page, making usage difficult. This change now places the approve/deny buttons within a link section within the operation timeline, as shown below.

![image](https://user-images.githubusercontent.com/57109409/103022214-8999f780-4519-11eb-90a7-63f8c769f158.png)

## Type of change

- [+] Ease of use

## How Has This Been Tested?

Tested manually by running operations in manual approval mode.