### PR TITLE
Adding support for implant name in deployment commands

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -304,6 +304,7 @@ class RestService(RestServiceInterface, BaseService):
                          for ability in abilities]
 
         app_config = {k: v for k, v in self.get_config().items() if k.startswith('app.')}
+        app_config.update({'agents.%s' % k: v for k, v in self.get_config(name='agents').items()})
 
         return dict(abilities=raw_abilities, app_config=app_config)
 


### PR DESCRIPTION
## Description

adding agent config file items to the agent config used for UI deployment command formatting.  This is to support the ability to dynamically change the name of the implant in deployment commands from the UI when deploying an agent from there (though there is the support for pulling the name from the agent request as well)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Implemented and made sure the proper data is passed to the front end and that it responds appropriately by filling in the implant name with the default 'implant_name' or whatever a user enters into the box.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
