### PR TITLE
Planner Link/Fact bug patch

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -50,7 +50,7 @@ class BasePlanningService(BaseService):
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
                 relevant_facts = await self._build_relevant_facts([x for x in variables if '_' not in x], facts)
-                if all([x for x in relevant_facts]):
+                if all(relevant_facts):
                     good_facts = [await RuleSet(rules=rules).apply_rules(facts=fact_set) for fact_set in relevant_facts]
                     valid_facts = [await self._trim_by_limit(decoded_test, g_fact[0]) for g_fact in good_facts]
                     for combo in list(itertools.product(*valid_facts)):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -49,7 +49,7 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
-                relevant_facts = await self._build_relevant_facts(variables, facts)
+                relevant_facts = await self._build_relevant_facts([x for x in variables if '_' not in x], facts)
                 if all([x for x in relevant_facts]):
                     good_facts = [await RuleSet(rules=rules).apply_rules(facts=fact_set) for fact_set in relevant_facts]
                     valid_facts = [await self._trim_by_limit(decoded_test, g_fact[0]) for g_fact in good_facts]

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -134,6 +134,8 @@ class BasePlanningService(BaseService):
     async def _build_relevant_facts(variables, facts):
         """
         Create a list of facts which are relevant to the given ability's defined variables
+        
+        Returns: (list) of lists, with each inner list providing all known values for the corresponding fact trait
         """
         relevant_facts = []
         for v in variables:

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -16,6 +16,9 @@ stop_bucket_exhaustion_params = [
     {'stopping_condition_met': True, 'operation_state': 'RUNNING', 'condition_stop': False, 'assert_value': False}
 ]
 
+test_string = '#{1_2_3} - #{a.b.c} - #{a.b.d} - #{a.b.e}'
+target_string = '#{1_2_3} - 1 - 2 - 3'
+
 
 class PlannerFake:
     def __init__(self, operation):
@@ -62,7 +65,11 @@ def setup_planning_test(loop, ability, agent, operation, data_svc, init_base_wor
                                                                             atomic_ordering=[], adversary_id='XYZ'),
                            source=tsource)
 
+    cability = ability(ability_id='321', executor='sh', platform='darwin', test=BaseWorld.encode_string(test_string),
+                       cleanup=BaseWorld.encode_string('whoami'), variations=[])
+
     loop.run_until_complete(data_svc.store(tability))
+    loop.run_until_complete(data_svc.store(cability))
 
     loop.run_until_complete(data_svc.store(
         Obfuscator(name='plain-text',
@@ -70,7 +77,7 @@ def setup_planning_test(loop, ability, agent, operation, data_svc, init_base_wor
                    module='plugins.stockpile.app.obfuscators.plain_text')
     ))
 
-    yield tability, tagent, toperation
+    yield tability, tagent, toperation, cability
 
 
 @pytest.fixture(params=stop_bucket_exhaustion_params)
@@ -78,7 +85,7 @@ def stop_bucket_exhaustion_setup(request, setup_planning_test):
     """
     Provides setup objects for tests of _stop_bucket_exhaustion().
     """
-    _, _, operation = setup_planning_test
+    _, _, operation, _ = setup_planning_test
     planner = planner_stub(stopping_condition_met=request.param['stopping_condition_met'])
     operation.state = operation.states[request.param["operation_state"]]
     return planner, operation, request.param['condition_stop'], request.param['assert_value']
@@ -89,7 +96,7 @@ class TestPlanningService:
     def test_add_ability_to_bucket(self, loop, setup_planning_test, planning_svc):
         b1 = 'salvador'
         b2 = 'hardin'
-        a, _, _ = setup_planning_test
+        a, _, _, _ = setup_planning_test
         loop.run_until_complete(planning_svc.add_ability_to_bucket(a, b1))
         assert a.buckets == [b1]
         loop.run_until_complete(planning_svc.add_ability_to_bucket(a, b2))
@@ -113,7 +120,7 @@ class TestPlanningService:
         assert loop.run_until_complete(planning_svc._stopping_condition_met(facts, stopping_condition)) is True
 
     def test_check_stopping_conditions(self, loop, fact, link, setup_planning_test, planning_svc):
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
         operation.source.facts = []
         stopping_conditions = [fact(trait='s.o.f.', value='seldon')]
 
@@ -129,7 +136,7 @@ class TestPlanningService:
         assert loop.run_until_complete(planning_svc.check_stopping_conditions(stopping_conditions, operation)) is True
 
     def test_update_stopping_condition_met(self, loop, fact, link, setup_planning_test, planning_svc):
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
         stopping_condition = fact(trait='t.c.t', value='boss')
 
         class PlannerStub():
@@ -149,7 +156,7 @@ class TestPlanningService:
         assert p.stopping_condition_met is True
 
     def test_sort_links(self, loop, link, planning_svc, setup_planning_test):
-        a, _, _ = setup_planning_test
+        a, _, _, _ = setup_planning_test
         l1 = link(command='m', paw='1', ability=a, score=1)
         l2 = link(command='a', paw='2', ability=a, score=2)
         l3 = link(command='l', paw='3', ability=a, score=3)
@@ -169,7 +176,7 @@ class TestPlanningService:
         """
         Case 1 - let planner run until it stops itself after bucket 'three'.
         """
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
         p = PlannerFake(operation)
         loop.run_until_complete(planning_svc.execute_planner(p, publish_transitions=False))
         assert p.calls == ['one', 'two', 'three']
@@ -179,7 +186,7 @@ class TestPlanningService:
         Case 2 - start planner but then hijack operation after bucket 'two and flag that stopping condition
         been found, thus stopping the planner when it attempt to proceed to next bucket
         """
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
 
         async def stub_update_stopping_condition_met(planner, operation):
             if planner.calls == ['one', 'two']:
@@ -194,7 +201,7 @@ class TestPlanningService:
         Case 3 - start planner but then hijack operation and set it to 'FINISH' state, thus
         stopping the planner when it attempts to proceed to next bucket
         """
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
 
         async def stub_update_stopping_condition_met_1(planner, operation):
             if planner.calls == ['one']:
@@ -205,7 +212,7 @@ class TestPlanningService:
         assert p.calls == ['one']
 
     def test_get_cleanup_links(self, loop, setup_planning_test, planning_svc):
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
         operation.add_link(Link.load(dict(command='', paw=agent.paw, ability=ability, status=0)))
         links = loop.run_until_complete(
             planning_svc.get_cleanup_links(operation=operation, agent=agent)
@@ -215,6 +222,18 @@ class TestPlanningService:
         assert link_list[0].command == ability.cleanup[0]
 
     def test_generate_and_trim_links(self, loop, setup_planning_test, planning_svc):
-        ability, agent, operation = setup_planning_test
+        ability, agent, operation, _ = setup_planning_test
         generated_links = loop.run_until_complete(planning_svc.generate_and_trim_links(agent, operation, [ability]))
         assert 1 == len(generated_links)
+
+    def test_link_fact_coverage(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        link = Link.load(dict(command=BaseWorld.encode_string(test_string), paw=agent.paw, ability=ability, status=0))
+        f1 = Fact(trait='a.b.c', value='1')
+        f2 = Fact(trait='a.b.d', value='2')
+        f3 = Fact(trait='a.b.e', value='3')
+
+        gen = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=[f1, f2, f3]))
+
+        assert len(gen) == 2
+        assert BaseWorld.decode_bytes(gen[1].display['command']) == target_string


### PR DESCRIPTION
## Description

Fix for links with multiple facts not being populated.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has be run within AWS under the atomic and batch planners with the Alice adversary. @mchan143 has confirmed that this remains compatible with the link id tracking changes. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [Not Necessary] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

### Notes
While testing, I noticed that our regex for searching doesn't account for the difference between variables `_` and facts `.`. One knock-on effect of this is that if a variable and fact share the same general name, i.e. `a_b_c` and `a.b.c`, weird breakages will happen. I don't think this will happen anytime soon, and I don't think overhauling the regex is worth it at the moment as a result.