### PR TITLE
Dns tunneling contact

### DIFF
--- a/app/contacts/contact_dns.py
+++ b/app/contacts/contact_dns.py
@@ -576,14 +576,11 @@ class Handler(asyncio.DatagramProtocol):
     def _generate_random_ipv4_response(last_octet_even):
         """Generate random IPv4 address as an A record response.
         If last_octet_even is true, make sure the last octet is even. Otherwise, make sure it is odd."""
-        random_bytes = random.randbytes(4)
-        last_octet = random_bytes[3]
-        if (last_octet % 2 == 0 and not last_octet_even) or (last_octet % 2 == 1 and last_octet_even):
-            last_octet = (last_octet + 1) % 256
-            return random_bytes[0:3] + last_octet.to_bytes(1, byteorder='big')
-        else:
-            return random_bytes
+        random_ip_int = random.randrange(1, 0xffffffff)
+        if (random_ip_int % 2 == 0 and not last_octet_even) or (random_ip_int % 2 == 1 and last_octet_even):
+            random_ip_int += 1
+        return random_ip_int.to_bytes(4, byteorder='big')
 
     @staticmethod
     def _get_random_ipv6_addr():
-        return random.randbytes(16)
+        return random.getrandbits(128).to_bytes(16, byteorder='big')

--- a/app/contacts/contact_dns.py
+++ b/app/contacts/contact_dns.py
@@ -344,7 +344,6 @@ class Handler(asyncio.DatagramProtocol):
     async def _handle_msg(self, data, addr):
         try:
             response_data = await self.generate_dns_tunneling_response_bytes(data)
-            print(response_data)
             self.transport.sendto(response_data, addr)
         except Exception as e:
             self.log.error(e)

--- a/app/contacts/contact_dns.py
+++ b/app/contacts/contact_dns.py
@@ -1,0 +1,605 @@
+import asyncio
+import json
+import random
+
+from base64 import b64encode
+from enum import Enum
+
+from app.utility.base_world import BaseWorld
+
+
+class Contact(BaseWorld):
+    def __init__(self, services):
+        self.name = 'dns'
+        self.description = 'Accept DNS tunneling messages'
+        self.log = self.create_logger('contact_dns')
+        self.contact_svc = services.get('contact_svc')
+        self.domain = self.get_config('app.contact.dns.domain')
+        self.handler = Handler(self.domain, services, self.name)
+
+    async def start(self):
+        loop = asyncio.get_event_loop()
+        dns = self.get_config('app.contact.dns.socket')
+        addr, port = dns.split(':')
+        loop.create_task(loop.create_datagram_endpoint(lambda: self.handler, local_addr=(addr, port)))
+
+
+class DnsPacket:
+    query_response_flag = 0x8000        # 1000 0000  0000 0000
+    authoritative_resp_flag = 0x0400    # 0000 0100  0000 0000
+    truncated_flag = 0x0200             # 0000 0010  0000 0000
+    recursion_desired_flag = 0x0100     # 0000 0001  0000 0000
+    recursion_available_flag = 0x0080   # 0000 0000  1000 0000
+    opcode_mask = 0x7800                # 0111 1000  0000 0000  # bitwise and with flags to get opcode
+    response_code_mask = 0x000f         # 0000 0000  0000 1111  # bitwise and with flags to get response code
+
+    opcode_offset = 11
+
+    def __init__(self, transaction_id, flags, num_questions, num_answer_rrs, num_auth_rrs, num_additional_rrs,
+                 qname_labels, record_type, dns_class):
+        self.transaction_id = int(transaction_id)
+        self.flags = int(flags)
+        self.num_questions = int(num_questions)
+        self.num_answer_rrs = int(num_answer_rrs)
+        self.num_auth_rrs = int(num_auth_rrs)
+        self.num_additional_rrs = int(num_additional_rrs)
+        self.qname_labels = qname_labels
+        self.qname = '.'.join(self.qname_labels)
+        self.record_type = record_type
+        self.dns_class = int(dns_class)
+
+    def is_query(self):
+        return not self.flags & self.query_response_flag
+
+    def is_response(self):
+        return bool(self.flags & self.query_response_flag)
+
+    def recursion_desired(self):
+        return bool(self.flags & self.recursion_desired_flag)
+
+    def recursion_available(self):
+        return bool(self.flags & self.recursion_available_flag)
+
+    def truncated(self):
+        return bool(self.flags & self.truncated_flag)
+
+    def get_opcode(self):
+        return (self.flags & self.opcode_mask) >> self.opcode_offset
+
+    def has_standard_query(self):
+        return self.get_opcode() == 0x0
+
+    def get_response_code(self):
+        return self.flags & self.response_code_mask
+
+    def __str__(self):
+        return '\n'.join([
+            'Qname: %s' % self.qname,
+            'Is response: %s' % self.is_response(),
+            'Transaction ID: 0x%02x' % self.transaction_id,
+            'Flags: 0x%04x' % self.flags,
+            'Num questions: %d' % self.num_questions,
+            'Num answer resource records: %d' % self.num_answer_rrs,
+            'Num auth resource records: %d' % self.num_auth_rrs,
+            'Num additional resource records: %d' % self.num_additional_rrs,
+            'Record type: %d' % self.record_type.value,
+            'Class: %d' % self.dns_class,
+            'Standard query: %s' % self.has_standard_query(),
+            'Opcode: 0x%03x' % self.get_opcode(),
+            'Response code: 0x%02x' % self.get_response_code(),
+            'Recursion desired: %s' % self.recursion_desired(),
+            'Recursion available: %s' % self.recursion_available(),
+            'Truncated: %s' % self.truncated(),
+        ])
+
+    def _get_header_bytes(self, byteorder='big'):
+        return self.transaction_id.to_bytes(2, byteorder=byteorder) + self.flags.to_bytes(2, byteorder=byteorder) \
+               + self.num_questions.to_bytes(2, byteorder=byteorder) \
+               + self.num_answer_rrs.to_bytes(2, byteorder=byteorder) \
+               + self.num_auth_rrs.to_bytes(2, byteorder=byteorder) \
+               + self.num_additional_rrs.to_bytes(2, byteorder=byteorder)
+
+    def _get_query_bytes(self, byteorder='big'):
+        return self._get_qname_bytes(self.qname_labels, byteorder=byteorder) \
+               + self.record_type.value.to_bytes(2, byteorder=byteorder) \
+               + self.dns_class.to_bytes(2, byteorder=byteorder)
+
+    @staticmethod
+    def generate_packet_from_bytes(data, byteorder='big'):
+        transaction_id = int.from_bytes(data[0:2], byteorder=byteorder)
+        flags = int.from_bytes(data[2:4], byteorder=byteorder)
+        num_questions = int.from_bytes(data[4:6], byteorder=byteorder)
+        num_answer_rrs = int.from_bytes(data[6:8], byteorder=byteorder)
+        num_auth_rrs = int.from_bytes(data[8:10], byteorder=byteorder)
+        num_additional_rrs = int.from_bytes(data[10:12], byteorder=byteorder)
+        qname_labels, qname_length = DnsPacket._parse_qname_labels(data[12:])
+        qname_offset = 12 + qname_length
+        record_type = DnsRecordType(int.from_bytes(data[qname_offset:qname_offset+2], byteorder=byteorder))
+        dns_class = int.from_bytes(data[qname_offset+2:qname_offset+4], byteorder=byteorder)
+        return DnsPacket(transaction_id, flags, num_questions, num_answer_rrs, num_auth_rrs, num_additional_rrs,
+                         qname_labels, record_type, dns_class)
+
+    @staticmethod
+    def _get_qname_bytes(qname_labels, byteorder='big'):
+        qname_bytes = b''
+        for label in qname_labels:
+            qname_bytes += len(label).to_bytes(1, byteorder=byteorder)
+            qname_bytes += label.encode('ascii')
+        qname_bytes += b'\x00'
+        return qname_bytes
+
+    @staticmethod
+    def _parse_qname_labels(data):
+        remaining = data
+        parts = []
+        representation_length = 1
+        while remaining and int(remaining[0]):
+            length = int(remaining[0])
+            parts.append(remaining[1:1 + length].decode('utf-8'))
+            remaining = remaining[1 + length:]
+            representation_length += 1 + length
+        return parts, representation_length
+
+
+class DnsAnswerObj:
+    def __init__(self, record_type, dns_class, ttl, data):
+        self.record_type = record_type
+        self.dns_class = dns_class
+        self.ttl = ttl
+        self.data = data
+
+    def get_bytes(self, byteorder='big'):
+        return DnsResponse.standard_pointer.to_bytes(2, byteorder=byteorder) \
+            + self.record_type.value.to_bytes(2, byteorder=byteorder) \
+            + self.dns_class.to_bytes(2, byteorder=byteorder) \
+            + self.ttl.to_bytes(4, byteorder=byteorder) \
+            + len(self.data).to_bytes(2, byteorder=byteorder) \
+            + self.data
+
+    def __str__(self):
+        return '\n'.join([
+            'Record type: %d' % self.record_type.value,
+            'Dns class: %d' % self.dns_class,
+            'TTL: %d' % self.ttl,
+            'Data: %s' % self.data.hex(),
+            'Data length: %d' % len(self.data),
+        ])
+
+
+class DnsResponse(DnsPacket):
+    standard_pointer = 0xc00c
+    max_txt_size = 255
+    default_ttl = 300
+    max_ttl = 86400
+    min_ttl = 300
+
+    def __init__(self, transaction_id, flags, num_questions, num_answer_rrs, num_auth_rrs, num_additional_rrs,
+                 qname_labels, record_type, dns_class, answers):
+        super().__init__(transaction_id, flags, num_questions, num_answer_rrs, num_auth_rrs, num_additional_rrs,
+                         qname_labels, record_type, dns_class)
+        self.answers = answers if answers else []
+
+    def get_bytes(self, byteorder='big'):
+        return self._get_header_bytes(byteorder=byteorder) + self._get_query_bytes(byteorder=byteorder) \
+            + self._get_answer_bytes(byteorder=byteorder)
+
+    def __str__(self):
+        output = [super().__str__(), 'Answers: ']
+        for answer in self.answers:
+            output.append(str(answer))
+        return '\n'.join(output)
+
+    def _get_answer_bytes(self, byteorder='big'):
+        answer_bytes = b''
+        for answer in self.answers:
+            answer_bytes += answer.get_bytes(byteorder=byteorder)
+        return answer_bytes
+
+    def _generate_pointer_and_qname_bytes(self, answer_qname, byteorder='big'):
+        lowered_answer_qname = answer_qname.lower()
+        lowered_requested_qname = self.qname.lower()
+        if lowered_answer_qname == lowered_requested_qname:
+            return self.standard_pointer.to_bytes(2, byteorder=byteorder)
+        elif lowered_answer_qname.endswith(lowered_requested_qname):
+            prefix = lowered_answer_qname[:-len(lowered_requested_qname)]
+            prefix_labels = [label for label in prefix.split('.') if label]
+            return self._get_qname_bytes(prefix_labels, byteorder=byteorder) \
+                + self.standard_pointer.to_bytes(2, byteorder=byteorder)
+        elif lowered_requested_qname.endswith(lowered_answer_qname):
+            offset = len(lowered_requested_qname) - len(lowered_answer_qname)
+            return (self.standard_pointer + offset).to_bytes(2, byteorder=byteorder)
+        else:
+            return self._get_qname_bytes(answer_qname.split('.'), byteorder=byteorder)
+
+    @staticmethod
+    def generate_response_for_query(dns_query, r_code, answers, authoritative=True, recursion_available=False,
+                                    truncated=False):
+        """Given DnsPacket query, return response with provided fields.
+        Answers is list of DnsAnswerObj for the given query.
+        """
+
+        transaction_id = dns_query.transaction_id  # DNS response carries same transaction ID as query
+
+        authoritative_flag = DnsResponse.authoritative_resp_flag if authoritative else 0x0
+        truncated_flag = DnsResponse.truncated_flag if truncated else 0x0
+        opcode_mask = dns_query.get_opcode() << DnsResponse.opcode_offset
+        recursion_desired_flag = DnsResponse.recursion_desired_flag if dns_query.recursion_desired() else 0x0
+        recursion_available_flag = DnsResponse.recursion_available_flag if recursion_available else 0x0
+        flags = 0x0 | DnsResponse.query_response_flag | opcode_mask | authoritative_flag | truncated_flag \
+            | recursion_desired_flag | recursion_available_flag | r_code.value
+        num_questions = dns_query.num_questions
+        num_answers = len(answers)
+        num_auth_rrs = 0
+        num_additional_rrs = 0
+        qname_labels = dns_query.qname_labels
+        record_type = dns_query.record_type
+        dns_class = dns_query.dns_class
+        return DnsResponse(transaction_id, flags, num_questions, num_answers, num_auth_rrs, num_additional_rrs,
+                           qname_labels, record_type, dns_class, answers)
+
+
+class DnsRecordType(Enum):
+    A = 1
+    NS = 2
+    TXT = 16
+    AAAA = 28
+    CNAME = 5
+
+
+class DnsResponseCodes(Enum):
+    SUCCESS = 0
+    NXDOMAIN = 3
+
+
+class Handler(asyncio.DatagramProtocol):
+    _remaining_data_suffix = 0x2e  # .
+    _completed_data_suffix = 0x2c  # ,
+
+    class MessageType(Enum):
+        Beacon = 'be'  # Beacons will also contain execution results
+        InstructionDownload = 'id'
+        PayloadRequest = 'pr'
+        PayloadFilenameDownload = 'pf'
+        PayloadDataDownload = 'pd'
+
+    class TunneledMessage:
+        def __init__(self, message_id, message_type, num_chunks):
+            self.message_id = message_id
+            self.message_type = message_type
+            self.chunks = [None] * num_chunks
+            self.required_chunks = num_chunks
+            self.completed_chunks = 0
+
+        def add_chunk(self, chunk_index, contents):
+            if contents and self.chunks[chunk_index] is None:
+                self.chunks[chunk_index] = contents
+                self.completed_chunks += 1
+
+        def is_complete(self):
+            return self.completed_chunks == self.required_chunks
+
+        def export_contents(self):
+            return b''.join(self.chunks)
+
+    class StoredResponse:
+        def __init__(self, data):
+            self.data = data
+            self.offset = 0
+            self.size = len(data)
+
+        def read_data(self, num_bytes):
+            ret_data = None
+            if not self.finished_reading():
+                end_seek = min(self.size, self.offset + num_bytes)
+                ret_data = self.data[self.offset:end_seek]
+                self.offset = end_seek
+            return ret_data
+
+        def finished_reading(self):
+            return self.offset >= self.size
+
+    class ClientRequestContext:
+        def __init__(self, request_id, dns_request, request_contents, client_addr):
+            self.client_addr = client_addr
+            self.request_id = request_id
+            self.dns_request = dns_request  # DnsPacket object
+            self.request_contents = request_contents
+
+    def __init__(self, domain, services, name):
+        super().__init__()
+        self.services = services
+        self.contact_svc = services.get('contact_svc')
+        self.file_svc = services.get('file_svc')
+        self.name = name
+        self.log = BaseWorld.create_logger('contact_dns_handler')
+        self.domain = domain
+        self.transport = None
+
+        # Stores received message chunks.
+        self.pending_messages = {}
+
+        # Stores completed messages from agents.
+        self.completed_messages = {}
+
+        # Stores instructions for agents to fetch
+        # Key: message ID.
+        # Value: StoredResponse obj
+        self.pending_instructions = {}
+
+        # Stores payloads for agents to fetch
+        # Key: message ID.
+        # Value: StoredResponse obj
+        self.pending_payloads = {}
+
+        # Stores payload names for agents to fetch
+        # Key: message ID.
+        # Value: StoredResponse obj
+        self.pending_payload_names = {}
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        async def handle_msg():
+            try:
+                packet = DnsPacket.generate_packet_from_bytes(data)
+                self.log.debug('Received %s DNS request: %s' % (packet.record_type.name, packet.qname))
+                await self._handle_dns_request(packet, addr)
+            except Exception as e:
+                self.log.error(e)
+        asyncio.get_event_loop().create_task(handle_msg())
+
+    async def _handle_dns_request(self, dns_request_packet, addr):
+        """Given DNS request packet, parse out the agent message. If the message is incomplete, add to pending
+        message. If the message is complete, or if it completes any pending messages, then process the complete
+        message."""
+
+        # Qname labels are of format message_id.message_type.chunk_index.total_chunks.data.contact_base_domain_fqdn.
+        # For example, 281723.be.0.1.68656c6c6f20776f726c64.mycalderac2domain.com indicates the following:
+        #   message ID is 281723
+        #   message type is "be", meaning "beacon"
+        #   this is the first chunk out of a total of 1 chunks
+        #   the data is "hello world" encoded in hex
+        #   base c2 domain is mycalderac2domain.com
+        labels = dns_request_packet.qname_labels
+        if dns_request_packet.qname.lower() != self.domain.lower() \
+                and not dns_request_packet.qname.lower().endswith('.' + self.domain.lower()):
+            self.log.warn('Received request for qname %s that is not the C2 DNS tunneling domain %s' %
+                          (dns_request_packet.qname, self.domain))
+            self.log.warn('Sending NXDOMAIN response.')
+            self._send_nxdomain_response(dns_request_packet, addr)
+            return
+
+        if dns_request_packet.record_type == DnsRecordType.AAAA:
+            self._send_dummy_ipv6_response(dns_request_packet, addr)
+            return
+        elif dns_request_packet.record_type not in (DnsRecordType.A, DnsRecordType.TXT):
+            self.log.warn('Received unsupported DNS record type request %d' % dns_request_packet.record_type.value)
+            self._send_empty_response(dns_request_packet, addr)
+            return
+
+        message_id = labels[0]
+        try:
+            # Store message
+            self._store_data_chunk(labels)
+        except ValueError as e:
+            # Invalid or mismatched message type - send NXDomain response
+            self.log.warn('Invalid dns tunneling message type received from client. Full error: %s' % e)
+            self._send_nxdomain_response(dns_request_packet, addr)
+            return
+
+        # Handle the message if complete. Any non-A record request is automatically considered "complete"
+        if self._message_complete(message_id) or dns_request_packet.record_type != DnsRecordType.A:
+            self.log.debug('Received complete client message %s' % message_id)
+            self._store_completed_message(message_id)
+            await self._handle_completed_message(message_id, dns_request_packet, addr)
+        else:
+            # Return standard acknowledgement response for incomplete A-record messages
+            self._acknowledge_incomplete_message(dns_request_packet, addr)
+
+    def _send_nxdomain_response(self, dns_query, addr):
+        response_obj = DnsResponse.generate_response_for_query(dns_query, DnsResponseCodes.NXDOMAIN, [])
+        self._send_dns_response(response_obj, addr)
+
+    def _send_empty_response(self, dns_query, addr):
+        response_obj = DnsResponse.generate_response_for_query(dns_query, DnsResponseCodes.SUCCESS, [])
+        self._send_dns_response(response_obj, addr)
+
+    def _send_dummy_ipv6_response(self, dns_request_packet, addr):
+        ipv6_bytes = self._generate_dummy_ipv6_response()
+        answer_obj = DnsAnswerObj(DnsRecordType.AAAA, dns_request_packet.dns_class, DnsResponse.default_ttl, ipv6_bytes)
+        response_obj = DnsResponse.generate_response_for_query(dns_request_packet, DnsResponseCodes.SUCCESS,
+                                                               [answer_obj])
+        self._send_dns_response(response_obj, addr)
+
+    def _send_dns_response(self, dns_response_obj, addr):
+        """Send the given DnsResponse object to the specified address."""
+        response_bytes = dns_response_obj.get_bytes()
+        self.transport.sendto(response_bytes, addr)
+
+    def _store_completed_message(self, message_id):
+        msg = self.pending_messages.pop(message_id, None)
+        if msg:
+            self.completed_messages[message_id] = msg
+
+    async def _handle_completed_message(self, message_id, dns_request_packet, addr):
+        msg = self.completed_messages.pop(message_id, None)
+        if msg:
+            contents = msg.export_contents()
+            request_context = self.ClientRequestContext(message_id, dns_request_packet, contents, addr)
+
+            # Process message based on message type
+            if msg.message_type == self.MessageType.Beacon:
+                await self._process_beacon(request_context)
+            elif msg.message_type == self.MessageType.InstructionDownload:
+                self._process_download_request_via_txt(request_context, self.pending_instructions, 'instructions')
+            elif msg.message_type == self.MessageType.PayloadRequest:
+                await self._process_payload_request(request_context)
+            elif msg.message_type == self.MessageType.PayloadFilenameDownload:
+                self._process_download_request_via_txt(request_context, self.pending_payload_names, 'payload filename')
+            elif msg.message_type == self.MessageType.PayloadDataDownload:
+                self._process_download_request_via_txt(request_context, self.pending_payloads, 'payload data')
+            else:
+                self.log.warn('Unsupported message type %s' % msg.message_type.value)
+
+    async def _process_payload_request(self, request_context):
+        payload_metadata = self._unpack_json(request_context.request_contents)
+        if payload_metadata:
+            filename = payload_metadata.get('file')
+            if filename:
+                payload, content, display_name = await self._fetch_payload(payload_metadata)
+                if payload and content and display_name:
+                    # Save file contents and payload name for agent to fetch later.
+                    encoded_payload_name = b64encode(display_name.encode('utf-8'))
+                    encoded_contents = b64encode(content)
+                    self.pending_payloads[request_context.request_id] = self.StoredResponse(encoded_contents)
+                    self.pending_payload_names[request_context.request_id] = self.StoredResponse(encoded_payload_name)
+
+                    # Notify agent that payload is ready
+                    self._notify_server_ready_via_ipv4(request_context.dns_request, request_context.client_addr)
+                    self.log.debug('Stored payload %s for request ID %s' % (display_name, request_context.request_id))
+                    return
+            else:
+                self.log.warn('Client did not include filename in payload request ID %s' % request_context.request_id)
+        else:
+            self.log.warn('Empty payload request received from message ID %s' % request_context.request_id)
+        self._send_nxdomain_response(request_context.dns_request, request_context.client_addr)
+
+    async def _fetch_payload(self, payload_metadata):
+        try:
+            return await self.file_svc.get_file(payload_metadata)
+        except FileNotFoundError:
+            self.log.warn('Could not find requested payload')
+            return None, None, None
+        except Exception as e:
+            self.log.warn('Error fetching payload: %s' % e)
+            return None, None, None
+
+    def _process_download_request_via_txt(self, request_context, data_repo, data_type='unknown'):
+        if request_context.dns_request.record_type != DnsRecordType.TXT:
+            self.log.warn('Client attempted to request %s without sending TXT query.' % data_type)
+            self._send_nxdomain_response(request_context.dns_request, request_context.client_addr)
+        else:
+            self.log.debug('Client requested %s via message ID %s' % (data_type, request_context.request_id))
+            stored_response = data_repo.get(request_context.request_id)
+            if stored_response:
+                self._send_data_chunk_via_txt(data_repo, request_context, stored_response)
+            else:
+                self.log.warn('No %s found for message ID %s' % (data_type, request_context.request_id))
+                self._send_nxdomain_response(request_context.dns_request, request_context.client_addr)
+
+    def _send_data_chunk_via_txt(self, data_repo, request_context, stored_response):
+        data = bytearray(stored_response.read_data(DnsResponse.max_txt_size - 1))
+        if stored_response.finished_reading():
+            # This is the last data chunk to send.
+            data.append(self._completed_data_suffix)
+            data_repo.pop(request_context.request_id)
+        else:
+            data.append(self._remaining_data_suffix)
+        self._send_txt_response(request_context.dns_request, data, DnsResponse.default_ttl, request_context.client_addr)
+
+    async def _process_beacon(self, request_context):
+        profile = self._unpack_json(request_context.request_contents)
+        if profile:
+            profile['paw'] = profile.get('paw')
+            profile['contact'] = profile.get('contact', self.name)
+            beacon_response = await self._get_beacon_response(profile)
+
+            # Store beacon response for agent to fetch later, and tell agent that beacon is ready
+            self._store_beacon_response(request_context.request_id, beacon_response)
+            self._notify_server_ready_via_ipv4(request_context.dns_request, request_context.client_addr)
+        else:
+            self.log.warn('Empty profile received from beacon message ID %s' % request_context.request_id)
+            self._send_nxdomain_response(request_context.dns_request, request_context.client_addr)
+
+    async def _get_beacon_response(self, profile):
+        agent, instructions = await self.contact_svc.handle_heartbeat(**profile)
+        response = dict(paw=agent.paw,
+                        sleep=await agent.calculate_sleep(),
+                        watchdog=agent.watchdog,
+                        instructions=json.dumps([json.dumps(i.display) for i in instructions]))
+        if agent.pending_contact != agent.contact:
+            response['new_contact'] = agent.pending_contact
+            self.log.debug('Sending agent instructions to switch from C2 channel %s to %s'
+                           % (agent.contact, agent.pending_contact))
+        return response
+
+    def _store_beacon_response(self, beacon_id, response_dict):
+        # Convert response_dict to json bytes
+        response_bytes = b64encode(json.dumps(response_dict).encode('utf-8'))
+        self.pending_instructions[beacon_id] = self.StoredResponse(response_bytes)
+
+    def _notify_server_ready_via_ipv4(self, dns_request_packet, dest_addr):
+        # IPv4 address with odd last octet means that server is ready for next step
+        response_data = self._generate_random_ipv4_response(False)
+        self._send_ipv4_response(dns_request_packet, response_data, DnsResponse.default_ttl, dest_addr)
+
+    def _unpack_json(self, data):
+        json_contents = None
+        try:
+            json_contents = json.loads(data.decode('utf-8'))
+        except Exception as e:
+            self.log.error('Error decoding contents into json: %s' % e)
+        return json_contents
+
+    def _send_ipv4_response(self, dns_request_packet, ipv4_bytes, ttl, addr):
+        answer_obj = DnsAnswerObj(DnsRecordType.A, dns_request_packet.dns_class, ttl, ipv4_bytes)
+        response_obj = DnsResponse.generate_response_for_query(dns_request_packet, DnsResponseCodes.SUCCESS,
+                                                               [answer_obj])
+        self._send_dns_response(response_obj, addr)
+
+    def _send_txt_response(self, dns_request_packet, txt_bytes, ttl, addr):
+        payload = len(txt_bytes).to_bytes(1, byteorder='big') + txt_bytes
+        answer_obj = DnsAnswerObj(DnsRecordType.TXT, dns_request_packet.dns_class, ttl, payload)
+        response_obj = DnsResponse.generate_response_for_query(dns_request_packet, DnsResponseCodes.SUCCESS,
+                                                               [answer_obj])
+        self._send_dns_response(response_obj, addr)
+
+    def _acknowledge_incomplete_message(self, request_packet, addr):
+        if request_packet.record_type != DnsRecordType.A:
+            self.log.warn("Client sent incomplete DNS tunneling message that was not an A record request. Invalid")
+            self._send_nxdomain_response(request_packet, addr)
+        else:
+            response_data = self._generate_random_ipv4_response(True)
+            self._send_ipv4_response(request_packet, response_data, DnsResponse.default_ttl, addr)
+
+    def _message_complete(self, message_id):
+        """Returns true if the message is complete, false if still missing chunks."""
+
+        msg = self.pending_messages.get(message_id)
+        return msg and msg.is_complete()
+
+    def _store_data_chunk(self, labels):
+        """Given the DNS request qname labels, store the data chunks in the appropriate pending tunneled message."""
+
+        message_id = labels[0]
+        message_type = self.MessageType(labels[1])
+        chunk_index = int(labels[2])
+        num_chunks = int(labels[3])
+        data = bytes.fromhex(labels[4])
+
+        pending_message = self.pending_messages.get(message_id)
+        if not pending_message:
+            # First chunk seen for this message ID.
+            pending_message = self.TunneledMessage(message_id, message_type, num_chunks)
+            self.pending_messages[message_id] = pending_message
+        elif pending_message.message_type != message_type:
+            raise ValueError('New data chunk type %s does not match current message type %s for message ID %s'
+                             % (pending_message.message_type.value, message_type.value, message_id))
+        pending_message.add_chunk(chunk_index, data)
+
+    @staticmethod
+    def _generate_random_ipv4_response(last_octet_even):
+        """Generate random IPv4 address as an A record response.
+        If last_octet_even is true, make sure the last octet is even. Otherwise, make sure it is odd."""
+        random_bytes = random.randbytes(4)
+        last_octet = random_bytes[3]
+        if (last_octet % 2 == 0 and not last_octet_even) or (last_octet % 2 == 1 and last_octet_even):
+            last_octet = (last_octet + 1) % 256
+            return random_bytes[0:3] + last_octet.to_bytes(1, byteorder='big')
+        else:
+            return random_bytes
+
+    @staticmethod
+    def _generate_dummy_ipv6_response():
+        return random.randbytes(16)

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -1,6 +1,8 @@
 ability_refresh: 60
 api_key_blue: BLUEADMIN123
 api_key_red: ADMIN123
+app.contact.dns.domain: mycaldera.caldera
+app.contact.dns.socket: 0.0.0.0:53
 app.contact.gist: API_KEY
 app.contact.html: /weather
 app.contact.http: http://0.0.0.0:8888

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ coverage
 pre-commit
 safety
 bandit
+dnspython==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ ldap3==2.8.1
 lxml~=4.6.2  # debrief
 reportlab==3.5.59  # debrief
 svglib==1.0.1  # debrief
+dnspython==2.1.0

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.contacts.contact_dns import Contact as DnsContact
+from app.utility.base_world import BaseWorld
+
+
+@pytest.fixture
+def dns_c2(loop, app_svc):
+    BaseWorld.apply_config(name='main', config={'app.contact.dns.domain': 'mycaldera.caldera',
+                                                'app.contact.dns.socket': '0.0.0.0:53',
+                                                'plugins': ['sandcat', 'stockpile'],
+                                                'crypt_salt': 'BLAH',
+                                                'api_key': 'ADMIN123',
+                                                'encryption_key': 'ADMIN123',
+                                                'exfil_dir': '/tmp'})
+    services = app_svc(loop).get_services()
+    dns_c2 = DnsContact(services)
+    return dns_c2
+
+
+class TestContactDns:
+    def test_config(self, dns_c2):
+        assert dns_c2.domain == 'mycaldera.caldera'
+
+    def test_handler_setup(self, dns_c2):
+        handler = dns_c2.handler
+        assert handler.domain == 'mycaldera.caldera'
+        assert handler.name == 'dns'

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -67,7 +67,7 @@ def beacon_profile_hex_chunks():
 
 @pytest.fixture
 def message_id():
-    return str(random.randint(10000000, 99999999))
+    return str(random.randrange(10000000, 100000000))
 
 
 @pytest.fixture

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -1,11 +1,18 @@
+import binascii
+import json
+import os
 import pytest
+import random
+
+from base64 import b64decode
+from dns import message, rdatatype
 
 from app.contacts.contact_dns import Contact as DnsContact
 from app.utility.base_world import BaseWorld
 
 
 @pytest.fixture
-def dns_c2(loop, app_svc):
+def dns_c2(loop, app_svc, contact_svc, data_svc, obfuscator):
     BaseWorld.apply_config(name='main', config={'app.contact.dns.domain': 'mycaldera.caldera',
                                                 'app.contact.dns.socket': '0.0.0.0:53',
                                                 'plugins': ['sandcat', 'stockpile'],
@@ -13,12 +20,83 @@ def dns_c2(loop, app_svc):
                                                 'api_key': 'ADMIN123',
                                                 'encryption_key': 'ADMIN123',
                                                 'exfil_dir': '/tmp'})
+    BaseWorld.apply_config(name='agents', config={'sleep_max': 5,
+                                                  'sleep_min': 5,
+                                                  'untrusted_timer': 90,
+                                                  'watchdog': 0,
+                                                  'implant_name': 'splunkd',
+                                                  'bootstrap_abilities': [
+                                                      '43b3754c-def4-4699-a673-1d85648fda6a'
+                                                  ]})
     services = app_svc(loop).get_services()
     dns_c2 = DnsContact(services)
     return dns_c2
 
 
+@pytest.fixture
+def get_dns_response(loop, dns_c2):
+    def _get_dns_response(qname, record_type):
+        query_bytes = message.make_query(qname, record_type).to_wire()
+        response_bytes = loop.run_until_complete(dns_c2.handler.generate_dns_tunneling_response_bytes(query_bytes))
+        return message.from_wire(response_bytes)
+    return _get_dns_response
+
+
+@pytest.fixture(scope='class')
+def beacon_profile_hex_chunks():
+    beacon_profile = {
+        'architecture': 'amd64',
+        'contact': 'dns',
+        'exe_name': 'sandcat.exe',
+        'executors': ['cmd', 'psh'],
+        'group': 'red',
+        'host': 'testhost',
+        'location': 'C:\\sandcat.exe',
+        'pid': 1234,
+        'platform': 'windows',
+        'ppid': 123,
+        'privilege': 'User',
+        'username': 'testuser'
+    }
+    marshaled = json.dumps(beacon_profile)
+    hex_str = marshaled.encode('utf-8').hex()
+    chunk_size = 62
+    hex_len = len(hex_str)
+    return [hex_str[i:i+chunk_size] for i in range(0, hex_len, chunk_size)]
+
+
+@pytest.fixture
+def message_id():
+    return str(random.randint(10000000, 99999999))
+
+
+@pytest.fixture
+def random_data():
+    """Return 31 bytes of random hex data, encoded in a 62-char string"""
+    return binascii.b2a_hex(os.urandom(31)).decode('utf-8')
+
+
+@pytest.fixture
+def get_beacon_profile_qnames(beacon_profile_hex_chunks):
+    def _get_beacon_profile_qnames(message_id):
+        num_chunks = len(beacon_profile_hex_chunks)
+        return ['%s.be.%d.%d.%s.mycaldera.caldera' % (message_id, i, num_chunks, beacon_profile_hex_chunks[i])
+                for i in range(0, num_chunks)]
+    return _get_beacon_profile_qnames
+
+
+@pytest.fixture
+def get_instruction_response(random_data, get_dns_response):
+    def _get_instruction_response(message_id):
+        qname = '%s.id.0.1.%s.mycaldera.caldera' % (message_id, random_data)
+        return get_dns_response(qname, 'txt')
+    return _get_instruction_response
+
+
 class TestContactDns:
+    _RCODE_NXDOMAIN = 3
+    _RCODE_SUCCESS = 0
+
     def test_config(self, dns_c2):
         assert dns_c2.domain == 'mycaldera.caldera'
 
@@ -26,3 +104,77 @@ class TestContactDns:
         handler = dns_c2.handler
         assert handler.domain == 'mycaldera.caldera'
         assert handler.name == 'dns'
+
+    def test_non_c2_domain_message(self, get_dns_response):
+        response_msg = get_dns_response('notthec2domain', 'a')
+        assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
+
+    def test_partial_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
+        first_qname = get_beacon_profile_qnames(message_id)[0]
+        response_msg = get_dns_response(first_qname, 'a')
+        assert response_msg and response_msg.rcode() == self._RCODE_SUCCESS
+
+        # Make sure we got back an IPv4 address
+        assert len(response_msg.answer) == 1
+        assert len(response_msg.answer[0]) == 1
+        assert response_msg.answer[0][0].rdtype == rdatatype.RdataType.A
+
+        # Last octet should be even if the server is expecting more data
+        assert int(response_msg.answer[0][0].address.split('.')[3]) % 2 == 0
+
+    def test_completed_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
+        qnames = get_beacon_profile_qnames(message_id)
+        final_index = len(qnames) - 1
+        for index, qname in enumerate(qnames):
+            response_msg = get_dns_response(qname, 'a')
+            assert response_msg and response_msg.rcode() == self._RCODE_SUCCESS
+
+            # Make sure we got back an IPv4 address
+            assert len(response_msg.answer) == 1
+            assert len(response_msg.answer[0]) == 1
+            assert response_msg.answer[0][0].rdtype == rdatatype.RdataType.A
+
+            # Check final octet
+            final_octet = int(response_msg.answer[0][0].address.split('.')[3])
+            if index == final_index:
+                assert final_octet % 2 == 1
+            else:
+                assert final_octet % 2 == 0
+
+    def test_instruction_download(self, get_dns_response, get_beacon_profile_qnames, message_id,
+                                  get_instruction_response):
+        # Send beacon before asking for instructions
+        for qname in get_beacon_profile_qnames(message_id):
+            get_dns_response(qname, 'a')
+
+        # Get instructions
+        response_msg = get_instruction_response(message_id)
+        assert response_msg and response_msg.rcode() == self._RCODE_SUCCESS
+
+        # Make sure we only get 1 TXT record
+        assert len(response_msg.answer) == 1
+        assert len(response_msg.answer[0]) == 1
+        answer = response_msg.answer[0][0]
+        assert answer.rdtype == rdatatype.RdataType.TXT
+        assert len(answer.strings) == 1
+        txt_response = answer.strings[0].decode('utf-8')
+
+        # Last character should be , if returning complete instructions
+        assert txt_response[-1] == ','
+        beacon_resp = json.loads(b64decode(txt_response).decode('utf-8'))
+        assert 'paw' in beacon_resp
+        want = dict(paw=beacon_resp.get('paw'),
+                    sleep=5,
+                    watchdog=0,
+                    instructions='[]')
+        assert want == beacon_resp
+
+    def test_unsupported_client_request(self, get_dns_response, message_id, random_data):
+        invalid_qname = '%s.invalid.0.1.%s.mycaldera.caldera' % (message_id, random_data)
+        response_msg = get_dns_response(invalid_qname, 'a')
+        assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
+
+    def test_invalid_instruction_request(self, get_dns_response, message_id, random_data):
+        invalid_qname = '%s.id.0.1.%s.mycaldera.caldera' % (message_id, random_data)
+        response_msg = get_dns_response(invalid_qname, 'a')  # Should be TXT request
+        assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN


### PR DESCRIPTION
## Description
Initial framework for DNS tunneling C2 contact mechanism. Supporting agents will communicate with the C2 by requesting A and TXT records. hex-encoded data is transmitted to the server using qname labels, and data is downloaded via TXT record responses.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Ran a sandcat DNS tunneling agent on Linux and Windows. Tested running various abilities, including abilities that sent output back to the C2 and abilities that required payloads. Will add official tests shortly.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
