### PR TITLE
Add markdown dependency to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ ldap3==2.8.1
 lxml~=4.6.2  # debrief
 reportlab==3.5.59  # debrief
 svglib==1.0.1  # debrief
+Markdown==3.3.3  # training


### PR DESCRIPTION
## Description
Related: https://github.com/mitre/training/pull/113

The training plugin uses `markdown` to generate html solution guides for flags. This PR adds it as a dependency in `requirements.txt`.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I uninstalled `markdown` from my virtuelenv and reinstalled it via `pip install -r requirements.txt`. Output below:

```
<!-- SNIP -->
Installing collected packages: Markdown
Successfully installed Markdown-3.3.3
```

I also ran `pytest` afterwards and no errors were reported.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code