### PR TITLE
Manual links

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -88,7 +88,8 @@ class RestApi(BaseWorld):
                     chain=lambda d: self.rest_svc.update_chain_data(d),
                     operations=lambda d: self.rest_svc.create_operation(access, d),
                     schedule=lambda d: self.rest_svc.create_schedule(access, d),
-                    link=lambda d: self.rest_svc.apply_potential_link(Link.load(d))
+                    link=lambda d: self.rest_svc.apply_potential_link(Link.load(d)),
+                    manual_link=lambda d: self.rest_svc.add_manual_link(access, d)
                 ),
                 POST=dict(
                     operation_report=lambda d: self.rest_svc.display_operation_report(d),

--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -89,7 +89,7 @@ class RestApi(BaseWorld):
                     operations=lambda d: self.rest_svc.create_operation(access, d),
                     schedule=lambda d: self.rest_svc.create_schedule(access, d),
                     link=lambda d: self.rest_svc.apply_potential_link(Link.load(d)),
-                    manual_link=lambda d: self.rest_svc.add_manual_link(access, d)
+                    manual_command=lambda d: self.rest_svc.add_manual_command(access, d)
                 ),
                 POST=dict(
                     operation_report=lambda d: self.rest_svc.display_operation_report(d),

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -197,7 +197,7 @@ class RestService(RestServiceInterface, BaseService):
         operation = await self.get_service('app_svc').find_op_with_link(link.id)
         return await operation.apply(link)
 
-    async def add_manual_link(self, access, data):
+    async def add_manual_command(self, access, data):
         for parameter in ['operation', 'agent', 'executor', 'command']:
             if parameter not in data.keys():
                 return dict(error='Missing parameter: %s' % parameter)
@@ -221,7 +221,7 @@ class RestService(RestServiceInterface, BaseService):
 
         encoded_command = self.encode_string(data['command'])
         ability = Ability(ability_id='(auto-generated)', tactic='(auto-generated)', technique_id='(auto-generated)',
-                          technique='(auto-generated)', name='Manual Link', description='Manual link ability',
+                          technique='(auto-generated)', name='Manual Command', description='Manual command ability',
                           cleanup='', test=encoded_command, executor=data['executor'], platform=agent.platform,
                           payloads=[], parsers=[], requirements=[], privilege=None, variations=[])
         link = Link.load(dict(command=encoded_command, paw=agent.paw, cleanup=0, ability=ability, score=0, jitter=2,

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -190,6 +190,39 @@
     margin-right: 5%;
     cursor: pointer;
 }
+.op-manual-commands {
+    float: right;
+    font-size: 13px;
+    margin-right: 3%;
+    cursor: pointer;
+}
+#manual-command-settings {
+    display: flex;
+    width: 80%;
+    margin: 2em auto 0;
+}
+#manual-executor {
+    flex: 12%;
+    margin: 0;
+    padding: 0;
+    color: gainsboro;
+    background-color: black;
+    border-color: gainsboro;
+}
+#manual-command {
+    flex: 76%;
+    margin: 0 1em;
+    text-align: left;
+    color: gainsboro;
+    background-color: black;
+    border-color: gainsboro;
+}
+#manual-run {
+    flex: 12%;
+    height: 2.3em;
+    margin: 0;
+    padding: 0;
+}
 .profile-tests {
     float: left;
     width: 100%;

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -159,6 +159,7 @@
       </div>
       <div id="content">
           <span class="op-potential-links" onclick="document.getElementById('potential-modal').style.display='block';">&#10010; potential links</span>
+          <span class="op-manual-commands" onclick="document.getElementById('manual-modal').style.display='block';">&#10010; manual command</span>
           <br>
           <ul id="timeline" class="timeline">
               <li id="time-start">
@@ -201,6 +202,26 @@
             </div>
             <div class="imgcontainer">
                 <span onclick="closePotentialLinksModal()" class="close" title="Close Modal">&times;</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="manual-modal" class="modal">
+    <div class="modal-content" style="width:100%;">
+        <div class="container section-profile row ability-viewer modal-box">
+            <div class="column control-width" style="flex:100%;">
+                <select id="manual-agent" onchange="selectManualAgent();">
+                    <option disabled selected>Choose an agent</option>
+                </select>
+                <div id="manual-command-settings" style="display:none">
+                  <select id="manual-executor"></select>
+                  <input type="text" id="manual-command" placeholder="Run arbitrary command" />
+                  <button id="manual-run" type="button" class="button-success atomic-button" onclick="runManualCommand()">Run</button>
+                </div>
+            </div>
+            <div class="imgcontainer">
+                <span onclick="closeManualCommandModal()" class="close" title="Close Modal">&times;</span>
             </div>
         </div>
     </div>
@@ -525,6 +546,12 @@
                         .attr("value", 'agent-'+paw)
                         .text(operation.host_group[i].display_name + '-'+operation.host_group[i].paw));
             }
+            if($("#manual-agent option[value='" + paw + "'").length === 0){
+                 $('#manual-agent').append($("<option></option>")
+                        .attr('value', paw)
+                        .text(operation.host_group[i].display_name + '-'+operation.host_group[i].paw)
+                        .data('executors', operation.host_group[i].executors));
+            }
         }
     }
 
@@ -609,6 +636,57 @@
 
     function updatePotentialLinkCount(){
         $('#potential-links-count').html($('#potential-links li').length + ' potential links');
+    }
+
+    function selectManualAgent() {
+        $('#manual-executor').empty();
+        let executorShells = {
+            'psh': 'PS >',
+            'cmd': '>',
+            'sh': '$'
+        };
+        $.each($('#manual-agent option:selected').data('executors'), function(index, executor) {
+            if (executor in executorShells) {
+                var newOption = $('<option></option>')
+                                .attr('value', executor)
+                                .text(executorShells[executor]);
+                                $('#manual-executor').append(newOption);
+            }
+        });
+        $('#manual-command-settings').show();
+    }
+
+    function closeManualCommandModal() {
+        $('#manual-modal').hide();
+        $('#manual-agent-filter').prop('selectedIndex', 0);
+        $('#manual-command-settings').hide();
+    }
+
+    function runManualCommand() {
+        function runManualCommandCallback(data) {
+            if (data['error']) {
+                stream('Error running manual command: ' + data['error']);
+            } else {
+                stream('Manual command queued');
+                $('#manual-command').val('');
+            }
+            $('#manual-run').addClass('button-success').removeClass('button-notready');
+        }
+        let agent = $('#manual-agent').val();
+        let operation = $('#operation-list').val();
+        let executor = $('#manual-executor').val();
+        let command = $('#manual-command').val();
+        if (agent !== null && operation !== null && executor !== null && command !== '') {
+            $('#manual-run').addClass('button-notready').removeClass('button-success');
+            let request = {
+                'index': 'manual_command',
+                'agent': agent,
+                'operation': operation,
+                'executor': executor,
+                'command': command
+            };
+            restRequest('PUT', request, runManualCommandCallback);
+        }
     }
 
     function refreshUpdatableFields(chain, div, newEntry=false){


### PR DESCRIPTION
## Description

Allows a user to run arbitrary commands in an operation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Create an operation
1. Click "manual command+"
1. Select agent
1. Select executor
1. Type command
1. Hit run

Request example:

```
PUT /api/rest HTTP/1.1
...

{"index":"manual_command","agent":"mnmkww","operation":"893546","executor":"psh","command":"ps"}
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [???] I have made corresponding changes to the documentation
- [???] I have added tests that prove my fix is effective or that my feature works
