### PR TITLE
Deadman/bootstrap ability GUI fix

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -399,7 +399,6 @@ class RestService(RestServiceInterface, BaseService):
         if deadman_abilities is not None:
             await self._update_agent_ability_list_property(deadman_abilities, 'deadman_abilities')
 
-
     async def _update_agent_ability_list_property(self, abilities_str, prop_name):
         """Set the specified agent config property with the specified abilities.
 

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -399,6 +399,7 @@ class RestService(RestServiceInterface, BaseService):
         if deadman_abilities is not None:
             await self._update_agent_ability_list_property(deadman_abilities, 'deadman_abilities')
 
+
     async def _update_agent_ability_list_property(self, abilities_str, prop_name):
         """Set the specified agent config property with the specified abilities.
 
@@ -413,7 +414,7 @@ class RestService(RestServiceInterface, BaseService):
                 abilities.append(ability_id)
             else:
                 self.log.debug('Could not find ability with id "{}" for property "{}"'.format(ability_id, prop_name))
-            self.set_config(name='agents', prop=prop_name, value=abilities)
+        self.set_config(name='agents', prop=prop_name, value=abilities)
 
     async def _explode_display_results(self, object_name, results):
         if object_name == 'adversaries':

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -358,7 +358,7 @@
         let deadman_abilities = $('#globalDeadman').val().split(",");
         $.each(bootstrap_abilities, function(index, bootstrap_ability) {
             let ability = bootstrap_ability.trim();
-            if ($.inArray(ability, data.bootstrap_abilities) === -1) {
+            if ($.inArray(ability, data.bootstrap_abilities) === -1 && ability.length > 0) {
                 invalid_bootstrap_abilities.push(ability);
             }
         });
@@ -367,7 +367,7 @@
         }
         $.each(deadman_abilities, function(index, deadman_ability) {
             let ability = deadman_ability.trim();
-            if ($.inArray(ability, data.deadman_abilities) === -1) {
+            if ($.inArray(ability, data.deadman_abilities) === -1 && ability.length > 0) {
                 invalid_deadman_abilities.push(ability);
             }
         });

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -59,6 +59,7 @@ def setup_rest_svc_test(loop, data_svc):
                    module='plugins.stockpile.app.obfuscators.plain_text')
     ))
 
+
 @pytest.mark.usefixtures(
     "setup_rest_svc_test"
 )


### PR DESCRIPTION
## Description
Added fix to allow users to clear deadman/bootstrap abilities through the GUI. Also fixed how multiple bootstrap and deadman abilities get parsed and updated in the config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested adding and removing bootstrap/deadman abilities (adding one ability, adding multiple abilities, removing all abilities), while making sure the agent config file was updated correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
