### PR TITLE
Removed parantheses in errant TTP strings, fixing JS error

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -220,8 +220,8 @@ class RestService(RestServiceInterface, BaseService):
             return dict(error='Agent missing specified executor')
 
         encoded_command = self.encode_string(data['command'])
-        ability = Ability(ability_id='(auto-generated)', tactic='(auto-generated)', technique_id='(auto-generated)',
-                          technique='(auto-generated)', name='Manual Command', description='Manual command ability',
+        ability = Ability(ability_id='auto-generated', tactic='auto-generated', technique_id='auto-generated',
+                          technique='auto-generated', name='Manual Command', description='Manual command ability',
                           cleanup='', test=encoded_command, executor=data['executor'], platform=agent.platform,
                           payloads=[], parsers=[], requirements=[], privilege=None, variations=[])
         link = Link.load(dict(command=encoded_command, paw=agent.paw, cleanup=0, ability=ability, score=0, jitter=2,


### PR DESCRIPTION
## Description

The names of abilities, techniques, and tactics for manual commands was being listed as '(auto-generated)' in
Debrief, and were causing errors in jQuery due to the parentheses. Removing the parentheses fixes the errors.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
I ran pytest and all tests passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
