### PR TITLE
VIRTS1743: added ellipsis for long ability names and expand on hover

### DIFF
--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -247,6 +247,10 @@
 .ability-box h4 {
     margin-left: 2%;
     padding-bottom: 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 95%;
 }
 .ability-box p {
     overflow: hidden;
@@ -264,6 +268,17 @@
     filter: invert(var(--invert-percentage));
     margin-top: -3px;
     margin-bottom: -3px;
+}
+.ability-long-name {
+    position: initial;
+    z-index: 100;
+    margin-left: -50%;
+    margin-right: -50%;
+    padding: 4px 8px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: grey;
+    background-color: var(--secondary-background);
 }
 .ability-viewer {
     background-color: var(--primary-background);

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -157,7 +157,7 @@
 
 <div id="ability-template" class="ability-box" style="display: none">
     <div class="ability-show">
-        <h4 id="name" style="margin:5px; margin-top:5px;"></h4>
+        <h4 id="name" style="margin:5px; margin-top:5px;"><span></span></h4>
         <b><p id="ability-attack" style="text-transform: uppercase;font-size:11px;opacity:0.7;"></p></b>
     </div>
     <center>
@@ -308,6 +308,24 @@
 
     $(document).on("mouseout", ".tooltip", function(event) {
         $("#ability-tooltip").hide();
+    })
+
+    $(document).on("mouseover", ".ability-box h4", function() {
+        if (isEllipsisActive(this)) {
+            $(this.firstElementChild).addClass("ability-long-name");
+            $(this).css("overflow", "visible");
+            let abilityBox = $(this).closest(".ability-box");
+            abilityBox.css("z-index", 100);
+            abilityBox.find(".topleftnum, .topright").css("z-index", -1);
+        }
+    })
+
+    $(document).on("mouseout", ".ability-box h4", function() {
+        $(this.firstElementChild).removeClass("ability-long-name");
+        $(this).css("overflow", "hidden");
+        let abilityBox = $(this).closest(".ability-box");
+        abilityBox.css("z-index", 1);
+        abilityBox.find(".topleftnum, .topright").css("z-index", 0);
     })
 
     function toggleAdversaryView() {
@@ -713,7 +731,7 @@
             .data('testId', ability.ability_id)
             .data('requirements', requirements);
 
-        template.find('#name').html(ability.name);
+        template.find('#name span').html(ability.name);
         template.find('#ability-attack').html(ability.tactic + ' | '+ ability.technique_name);
 
         if(requirements.length > 0) {
@@ -1009,5 +1027,9 @@
     }
 
     //# sourceURL=profiles.js
+
+    function isEllipsisActive(e) {
+     return (e.offsetWidth < e.scrollWidth);
+}
 
 </script>


### PR DESCRIPTION
## Description

Long ability names that overflowed into a second line caused some misalignment/ordering issues in the adversary profiles. This fix prevents the word wrap and instead adds an ellipsis for long ability names that can be viewed on hover, effectively keeping all ability boxes the same height preventing the misalignment issues.

Before: 
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/61020544/106624996-3ec1c580-6544-11eb-9ed9-fe55b0afc6e4.png">

After:
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/61020544/106624869-1afe7f80-6544-11eb-9977-e6f5e61398c0.png">


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- In the GUI with current abilities that have long names (_Inject cred dumper into process (Spooky)_ and _Leverage proc dump for lsass memory_) as well as absurdly long sentence-length names.
- Positioning these ability boxes in the left, middle, and right columns

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
