### PR TITLE
Fix bug with xored payloads not selecting properly

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -176,8 +176,15 @@ class RestService(RestServiceInterface, BaseService):
         payload_dirs = [pathlib.Path.cwd() / 'data' / 'payloads']
         payload_dirs.extend(pathlib.Path.cwd() / 'plugins' / plugin.name / 'payloads'
                             for plugin in await self.get_service('data_svc').locate('plugins') if plugin.enabled)
-        return set(p.name for p_dir in payload_dirs for p in p_dir.glob('*')
-                   if p.is_file() and not p.name.startswith('.'))
+        payloads = set()
+        for p_dir in payload_dirs:
+            for p in p_dir.glob('*'):
+                if p.is_file() and not p.name.startswith('.'):
+                    if p.name.endswith('.xored'):
+                        payloads.add(p.name.replace('.xored', ''))
+                    else:
+                        payloads.add(p.name)
+        return payloads
 
     async def find_abilities(self, paw):
         data_svc = self.get_service('data_svc')


### PR DESCRIPTION
## Description

There was a bug that caused the payload to be stripped from the ability when adding it to an adversary using the GUI. This affected abilities with xored payloads, such as https://github.com/mitre/stockpile/blob/master/data/abilities/discovery/13379ae1-d20e-4162-91f8-320d78a35e7f.yml. It would show up as `powerview.ps1.xored` in the GUI multiselect, but since it's listed as `powerview.ps1` in the ability it wouldn't match and would not get selected. Then when the ability was added to an adversary, it would be saved as if the payload was removed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Confirmed that the payload is still in the ability after adding to an adversary.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
