### PR TITLE
Fix/http contact

### DIFF
--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -73,16 +73,17 @@ class TcpSessionHandler(BaseWorld):
             (reader, writer) = next((i.reader, i.writer) for i in self.sessions if i.id == int(session_id))
             writer.write(str.encode(' '))
             writer.write(str.encode('%s\n' % cmd))
-            self.log.info(cmd)
             await writer.drain()
             try:
-                response = await asyncio.wait_for(await self._attempt_connection(reader), timeout=10) # let's say 10 seconds are enough
+                response = await asyncio.wait_for(self._attempt_connection(reader), timeout=10) # let's say 10 seconds are enough
                 response = json.loads(response)
             except asyncio.TimeoutError:
-                response = dict(status=1, pwd='~$ ', response=str(err))
-            self.log.info(response)
+                response = dict(status=1, pwd='~$ ', response="Await timeout!")
+            except Exception as e:
+                self.log.exception(e)
             return response['status'], response["pwd"], response['response']
         except Exception as e:
+            self.log.exception(e)
             return 1, '~$ ', e
 
     """ PRIVATE """
@@ -102,7 +103,7 @@ class TcpSessionHandler(BaseWorld):
                 data += part
                 if len(part) < buffer:
                     break
-            except err:
+            except Exception as err:
                 return json.dumps(dict(status=1, pwd='~$ ', response=str(err)))
         return str(data, 'utf-8')
 


### PR DESCRIPTION
## Description

ManX plugin has a problem in communication with manx agent: it awaits only for part of a second for the response. 
If the response calculation takes more time (e.g. find command) the result will be 
e.g sleep 5 && ls
[Errno 11] Resource temporarily unavailable

This happens because of improper await server usage (write and read are blocking), so I changed the socket with writer and reader.

For a while I've left a 10 second timeout.

Also, it is really strange that caldera (as a core, framework) uses Session object from a plugin ManX, so I moved Session class from ManX to http_contact ( because Session is never used anywhere else)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Hand testing

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
