### PR TITLE
op can check whether it has run a given ability ID

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -115,6 +115,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
         learned_relationships = [r for lnk in self.chain for r in lnk.relationships]
         return seeded_relationships + learned_relationships
 
+    def ran_ability_id(self, ability_id):
+        return ability_id in [link.ability.ability_id for link in self.chain if link.finish]
+
     async def apply(self, link):
         while self.state != self.states['RUNNING']:
             if self.state == self.states['RUN_ONE_LINK']:

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -1,0 +1,13 @@
+from unittest.mock import MagicMock
+
+from app.objects.c_operation import Operation
+from app.objects.secondclass.c_link import Link
+
+
+class TestOperation:
+
+    def test_ran_ability_id(self, ability, adversary):
+        op = Operation(name='test', agents=[], adversary=adversary)
+        mock_link = MagicMock(spec=Link, ability=ability(ability_id='123'), finish='2021-01-01 08:00:00')
+        op.chain = [mock_link]
+        assert op.ran_ability_id('123')


### PR DESCRIPTION
## Description

Function added for operation to check whether it has run a given ability ID already

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Used in combination with the blue certification when flags check whether an ability ID has been run.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
