### PR TITLE
Manual links were breaking cleanup link generation

### DIFF
--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -227,7 +227,8 @@ class RestService(RestServiceInterface, BaseService):
             return dict(error='Agent missing specified executor')
 
         encoded_command = self.encode_string(data['command'])
-        ability = Ability(ability_id='auto-generated', tactic='auto-generated', technique_id='auto-generated',
+        ability_id = str(uuid.uuid4())
+        ability = Ability(ability_id=ability_id, tactic='auto-generated', technique_id='auto-generated',
                           technique='auto-generated', name='Manual Command', description='Manual command ability',
                           cleanup='', test=encoded_command, executor=data['executor'], platform=agent.platform,
                           payloads=[], parsers=[], requirements=[], privilege=None, variations=[])


### PR DESCRIPTION
## Description

Fix bug with manual links throwing an error when generating cleanup links. This error would prevent cleanup links from being generated properly and an operation could not be finished.

Also, generate unique ability ids for each ability to ensure that `ability.unique` is actually unique.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run an empty operation
2. Add a manual link
3. Finish the operation
4. Check the value of `operation.finish`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
