### PR TITLE
Don't sort YAML alphabetically

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -490,7 +490,8 @@ class RestService(RestServiceInterface, BaseService):
             # Get access
             allowed = self._get_allowed_from_access(access)
 
-        await self.get_service('file_svc').save_file(file_path, yaml.dump([final], encoding='utf-8'), '', encrypt=False)
+        await self.get_service('file_svc').save_file(file_path, yaml.dump([final], encoding='utf-8', sort_keys=False),
+                                                     '', encrypt=False)
         await self.get_service('data_svc').remove('abilities', dict(ability_id=final['id']))
         await self.get_service('data_svc').load_ability_file(file_path, allowed)
         await self._restore_exec_timeouts(final['id'], new_ability_exec_timeouts)
@@ -520,7 +521,8 @@ class RestService(RestServiceInterface, BaseService):
         return [i.display for i in await self.get_service('data_svc').locate(object_class_name, dict(id=final['id']))]
 
     async def _save_and_refresh_item(self, file_path, object_class, final, allowed):
-        await self.get_service('file_svc').save_file(file_path, yaml.dump(final, encoding='utf-8'), '', encrypt=False)
+        await self.get_service('file_svc').save_file(file_path, yaml.dump(final, encoding='utf-8', sort_keys=False),
+                                                     '', encrypt=False)
         await self.get_service('data_svc').load_yaml_file(object_class, file_path, allowed)
 
     async def _prep_new_ability(self, ab):


### PR DESCRIPTION
## Description

Implements https://github.com/mitre/caldera/issues/1923. Retains YAML ordering.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Look at an adversary profile .yml file
2. In the web UI, open the profile in the Adversaries modal and hit Save
3. Note that the order will no longer change

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
