### PR TITLE
IP rule matching

### DIFF
--- a/tests/utility/test_ip_rule.py
+++ b/tests/utility/test_ip_rule.py
@@ -1,0 +1,43 @@
+from app.objects.secondclass.c_fact import Fact
+from app.objects.secondclass.c_rule import Rule
+from app.utility.rule_set import RuleAction
+from app.utility.rule_set import RuleSet
+
+
+class TestIPRule:
+    host1 = "127.0.0.1"
+    host2 = "127.0.1.0"
+    host3 = "128.0.0.1"
+    host4 = "127.0.0.0/23"
+    host5 = "127.0.0.0/25"
+    subnet1 = "127.0.0.0/24"
+    fact1 = Fact(trait="host.ip.address", value=host1)
+    fact2 = Fact(trait="host.ip.address", value=host2)
+    fact3 = Fact(trait="host.ip.address", value=host3)
+    fact4 = Fact(trait="host.ip.address", value=host4)
+    fact5 = Fact(trait="host.ip.address", value=host5)
+    fact6 = Fact(trait="host.ip.address", value=subnet1)
+    rule = Rule(trait="host.ip.address", action=RuleAction.DENY, match=subnet1)
+    rs = RuleSet(rules=[rule])
+
+    async def test_is_ip_rule_match(self):
+        assert await self.rs._is_ip_rule_match(self.rule, self.fact1)
+        assert (not await self.rs._is_ip_rule_match(self.rule, self.fact2))
+        assert (not await self.rs._is_ip_rule_match(self.rule, self.fact3))
+
+    async def test_is_fact_allowed(self):
+        assert (not await self.rs.is_fact_allowed(self.fact1))
+        assert await self.rs.is_fact_allowed(self.fact2)
+        assert await self.rs.is_fact_allowed(self.fact3)
+
+    async def test_smaller_subnet(self):
+        assert (not await self.rs._is_ip_rule_match(self.rule, self.fact4))
+        assert await self.rs.is_fact_allowed(self.fact4)
+
+    async def test_larger_subnet(self):
+        assert (not await self.rs._is_ip_rule_match(self.rule, self.fact5))
+        assert await self.rs.is_fact_allowed(self.fact5)
+
+    async def test_same_subnet(self):
+        assert await self.rs._is_ip_rule_match(self.rule, self.fact6)
+        assert (not await self.rs.is_fact_allowed(self.fact6))

--- a/tests/utility/test_ip_rule.py
+++ b/tests/utility/test_ip_rule.py
@@ -5,19 +5,19 @@ from app.utility.rule_set import RuleSet
 
 
 class TestIPRule:
-    host1 = "127.0.0.1"
-    host2 = "127.0.1.0"
-    host3 = "128.0.0.1"
-    host4 = "127.0.0.0/23"
-    host5 = "127.0.0.0/25"
-    subnet1 = "127.0.0.0/24"
-    fact1 = Fact(trait="host.ip.address", value=host1)
-    fact2 = Fact(trait="host.ip.address", value=host2)
-    fact3 = Fact(trait="host.ip.address", value=host3)
-    fact4 = Fact(trait="host.ip.address", value=host4)
-    fact5 = Fact(trait="host.ip.address", value=host5)
-    fact6 = Fact(trait="host.ip.address", value=subnet1)
-    rule = Rule(trait="host.ip.address", action=RuleAction.DENY, match=subnet1)
+    host1 = '127.0.0.1'
+    host2 = '127.0.1.0'
+    host3 = '128.0.0.1'
+    host4 = '127.0.0.0/23'
+    host5 = '127.0.0.0/25'
+    subnet1 = '127.0.0.0/24'
+    fact1 = Fact(trait='host.ip.address', value=host1)
+    fact2 = Fact(trait='host.ip.address', value=host2)
+    fact3 = Fact(trait='host.ip.address', value=host3)
+    fact4 = Fact(trait='host.ip.address', value=host4)
+    fact5 = Fact(trait='host.ip.address', value=host5)
+    fact6 = Fact(trait='host.ip.address', value=subnet1)
+    rule = Rule(trait='host.ip.address', action=RuleAction.DENY, match=subnet1)
     rs = RuleSet(rules=[rule])
 
     async def test_is_ip_rule_match(self):


### PR DESCRIPTION
## Description

IP rule matching was using the method ipaddress.IPv4Network.subnet_of(), which was introduced in Python 3.7,
thus breaking IP rule matching in 3.6, which Caldera supports. Changed IP rule matching to use a subnet member of idiom that is compatible with 3.6+ (earlier in fact).

In addition, clarified subnet rule matching and added relevant tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created a new test for IP rule matching. Ran pytest and tox; the test passed on each supported Python version.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
