### PR TITLE
Fixing multiple duplicated abilities in potential links under specific circumstances

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -49,7 +49,6 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
-                variables = list(set(variables))
                 relevant_facts = await self._build_relevant_facts([x for x in variables if len(x.split('.')) > 2],
                                                                   facts)
                 if all(relevant_facts):
@@ -162,7 +161,7 @@ class BasePlanningService(BaseService):
             score += (score + var.score)
             used.append(var)
             re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
-            copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test)
+            copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test, 1)
         return copy_test, score, used
 
     @staticmethod

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -49,7 +49,7 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
-                relevant_facts = await self._build_relevant_facts([x for x in variables if len(x.split('.')) > 2],
+                relevant_facts = await self._build_relevant_facts([x for x in set(variables) if len(x.split('.')) > 2],
                                                                   facts)
                 if all(relevant_facts):
                     good_facts = [await RuleSet(rules=rules).apply_rules(facts=fact_set) for fact_set in relevant_facts]
@@ -161,7 +161,7 @@ class BasePlanningService(BaseService):
             score += (score + var.score)
             used.append(var)
             re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
-            copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test, 1)
+            copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test)
         return copy_test, score, used
 
     @staticmethod

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -49,6 +49,7 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = re.findall(self.re_variable, decoded_test)
             if variables:
+                variables = list(set(variables))
                 relevant_facts = await self._build_relevant_facts([x for x in variables if len(x.split('.')) > 2],
                                                                   facts)
                 if all(relevant_facts):


### PR DESCRIPTION
## Description

Small fix to dedup multiple instances of the same variable in a command
When a fact/variable appears multiple times in a command the regex on [L50](https://github.com/mitre/caldera/blob/12493dc4436b7838cf4beb1babfad0cf8fb932ac/app/utility/base_planning_svc.py#L50) it will be represented more than once in the list of variables. Those are expanded out into lists of values found for the variables that then are multiplied out to create variations.
The problem is that when the variables are substituted the first fact to get substituted replaces all other occurrences and the second fact is essentially ignored, this produces identical potential links that are represented by 'fact variations' raised to the power of 'occurrences of the fact'

This also could be fixed on [L164](https://github.com/mitre/caldera/blob/12493dc4436b7838cf4beb1babfad0cf8fb932ac/app/utility/base_planning_svc.py#L164) if we wanted to keep the variations of the same fact/variable within a single command, though that could lead to issues when composing commands as it would most likely not be the expected behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ran the condition of a repeatable ability with a fact referenced multiple times to make sure there are not multiples of the same command listed in potential links

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
