### PR TITLE
VIRTS1541: Warn user if atomic selected and profile has repeatable abilities (revised)

### DIFF
--- a/app/objects/c_adversary.py
+++ b/app/objects/c_adversary.py
@@ -67,7 +67,7 @@ class Adversary(FirstClassObjectInterface, BaseObject):
         existing.update('atomic_ordering', self.atomic_ordering)
         existing.update('objective', self.objective)
         existing.update('tags', self.tags)
-        existing.update('has_repeatable_abilities', self.check_repeatable_abilities(ram))
+        existing.update('has_repeatable_abilities', self.check_repeatable_abilities(ram['abilities']))
         return existing
 
     def has_ability(self, ability):
@@ -82,5 +82,5 @@ class Adversary(FirstClassObjectInterface, BaseObject):
                 return plugin
         return None
 
-    def check_repeatable_abilities(self, ram):
-        return any(ab.repeatable for ab_id in self.atomic_ordering for ab in ram['abilities'] if ab.ability_id == ab_id)
+    def check_repeatable_abilities(self, ability_list):
+        return any(ab.repeatable for ab_id in self.atomic_ordering for ab in ability_list if ab.ability_id == ab_id)

--- a/app/objects/c_adversary.py
+++ b/app/objects/c_adversary.py
@@ -14,6 +14,7 @@ class AdversarySchema(ma.Schema):
     atomic_ordering = ma.fields.List(ma.fields.String())
     objective = ma.fields.String()
     tags = ma.fields.List(ma.fields.String())
+    has_repeatable_abilities = ma.fields.Boolean()
 
     @ma.pre_load
     def fix_id(self, adversary, **_):
@@ -54,6 +55,7 @@ class Adversary(FirstClassObjectInterface, BaseObject):
         self.atomic_ordering = atomic_ordering
         self.objective = objective
         self.tags = set(tags) if tags else set()
+        self.has_repeatable_abilities = False
 
     def store(self, ram):
         existing = self.retrieve(ram['adversaries'], self.unique)
@@ -65,6 +67,7 @@ class Adversary(FirstClassObjectInterface, BaseObject):
         existing.update('atomic_ordering', self.atomic_ordering)
         existing.update('objective', self.objective)
         existing.update('tags', self.tags)
+        existing.update('has_repeatable_abilities', self.check_repeatable_abilities(ram))
         return existing
 
     def has_ability(self, ability):
@@ -78,3 +81,6 @@ class Adversary(FirstClassObjectInterface, BaseObject):
             if await self.walk_file_path(os.path.join('plugins', plugin, 'data', ''), '%s.yml' % self.adversary_id):
                 return plugin
         return None
+
+    def check_repeatable_abilities(self, ram):
+        return any(ab.repeatable for ab_id in self.atomic_ordering for ab in ram['abilities'] if ab.ability_id == ab_id)

--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -15,6 +15,7 @@ class PlannerSchema(ma.Schema):
     description = ma.fields.String()
     stopping_conditions = ma.fields.List(ma.fields.Nested(FactSchema()))
     ignore_enforcement_modules = ma.fields.List(ma.fields.String())
+    allow_repeatable_abilities = ma.fields.Boolean()
 
     @ma.post_load()
     def build_planner(self, data, **_):
@@ -31,7 +32,7 @@ class Planner(FirstClassObjectInterface, BaseObject):
         return self.hash(self.name)
 
     def __init__(self, planner_id, name, module, params, stopping_conditions=None, description=None,
-                 ignore_enforcement_modules=()):
+                 ignore_enforcement_modules=(), allow_repeatable_abilities=False):
         super().__init__()
         self.planner_id = planner_id
         self.name = name
@@ -40,6 +41,7 @@ class Planner(FirstClassObjectInterface, BaseObject):
         self.description = description
         self.stopping_conditions = self._set_stopping_conditions(stopping_conditions)
         self.ignore_enforcement_modules = ignore_enforcement_modules
+        self.allow_repeatable_abilities = allow_repeatable_abilities
 
     def store(self, ram):
         existing = self.retrieve(ram['planners'], self.unique)

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -345,4 +345,4 @@ class DataService(DataServiceInterface, BaseService):
             for ability_id in adv.atomic_ordering:
                 if not next((ability for ability in self.ram['abilities'] if ability.ability_id == ability_id), None):
                     self.log.warning('Ability referenced in %s but not found: %s' % (adv.adversary_id, ability_id))
-            adv.has_repeatable_abilities = adv.check_repeatable_abilities(self.ram)
+            adv.has_repeatable_abilities = adv.check_repeatable_abilities(self.ram['abilities'])

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -345,3 +345,4 @@ class DataService(DataServiceInterface, BaseService):
             for ability_id in adv.atomic_ordering:
                 if not next((ability for ability in self.ram['abilities'] if ability.ability_id == ability_id), None):
                     self.log.warning('Ability referenced in %s but not found: %s' % (adv.adversary_id, ability_id))
+            adv.has_repeatable_abilities = adv.check_repeatable_abilities(self.ram)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -469,7 +469,7 @@ class RestService(RestServiceInterface, BaseService):
         await self._save_and_refresh_item(file_path, Adversary, final, allowed)
         stored_adv = await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))
         for a in stored_adv:
-            a.has_repeatable_abilities = a.check_repeatable_abilities(self.get_service('data_svc').ram)
+            a.has_repeatable_abilities = a.check_repeatable_abilities(self.get_service('data_svc').ram['abilities'])
         return [a.display for a in stored_adv]
 
     async def _persist_ability(self, access, ab):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -467,7 +467,10 @@ class RestService(RestServiceInterface, BaseService):
         if len(await self.get_service('data_svc').locate('objectives', match=dict(id=final['objective']))) == 0:
             final['objective'] = obj_default.id
         await self._save_and_refresh_item(file_path, Adversary, final, allowed)
-        return [a.display for a in await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))]
+        stored_adv = await self._services.get('data_svc').locate('adversaries', dict(adversary_id=final["id"]))
+        for a in stored_adv:
+            a.has_repeatable_abilities = a.check_repeatable_abilities(self.get_service('data_svc').ram)
+        return [a.display for a in stored_adv]
 
     async def _persist_ability(self, access, ab):
         """Persist ability.

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -29,6 +29,14 @@ class BaseObject(BaseWorld):
             return self
 
     def update(self, field, value):
+        """
+        Updates the given field to the given value as long as the value is not None and the new value is different from
+        the current value. Ignoring None prevents current property values from being overwritten to None if the given
+        property is not intentionally passed back to be updated (example: Agent heartbeat)
+
+        :param field: object property to update
+        :param value: value to update to
+        """
         if (value is not None) and (value != self.__getattribute__(field)):
             self.__setattr__(field, value)
 

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -29,7 +29,7 @@ class BaseObject(BaseWorld):
             return self
 
     def update(self, field, value):
-        if (value or type(value) == list) and (value != self.__getattribute__(field)):
+        if (value is not None) and (value != self.__getattribute__(field)):
             self.__setattr__(field, value)
 
     def search_tags(self, value):

--- a/static/css/navigate.css
+++ b/static/css/navigate.css
@@ -55,6 +55,7 @@
    position: fixed;
    left: 0;
    bottom: 0;
+   height: 30px;
    width: 100%;
    z-index: 105;
    background-color: var(--navbar-color);

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -81,8 +81,10 @@
                 {% for p in planners %}
                   {% if p.name == "atomic" %}
                     <option value="{{ p.name }}" selected>Use {{ p.name }} planner</option>
+                  {% elif p.allow_repeatable_abilities %}
+                    <option value="{{ p.name }}" data-allow-repeatable-abilities>Use {{ p.name }} planner</option>
                   {% else %}
-                      <option value="{{ p.name }}">Use {{ p.name }} planner</option>
+                    <option value="{{ p.name }}">Use {{ p.name }} planner</option>
                   {% endif %}
                 {% endfor %}
               </select>
@@ -822,11 +824,22 @@
     //# sourceURL=operations.js
 
     function advHasRepeatableAbilities(selectedAdversary) {
-        if ($('#queuePlanner').val() == 'atomic' && $('#qflow-' + selectedAdversary).data('has-repeatable') != null) {
-            stream('The profile selected has repeatable abilities. When used in combination with the atomic planner, the atomic planner may repeatedly retry the same fact value with the repeatable ability.');
+        if ($('#qflow-' + selectedAdversary).data('has-repeatable') != null) {
+            $("#queuePlanner option").each(function() {
+                if (!this.hasAttribute('data-allow-repeatable-abilities')) {
+                    this.setAttribute('disabled', '');
+                    this.removeAttribute('selected');
+                }
+             });
+            $('#queuePlanner option[value="batch"]').prop('selected', 'selected');
+            $('#queuePlanner').val('batch');
+             stream('The profile selected has repeatable abilities. Some planners do not support repeatable abilities and have been disabled.');
         }
         else {
-            stream('');
+            $('#queuePlanner option').each(function() { this.removeAttribute('disabled'); this.removeAttribute('selected') });
+            $('#queuePlanner option[value="atomic"]').prop('selected', 'selected');
+            $('#queuePlanner').val('atomic');
+            stream('Selected planner defaulting to ' + $('#queuePlanner').val() + '.');
         }
     }
 </script>

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -49,10 +49,14 @@
                     <option id="qgroup-{{ g }}" value="{{ g }}">{{ g }}</option>
                 {% endfor %}
               </select>
-              <select name="work" id="queueFlow" class="queueOption" style="opacity:0.5" disabled="true">
+              <select name="work" id="queueFlow" class="queueOption" style="opacity:0.5" disabled="true" onchange="advHasRepeatableAbilities(this.value)">
                 <option value="" class="default-option" selected>No adversary (manual)</option>
                 {% for adv in adversaries %}
-                  <option id="qflow-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
+                  {% if adv.has_repeatable_abilities %}
+                    <option id="qflow-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}" data-has-repeatable>{{ adv.name }}</option>
+                  {% else %}
+                    <option id="qflow-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
+                  {% endif %}
                 {% endfor %}
               </select>
               <select name="phases" id="queueAutoClose" class="queueOption" style="opacity:0.5" disabled="true">
@@ -816,4 +820,13 @@
         $('#resultCmd').html(atob(command));
     }
     //# sourceURL=operations.js
+
+    function advHasRepeatableAbilities(selectedAdversary) {
+        if ($('#queuePlanner').val() == 'atomic' && $('#qflow-' + selectedAdversary).data('has-repeatable') != null) {
+            stream('The profile selected has repeatable abilities. When used in combination with the atomic planner, the atomic planner may repeatedly retry the same fact value with the repeatable ability.');
+        }
+        else {
+            stream('');
+        }
+    }
 </script>

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -830,16 +830,14 @@
                     this.setAttribute('disabled', '');
                     this.removeAttribute('selected');
                 }
-             });
-            $('#queuePlanner option[value="batch"]').prop('selected', 'selected');
-            $('#queuePlanner').val('batch');
-             stream('The profile selected has repeatable abilities. Some planners do not support repeatable abilities and have been disabled.');
+            });
+            $('#queuePlanner').val($('#queuePlanner option:not([disabled]):first').val());
+            stream('The profile selected has repeatable abilities. Some planners do not support repeatable abilities and have been disabled.');
         }
         else {
             $('#queuePlanner option').each(function() { this.removeAttribute('disabled'); this.removeAttribute('selected') });
-            $('#queuePlanner option[value="atomic"]').prop('selected', 'selected');
-            $('#queuePlanner').val('atomic');
-            stream('Selected planner defaulting to ' + $('#queuePlanner').val() + '.');
+            $('#queuePlanner').val($('#queuePlanner option:not([disabled]):first').val());
+            stream('Selecting first available planner: ' + $('#queuePlanner').val() + '.');
         }
     }
 </script>

--- a/tests/objects/test_adversary.py
+++ b/tests/objects/test_adversary.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.objects.c_ability import Ability
+from app.objects.c_adversary import Adversary
+
+
+@pytest.fixture
+def unrepeatable_ability():
+    return Ability(ability_id='123', repeatable=False)
+
+
+@pytest.fixture
+def repeatable_ability():
+    return Ability(ability_id='456', repeatable=True)
+
+
+class TestAdversary:
+
+    def test_store_not_existing(self, adversary):
+        test_adversary = adversary()
+        ram = dict(adversaries=[])
+        test_adversary.store(ram)
+        assert ram == dict(adversaries=[test_adversary])
+
+    def test_store_existing(self, unrepeatable_ability, repeatable_ability):
+        test_adversary = Adversary(adversary_id='123', name='test', description='',
+                                   atomic_ordering=['123'])
+        ram = dict(adversaries=[test_adversary], abilities=[unrepeatable_ability, repeatable_ability])
+        test_adversary.atomic_ordering = ['456']
+        test_adversary.store(ram)
+        assert ram['adversaries'][0].has_repeatable_abilities
+        assert ram['adversaries'][0].atomic_ordering[0] == '456'
+
+    def test_check_repeatable_abilities(self, repeatable_ability):
+        test_adversary = Adversary(adversary_id='123', name='test', description='',
+                                   atomic_ordering=['456'])
+        ram = dict(adversaries=[test_adversary], abilities=[repeatable_ability])
+        assert test_adversary.check_repeatable_abilities(ram)
+
+    def test_update_empty_list(self, adversary, ability):
+        test_adversary = adversary()
+        test_adversary.atomic_ordering = [ability()]
+        test_adversary.update('atomic_ordering', [])
+        assert test_adversary.atomic_ordering == []
+
+    def test_update_boolean(self, adversary):
+        test_adversary = adversary()
+        test_adversary.update('has_repeatable_abilities', False)
+        assert not test_adversary.has_repeatable_abilities

--- a/tests/objects/test_adversary.py
+++ b/tests/objects/test_adversary.py
@@ -35,7 +35,7 @@ class TestAdversary:
         test_adversary = Adversary(adversary_id='123', name='test', description='',
                                    atomic_ordering=['456'])
         ram = dict(adversaries=[test_adversary], abilities=[repeatable_ability])
-        assert test_adversary.check_repeatable_abilities(ram)
+        assert test_adversary.check_repeatable_abilities(ram['abilities'])
 
     def test_update_empty_list(self, adversary, ability):
         test_adversary = adversary()

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -82,7 +82,8 @@ class TestRestSvc:
     def test_create_operation(self, loop, rest_svc, data_svc):
         want = {'name': 'Test',
                 'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc', 'adversary_id': 'ad-hoc',
-                              'atomic_ordering': [], 'objective': None, 'tags': []}, 'state': 'finished',
+                              'atomic_ordering': [], 'objective': None, 'tags': [], 'has_repeatable_abilities': False},
+                'state': 'finished',
                 'planner': {'name': 'test', 'description': None, 'module': 'test', 'stopping_conditions': [],
                             'params': {},
                             'ignore_enforcement_modules': [], 'id': '123'},

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -86,7 +86,7 @@ class TestRestSvc:
                 'state': 'finished',
                 'planner': {'name': 'test', 'description': None, 'module': 'test', 'stopping_conditions': [],
                             'params': {},
-                            'ignore_enforcement_modules': [], 'id': '123'},
+                            'ignore_enforcement_modules': [], 'id': '123', 'allow_repeatable_abilities': False},
                 'jitter': '2/8',
                 'host_group': [
                     {'trusted': True, 'architecture': 'unknown', 'watchdog': 0, 'contact': 'unknown',


### PR DESCRIPTION
## Description

**REVISED PR** (original PR [here](https://github.com/mitre/caldera/pull/2015)) 

Instead of the addition of an API endpoint, the `has_repeatable_abilities` property was added to the Adversary object. 

A point to make regarding the changes below, because abilities are loaded _after_ adversary profiles have been loaded, `has_repeatable_abilities` had to be updated after the initial call to `store` an Adversary object. Simply calling `store()` on a brand new Adversary object will _not_ update the `has_repeatable_abilities` property. This has been remediated by following with a call to `check_repeatable_abilities` where possible.

**Description from the original PR:**

It's not currently documented anywhere indicating repeatable abilities should be used with the batch planner. This fix streams a warning to the GUI if the selected profile has repeatable abilities and the atomic planner is selected.

Using a profile with a repeatable ability and the atomic planner, atomic will attempt to execute links as they are created. However, a repeatable ability will continuously be created and cause the planner to loop infinitely on executing that same ability.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added adversary profile to the GUI with repeatable abilities
- Added repeatable ability to an adversary profile that did not previously have repeatable abilities
- Removed repeatable ability from an adversary profile that previously had a repeatable ability
- Loaded profiles with and without repeatable abilities into a fresh server

Stream warning appears when:

- an adversary profile with repeatable abilities is selected and atomic (the default planner) is selected
- the Incident Responder defender profile is selected and atomic is selected

Stream warning disappears when another profile with no repeatable abilities is selected instead.

Stream warning does not appear if the profile selected has no repeatable abilities or if the planner selected is not atomic.

## Checklist:

- [X] My code follows the style guidelines of this project (less certain about the tests, feel free to critique)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation - https://github.com/mitre/fieldmanual/pull/51
- [X] I have added tests that prove my fix is effective or that my feature works
