### PR TITLE
Always reload data from data dir

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -173,6 +173,7 @@ class DataService(DataServiceInterface, BaseService):
         try:
             if not plugins:
                 plugins = [p for p in await self.locate('plugins') if p.data_dir and p.enabled]
+            if not [plugin for plugin in plugins if plugin.data_dir == 'data']:
                 plugins.append(Plugin(data_dir='data'))
             for plug in plugins:
                 await self._load_payloads(plug)


### PR DESCRIPTION
## Description

Starting the server does not reload abilities in CALDERA's `data/` directory.

Reported in https://github.com/mitre/caldera/issues/1955

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Create a new adversary and ability in UI, save
2. Stop CALDERA
3. Edit files in `data/`
4. Restart CALDERA, note changes

Also confirmed that creating abilities/adversaries works.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
