### PR TITLE
VIRTS1541: Warn user if atomic selected and profile has repeatable abilities 

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -98,7 +98,8 @@ class RestApi(BaseWorld):
                     link=lambda d: self.rest_svc.get_potential_links(**d),
                     operation=lambda d: self.rest_svc.update_operation(**d),
                     task=lambda d: self.rest_svc.task_agent_with_ability(**d),
-                    agent_configuration=lambda d: self.rest_svc.get_agent_configuration(d)
+                    agent_configuration=lambda d: self.rest_svc.get_agent_configuration(d),
+                    check_repeatable_abilities=lambda d: self.rest_svc.check_repeatable_abilities(d)
                 )
             )
             if index not in options[request.method]:

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -264,6 +264,13 @@ class RestService(RestServiceInterface, BaseService):
 
         return dict(abilities=raw_abilities, app_config=app_config)
 
+    async def check_repeatable_abilities(self, data):
+        adversary = (await self.get_service('data_svc').locate('adversaries',
+                                                               match=dict(adversary_id=data.get('adversary_id'))))[0]
+        has_repeatable = [ab.repeatable for ab_id in adversary.atomic_ordering for ab in
+                          await self.get_service('data_svc').locate('abilities', match=dict(ability_id=ab_id))]
+        return dict(has_repeatable=any(has_repeatable))
+
     """ PRIVATE """
 
     async def _build_operation_object(self, access, data):

--- a/static/css/navigate.css
+++ b/static/css/navigate.css
@@ -55,6 +55,7 @@
    position: fixed;
    left: 0;
    bottom: 0;
+   height: 30px;
    width: 100%;
    z-index: 105;
    background-color: var(--navbar-color);

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -49,7 +49,7 @@
                     <option id="qgroup-{{ g }}" value="{{ g }}">{{ g }}</option>
                 {% endfor %}
               </select>
-              <select name="work" id="queueFlow" class="queueOption" style="opacity:0.5" disabled="true">
+              <select name="work" id="queueFlow" class="queueOption" style="opacity:0.5" disabled="true" onchange="advHasRepeatableAbilities()">
                 <option value="" class="default-option" selected>No adversary (manual)</option>
                 {% for adv in adversaries %}
                   <option id="qflow-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
@@ -738,4 +738,19 @@
         $('#resultCmd').html(atob(command));
     }
     //# sourceURL=operations.js
+
+    function advHasRepeatableAbilities() {
+        function callback(data) {
+            if (data['has_repeatable']) {
+                stream('The profile selected has repeatable abilities. When used in combination with the atomic planner, the atomic planner may repeatedly retry the same fact value with the repeatable ability.');
+            }
+            else {
+                stream('');
+            }
+        }
+        if ($('#queuePlanner').val() == 'atomic') {
+            let adversaryId = $('#queueFlow').val();
+            restRequest('POST', {'index':'check_repeatable_abilities', 'adversary_id':adversaryId}, callback);
+        }
+    }
 </script>

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -188,3 +188,13 @@ class TestRestSvc:
         link = operation.potential_links[0]
         loop.run_until_complete(internal_rest_svc.apply_potential_link(link))
         assert 1 == len(operation.chain)
+
+    def test_check_repeatable_abilities(self, loop, rest_svc, data_svc):
+        loop.run_until_complete(data_svc.store(
+            Ability(ability_id='456', test=BaseWorld.encode_string('whoami'), variations=[],
+                    executor='psh', platform='windows', repeatable=True))
+        )
+        adversary = Adversary(adversary_id='123', name='test', description='test', atomic_ordering=['456'])
+        loop.run_until_complete(data_svc.store(adversary))
+        internal_rest_svc = rest_svc(loop)
+        assert internal_rest_svc.check_repeatable_abilities(dict(adversary_id='456'))


### PR DESCRIPTION
## Description

It's not currently documented anywhere indicating repeatable abilities should be used with the batch planner. This fix streams a warning to the GUI if the selected profile has repeatable abilities and the atomic planner is selected.

Using a profile with a repeatable ability and the atomic planner, atomic will attempt to execute links as they are created. However, a repeatable ability will continuously be created and cause the planner to loop infinitely on executing that same ability.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Through the GUI.

Stream warning appears when:
- an adversary profile with repeatable abilities is selected and atomic (the default planner) is selected
- the Incident Responder defender profile is selected and atomic is selected

Stream warning disappears when another profile with no repeatable abilities is selected instead.

Stream warning does not appear if the profile selected has no repeatable abilities or if the planner selected is not atomic.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation - https://github.com/mitre/fieldmanual/pull/51
- [x] I have added tests that prove my fix is effective or that my feature works
