### PR TITLE
Clarify terminating agents from the UI

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -535,6 +535,9 @@ p[onclick] {
 .maroon {
     background-color: maroon;
 }
+.yellow {
+    background-color: #FFB000;
+}
 .golden {
     background-color: goldenrod;
     border-radius: 50%;

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -68,7 +68,16 @@
                     <td><p>{{ a.paw }}</p></td>
                     <td><p>{{ a.host }}</p></td>
                     <td><p>{{ a.contact }}</p></td>
-                    <td><button id="{{a.paw|e}}-pid" class="button-row" onclick="showAgentInfo('{{ a.paw|e }}')">{{ a.pid }}</button></td>
+                    {% if a.trusted %}
+                        {% if a.watchdog > 0 and a.watchdog < a.sleep_min %}
+                            {% set agentStatus = "yellow" %}
+                        {% else %}
+                            {% set agentStatus = "" %}
+                        {% endif %}
+                    {% else %}
+                        {% set agentStatus = "maroon" %}
+                    {% endif %}
+                    <td><button id="{{a.paw|e}}-pid" class="button-row {{ agentStatus }}" onclick="showAgentInfo('{{ a.paw|e }}')">{{ a.pid }}</button></td>
                     <td><p>{{ a.privilege }}</p></td>
                     <td><p onclick="deleteAgent('{{ a.paw }}')">&#x274C;</p></td>
                 </tr>
@@ -266,6 +275,7 @@
                         if(!a.trusted) {
                             let element = document.getElementById(paw + '-pid');
                             if (element !== null) {
+                                element.classList.remove('yellow');
                                 element.classList.add('maroon');
                             }
                         }
@@ -392,6 +402,11 @@
             restRequest('PUT', data, (data) => {
                 document.getElementById('agent-modal').style.display='none';
                 stream(`Agent ${data.paw} will self terminate after its next beacon.`);
+                let element = document.getElementById(data.paw + '-pid');
+                if (element !== null) {
+                    element.classList.remove('maroon');
+                    element.classList.add('yellow');
+                }
             });
         }
     }


### PR DESCRIPTION
## Description

Agents will now turn yellow when the initial request to terminate is submitted, and then red once they become untrusted (previous functionality). Agent status color will persist if page is refreshed, to cut down on user confusion.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I did the following locally:
- running an agent, killing the agent in the UI, watching the agent turn from green to yellow to red
- testing the above but refreshing the page after clicking the button to kill the agent
- testing the above with multiple agents to verify the correct agents have the correct colors
- deleting an active agent and ensuring it is green when the next beacon comes in

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
