### PR TITLE
Fix issue with deletion of sessions during refresh()

### DIFF
--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -47,11 +47,18 @@ class TcpSessionHandler(BaseWorld):
         self.sessions = []
 
     async def refresh(self):
-        for index, session in enumerate(self.sessions):
+        index = 0
+
+        while index < len(self.sessions):
+            session = self.sessions[index]
+
             try:
                 session.connection.send(str.encode(' '))
             except socket.error:
+                self.log.debug('Error occurred when refreshing session %s. Removing from session pool.', session.id)
                 del self.sessions[index]
+            else:
+                index += 1
 
     async def accept(self, reader, writer):
         try:

--- a/tests/contacts/test_contact_tcp.py
+++ b/tests/contacts/test_contact_tcp.py
@@ -1,16 +1,15 @@
 import logging
 import socket
 from unittest import mock
-from unittest import IsolatedAsyncioTestCase
 
 from app.contacts.contact_tcp import TcpSessionHandler
 
 logger = logging.getLogger(__name__)
 
 
-class TestTcpSessionHandler(IsolatedAsyncioTestCase):
+class TestTcpSessionHandler:
 
-    async def test_refresh_with_socket_errors(self):
+    def test_refresh_with_socket_errors(self, loop):
         handler = TcpSessionHandler(services=None, log=logger)
 
         session_with_socket_error = mock.Mock()
@@ -22,11 +21,11 @@ class TestTcpSessionHandler(IsolatedAsyncioTestCase):
             mock.Mock()
         ]
 
-        await handler.refresh()
+        loop.run_until_complete(handler.refresh())
         assert len(handler.sessions) == 1
         assert all(x is not session_with_socket_error for x in handler.sessions)
 
-    async def test_refresh_without_socket_errors(self):
+    def test_refresh_without_socket_errors(self, loop):
         handler = TcpSessionHandler(services=None, log=logger)
         handler.sessions = [
             mock.Mock(),
@@ -34,5 +33,5 @@ class TestTcpSessionHandler(IsolatedAsyncioTestCase):
             mock.Mock()
         ]
 
-        await handler.refresh()
+        loop.run_until_complete(handler.refresh())
         assert len(handler.sessions) == 3

--- a/tests/contacts/test_contact_tcp.py
+++ b/tests/contacts/test_contact_tcp.py
@@ -1,0 +1,38 @@
+import logging
+import socket
+from unittest import mock
+from unittest import IsolatedAsyncioTestCase
+
+from app.contacts.contact_tcp import TcpSessionHandler
+
+logger = logging.getLogger(__name__)
+
+
+class TestTcpSessionHandler(IsolatedAsyncioTestCase):
+
+    async def test_refresh_with_socket_errors(self):
+        handler = TcpSessionHandler(services=None, log=logger)
+
+        session_with_socket_error = mock.Mock()
+        session_with_socket_error.connection.send.side_effect = socket.error()
+
+        handler.sessions = [
+            session_with_socket_error,
+            session_with_socket_error,
+            mock.Mock()
+        ]
+
+        await handler.refresh()
+        assert len(handler.sessions) == 1
+        assert all(x is not session_with_socket_error for x in handler.sessions)
+
+    async def test_refresh_without_socket_errors(self):
+        handler = TcpSessionHandler(services=None, log=logger)
+        handler.sessions = [
+            mock.Mock(),
+            mock.Mock(),
+            mock.Mock()
+        ]
+
+        await handler.refresh()
+        assert len(handler.sessions) == 3


### PR DESCRIPTION
## Description
Fixed an issue in `TcpSessionHandler.refresh()` where sessions may be skipped due to mutation of the list being iterated over.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
I added unit tests to confirm the undesired behavior and then implemented the fix (tests pass now).


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
