### PR TITLE
Add framework to allow users to change agent contact via GUI

### DIFF
--- a/app/contacts/contact_gist.py
+++ b/app/contacts/contact_gist.py
@@ -51,7 +51,8 @@ class Contact(BaseWorld):
         Handles various beacons types (beacon and results)
         """
         for beacon in beacons:
-            beacon['contact'] = self.name
+            if 'contact' not in beacon:
+                beacon['contact'] = self.name
             agent, instructions = await self.contact_svc.handle_heartbeat(**beacon)
             await self._send_payloads(agent, instructions)
             await self._send_instructions(agent, instructions)
@@ -85,6 +86,8 @@ class Contact(BaseWorld):
                         sleep=await agent.calculate_sleep(),
                         watchdog=agent.watchdog,
                         instructions=json.dumps([json.dumps(i.display) for i in instructions]))
+        if agent.gui_selected_contact != agent.contact:
+            response['new_contact'] = agent.gui_selected_contact
         await self._post_instructions(self._encode_string(json.dumps(response).encode('utf-8')), agent.paw)
 
     async def _post_instructions(self, text, paw):

--- a/app/contacts/contact_gist.py
+++ b/app/contacts/contact_gist.py
@@ -88,6 +88,7 @@ class Contact(BaseWorld):
                         instructions=json.dumps([json.dumps(i.display) for i in instructions]))
         if agent.gui_selected_contact != agent.contact:
             response['new_contact'] = agent.gui_selected_contact
+            self.log.debug('Sending agent instructions to switch from C2 channel %s to %s' % (agent.contact, agent.gui_selected_contact))
         await self._post_instructions(self._encode_string(json.dumps(response).encode('utf-8')), agent.paw)
 
     async def _post_instructions(self, text, paw):

--- a/app/contacts/contact_gist.py
+++ b/app/contacts/contact_gist.py
@@ -51,8 +51,7 @@ class Contact(BaseWorld):
         Handles various beacons types (beacon and results)
         """
         for beacon in beacons:
-            if 'contact' not in beacon:
-                beacon['contact'] = self.name
+            beacon['contact'] = beacon.get('contact', self.name)
             agent, instructions = await self.contact_svc.handle_heartbeat(**beacon)
             await self._send_payloads(agent, instructions)
             await self._send_instructions(agent, instructions)
@@ -86,9 +85,9 @@ class Contact(BaseWorld):
                         sleep=await agent.calculate_sleep(),
                         watchdog=agent.watchdog,
                         instructions=json.dumps([json.dumps(i.display) for i in instructions]))
-        if agent.gui_selected_contact != agent.contact:
-            response['new_contact'] = agent.gui_selected_contact
-            self.log.debug('Sending agent instructions to switch from C2 channel %s to %s' % (agent.contact, agent.gui_selected_contact))
+        if agent.pending_contact != agent.contact:
+            response['new_contact'] = agent.pending_contact
+            self.log.debug('Sending agent instructions to switch from C2 channel %s to %s' % (agent.contact, agent.pending_contact))
         await self._post_instructions(self._encode_string(json.dumps(response).encode('utf-8')), agent.paw)
 
     async def _post_instructions(self, text, paw):

--- a/app/contacts/contact_http.py
+++ b/app/contacts/contact_http.py
@@ -13,6 +13,7 @@ class Contact(BaseWorld):
         self.description = 'Accept beacons through a REST API endpoint'
         self.app_svc = services.get('app_svc')
         self.contact_svc = services.get('contact_svc')
+        self.log = self.create_logger('contact_http')
 
     async def start(self):
         self.app_svc.application.router.add_route('POST', '/beacon', self._beacon)
@@ -32,6 +33,7 @@ class Contact(BaseWorld):
                             instructions=json.dumps([json.dumps(i.display) for i in instructions]))
             if agent.gui_selected_contact != agent.contact:
                 response['new_contact'] = agent.gui_selected_contact
+                self.log.debug('Sending agent instructions to switch from C2 channel %s to %s' % (agent.contact, agent.gui_selected_contact))
             return web.Response(text=self.contact_svc.encode_string(json.dumps(response)))
         except Exception as e:
-            logging.error('Malformed beacon: %s' % e)
+            self.log.error('Malformed beacon: %s' % e)

--- a/app/contacts/contact_http.py
+++ b/app/contacts/contact_http.py
@@ -23,12 +23,15 @@ class Contact(BaseWorld):
         try:
             profile = json.loads(self.contact_svc.decode_bytes(await request.read()))
             profile['paw'] = profile.get('paw')
-            profile['contact'] = 'http'
+            if 'contact' not in profile:
+                profile['contact'] = 'http'
             agent, instructions = await self.contact_svc.handle_heartbeat(**profile)
             response = dict(paw=agent.paw,
                             sleep=await agent.calculate_sleep(),
                             watchdog=agent.watchdog,
                             instructions=json.dumps([json.dumps(i.display) for i in instructions]))
+            if agent.gui_selected_contact != agent.contact:
+                response['new_contact'] = agent.gui_selected_contact
             return web.Response(text=self.contact_svc.encode_string(json.dumps(response)))
         except Exception as e:
             logging.error('Malformed beacon: %s' % e)

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -33,7 +33,7 @@ class AgentFieldsSchema(ma.Schema):
     host = ma.fields.String()
     watchdog = ma.fields.Integer()
     contact = ma.fields.String()
-    gui_selected_contact = ma.fields.String()
+    pending_contact = ma.fields.String()
     links = ma.fields.List(ma.fields.Nested(LinkSchema()))
     proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()))
     proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()))
@@ -104,7 +104,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.origin_link_id = origin_link_id
         self.deadman_enabled = deadman_enabled
         self.available_contacts = available_contacts if available_contacts else [self.contact]
-        self.gui_selected_contact = contact
+        self.pending_contact = contact
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -152,7 +152,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.update('contact', kwargs.get('contact'))
 
     async def gui_modification(self, **kwargs):
-        loaded = AgentFieldsSchema(only=('group', 'trusted', 'sleep_min', 'sleep_max', 'watchdog', 'gui_selected_contact')).load(kwargs)
+        loaded = AgentFieldsSchema(only=('group', 'trusted', 'sleep_min', 'sleep_max', 'watchdog', 'pending_contact')).load(kwargs)
         for k, v in loaded.items():
             self.update(k, v)
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -43,6 +43,7 @@ class ContactService(ContactServiceInterface, BaseService):
             await agent.heartbeat_modification(**kwargs)
             self.log.debug('Incoming %s beacon from %s' % (agent.contact, agent.paw))
             for result in results:
+                self.log.debug('Received result for link %s from agent %s via contact %s' % (result['id'], agent.paw, agent.contact))
                 await self._save(Result(**result))
                 operation = await self.get_service('app_svc').find_op_with_link(result['id'])
                 access = operation.access if operation else self.Access.RED

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -67,7 +67,7 @@
                 <tr id="{{ a.paw }}">
                     <td><p>{{ a.paw }}</p></td>
                     <td><p>{{ a.host }}</p></td>
-                    <td><p>{{ a.contact }}</p></td>
+                    <td><p id="{{a.paw}}-contact">{{ a.contact }}</p></td>
                     <td><button id="{{a.paw}}-pid" class="button-row" onclick="showAgentInfo('{{ a.paw }}')">{{ a.pid }}</button></td>
                     <td><p>{{ a.privilege }}</p></td>
                     <td><p onclick="deleteAgent('{{ a.paw }}')">&#x274C;</p></td>
@@ -88,8 +88,10 @@
                 <hr>
                 <table class="obfuscation-table" border=1 frame=void rules=rows>
                     <tr>
-                        <td>Contact</td>
-                        <td><p id="modal-contact"></p></td>
+                        <td>Contact *</td>
+                        <td>
+                             <select id="modal-contact" value=""/>
+                        </td>
                     </tr>
                     <tr>
                         <td>Host</td>
@@ -259,6 +261,7 @@
                         if(!a.trusted) {
                             $('#'+paw+'-pid').addClass('maroon');
                         }
+                        $('#'+paw+'-contact').text(a.contact);
                         found = true;
                     }
                 });
@@ -298,7 +301,8 @@
             'index': 'agents',
             'paw': $('#modal-paw').text(),
             'group': $('#modal-group').val(),
-            'watchdog': parseInt($('#modal-watchdog').val())
+            'watchdog': parseInt($('#modal-watchdog').val()),
+            'gui_selected_contact': $('#modal-contact').val()
         };
         if (sleepArr.length !== 0) {
             data["sleep_min"] = parseInt(sleepArr[0]);
@@ -385,8 +389,8 @@
             let agent = data[0];
             let peer_receivers = "";
             let peer_chain = "";
+            let current_contact = agent['contact'];
             parent.find('#modal-paw').html(agent['paw']);
-            parent.find('#modal-contact').html(agent['contact']);
             parent.find('#modal-host').html(agent['host']);
             parent.find('#modal-username').html(agent['username']);
             parent.find('#modal-privilege').html(agent['privilege']);
@@ -402,6 +406,29 @@
             parent.find('#modal-ppid').html(agent['ppid']);
             parent.find('#modal-executors').html(JSON.stringify(agent['executors']));
             parent.find('#modal-watchdog').html(agent['watchdog']);
+
+            // Set up contact selection
+            let num_contacts = agent['available_contacts'].length;
+            let contact_elem = parent.find('#modal-contact');
+            contact_elem.empty();
+            contact_elem.prepend(
+                $('<option></option>')
+                    .addClass('contact-option')
+                    .val(current_contact)
+                    .text(current_contact)
+            );
+            for (i = 0; i < num_contacts; i++) {
+                let curr = agent['available_contacts'][i];
+                if (curr != current_contact) {
+                    contact_elem.append(
+                        $('<option></option>')
+                            .addClass('contact-option')
+                            .val(curr)
+                            .text(curr)
+                    );
+                }
+            }
+            contact_elem.val(current_contact);
 
             // Set up peer-to-peer proxy receiver information display.
             if (Object.keys(agent['proxy_receivers']).length == 0) {

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -302,7 +302,7 @@
             'paw': $('#modal-paw').text(),
             'group': $('#modal-group').val(),
             'watchdog': parseInt($('#modal-watchdog').val()),
-            'gui_selected_contact': $('#modal-contact').val()
+            'pending_contact': $('#modal-contact').val()
         };
         if (sleepArr.length !== 0) {
             data["sleep_min"] = parseInt(sleepArr[0]);

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -93,7 +93,8 @@ class TestRestSvc:
                      'executors': ['pwsh', 'psh'], 'ppid': 0, 'sleep_min': 2, 'server': '://None:None',
                      'platform': 'windows', 'host': 'unknown', 'paw': '123', 'pid': 0,
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
-                     'proxy_receivers': {}, 'proxy_chain': [], 'origin_link_id': 0}],
+                     'proxy_receivers': {}, 'proxy_chain': [], 'origin_link_id': 0,
+                     'deadman_enabled': False, 'available_contacts': ['unknown'], 'pending_contact': 'unknown'}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)


### PR DESCRIPTION
## Description
Adding framework to allow users to change agent contact via GUI. The agent should send to the server its current C2 contact mechanism as well as available C2 channels (e.g. HTTP and GIST). When viewing agent details in the agent modal, the "contact" field now has a drop-down menu showing the agent's available C2 channels. Users can select a new C2 channel, which will be sent to the agent after the next beacon. The new C2 is passed as an additional key-value pair in the response dict. This way, if an agent does not support C2 switching, it will simply not process that new dict key and will continue using the previous C2.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

I tested switching between HTTP and GIST C2 channels using the sandcat agent (after making additional changes to the gocat plugin). I verified that the server was receiving and processing beacons correctly after each switch and that the agent information in the GUI updated accordingly.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
