### PR TITLE
Virts 1740 modal creation time

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -40,6 +40,7 @@ class AgentFieldsSchema(ma.Schema):
     origin_link_id = ma.fields.Integer()
     deadman_enabled = ma.fields.Boolean()
     available_contacts = ma.fields.List(ma.fields.String())
+    created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -110,6 +110,10 @@
                         <td><p id="modal-last_seen"></p></td>
                     </tr>
                     <tr>
+                        <td>Created</td>
+                        <td><p id="modal-created"></p></td>
+                    </tr>
+                    <tr>
                         <td>Group *</td>
                         <td><input id="modal-group" style="text-align: left"/></td>
                     </tr>
@@ -417,6 +421,7 @@
             parent.find('#modal-privilege').text(agent['privilege']);
             parent.find('#modal-last_seen').text(agent['last_seen']);
             parent.find('#modal-exe_name').text(agent['exe_name']);
+            parent.find('#modal-created').html(agent['created']);
             parent.find('#modal-group').val(agent['group']);
             parent.find('#modal-sleep').val(agent['sleep_min']+'/'+agent['sleep_max']);
             parent.find('#modal-watchdog').val(agent['watchdog']);

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -104,6 +104,7 @@ class TestRestSvc:
         operation[0].pop('id')
         operation[0]['host_group'][0].pop('last_seen')
         operation[0].pop('start')
+        operation[0]['host_group'][0].pop('created')
         assert want == operation[0]
 
     def test_delete_ability(self, loop, rest_svc, file_svc):


### PR DESCRIPTION
## Description

Changed agent modal to display a Created attribute which shows the time the agent was created as a datetime string.

## Type of change

- [*] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran pytest, all tests passed after fixing one of the tests to accommodate the change.


## Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
