### PR TITLE
Make headers dict case insensitive

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 
 from aiohttp import web
+from multidict import CIMultiDict
 from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
@@ -28,7 +29,7 @@ class FileSvc(FileServiceInterface, BaseService):
         self.packers = dict()
 
     async def get_file(self, headers):
-        headers = dict(headers)
+        headers = CIMultiDict(headers)
         if 'file' not in headers:
             raise KeyError('File key was not provided')
 


### PR DESCRIPTION
## Description

Fixes issue with headers becoming case sensitive. Breaks file download requests from Go agent since headers (like file) get capitalized.

@mrengstrom concurs with this solution (pretty sure).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Request made from Sandcat agent:

```
POST /file/download HTTP/1.1
Host: 192.168.80.129:8888
User-Agent: Go-http-client/1.1
Content-Length: 0
File: HelloWorldCpp.exe
Paw: ndsbmf
Platform: windows
Accept-Encoding: gzip

```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
