### PR TITLE
Fix bug in enable plugin

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -224,7 +224,7 @@ class RestService(RestServiceInterface, BaseService):
             new_plugin = data.get('value')
             # only add the new plugin if it is not already in the enabled_plugins
             if new_plugin not in enabled_plugins:
-                enabled_plugins.append(data.get('value'))
+                enabled_plugins.append(new_plugin)
         else:
             self.set_config('main', data.get('prop'), data.get('value'))
         return self.get_config()

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -222,7 +222,6 @@ class RestService(RestServiceInterface, BaseService):
         if data.get('prop') == 'plugin':
             enabled_plugins = self.get_config('plugins')
             new_plugin = data.get('value')
-            # only add the new plugin if it is not already in the enabled_plugins
             if new_plugin not in enabled_plugins:
                 enabled_plugins.append(new_plugin)
         else:

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -221,7 +221,10 @@ class RestService(RestServiceInterface, BaseService):
     async def update_config(self, data):
         if data.get('prop') == 'plugin':
             enabled_plugins = self.get_config('plugins')
-            enabled_plugins.append(data.get('value'))
+            new_plugin = data.get('value')
+            # only add the new plugin if it is not already in the enabled_plugins
+            if new_plugin not in enabled_plugins:
+                enabled_plugins.append(data.get('value'))
         else:
             self.set_config('main', data.get('prop'), data.get('value'))
         return self.get_config()


### PR DESCRIPTION
## Description

The rest_service allowed a plugin to be added to the conf/default.yml more than once.

To reproduce this bug
1. Run caldera with an unchanged conf/default.yml file
2. Navigate to the configuration web page
3. Click to enable a plugin more than once (the human plugin can be clicked 5 times as an example)
4. View the conf/default.yml file to confirm that the human plugin appears in the enabled plugins section more than once (5 times per the previous example)


This fix adds logic to only allow the plugin to be added once. The 'if statement' will check to ensure the plugin is not already in the plugins section of the configuration file before appending the text for the newly enabled plugin

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested using the recommended pytest method (from the caldera contribution docs) on Python version 3.9.1 on Kali.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
