### PR TITLE
lower casing tactics on abilities created through the rest endpoint

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -77,7 +77,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         super().__init__()
         self._test = test
         self.ability_id = ability_id
-        self.tactic = tactic
+        self.tactic = tactic.lower() if tactic else None
         self.technique_name = technique
         self.technique_id = technique_id
         self.name = name

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -507,11 +507,12 @@ class RestService(RestServiceInterface, BaseService):
                            'alphanumeric characters, hyphens, and underscores.' % ab.get('id'))
             return []
 
-        # Validate tactic, used for directory creation
+        # Validate tactic, used for directory creation, lower case if present
         if not ab.get('tactic') or not validator.match(ab.get('tactic')):
             self.log.debug('Invalid ability tactic "%s". Tactics can only contain '
                            'alphanumeric characters, hyphens, and underscores.' % ab.get('tactic'))
             return []
+        ab['tactic'] = ab.get('tactic').lower()
 
         # Validate platforms, ability will not be loaded if empty
         if not ab.get('platforms'):


### PR DESCRIPTION
## Description

lower casing tactics on abilities created through the rest endpoint and when loaded as well

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added abilities that were mixed/non-lower case from the web gui and verified that what was stored in the yaml file (and thus, object store) was of all lower case.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
