### PR TITLE
Ensure an objective exists

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -370,9 +370,10 @@ class RestService(RestServiceInterface, BaseService):
                                           await self.get_service('data_svc').locate('abilities',
                                                                                     match=dict(ability_id=ab_id))]
                 if adv['objective']:
-                    adv['objective'] = [ob.display for ob in
-                                        await self.get_service('data_svc').locate('objectives',
-                                                                                  match=dict(id=adv['objective']))][0]
+                    objectives = await self.get_service('data_svc').locate('objectives',
+                                                                           match=dict(id=adv['objective']))
+                    if objectives:
+                        adv['objective'] = objectives[0].display
         return results
 
     async def _delete_data_from_memory_and_disk(self, ram_key, identifier, data):


### PR DESCRIPTION
## Description

There is a bug where, when exploding an adversary, CALDERA will silently fail if the assigned objective does not exist. This can happen if an objective is removed for whatever reason or mistyped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

To duplicate: add an objective that doesn't exist to an adversary. The load will fail.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
