### PR TITLE
Check for request when checking auth

### DIFF
--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -1,7 +1,7 @@
 import base64
 from collections import namedtuple
 
-from aiohttp import web
+from aiohttp import web, web_request
 from aiohttp.web_exceptions import HTTPUnauthorized, HTTPForbidden
 from aiohttp_security import SessionIdentityPolicy, check_permission, remember, forget
 from aiohttp_security import setup as setup_security
@@ -37,7 +37,8 @@ def check_authorization(func):
         return await func(*args, **params)
 
     async def helper(*args, **params):
-        await args[0].auth_svc.check_permissions('app', args[1])
+        if len(args) > 1 and type(args[1]) is web_request.Request:
+            await args[0].auth_svc.check_permissions('app', args[1])
         result = await process(func, *args, **params)
         return result
     return helper


### PR DESCRIPTION
## Description

Adding authorization checks to a class will cause any internal calls to public functions to break. While this may be intentional (maybe only APIs should use these decorators), it makes for some unpleasant debugging and it's not documented. I was finally able to track this down when trying to call a public method in a plugin's hook enable method, throwing the error when the plugin loads.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Add `@for_all_public_methods(check_authorization)` decorator to a class or `@check_authorization` to a specific method
2. Call a public method (or the specific method)
3. This will throw a tuple index out of range error (can easily check by calling a public method in a plugin's hook enable method)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
