### PR TITLE
Agent IP addresses

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -41,6 +41,7 @@ class AgentFieldsSchema(ma.Schema):
     deadman_enabled = ma.fields.Boolean()
     available_contacts = ma.fields.List(ma.fields.String())
     created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
+    host_ips = ma.fields.List(ma.fields.String())
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
@@ -74,7 +75,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
                  proxy_receivers=None, proxy_chain=None, origin_link_id=0, deadman_enabled=False,
-                 available_contacts=None):
+                 available_contacts=None, host_ips=None):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
         self.host = host
@@ -106,6 +107,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.deadman_enabled = deadman_enabled
         self.available_contacts = available_contacts if available_contacts else [self.contact]
         self.pending_contact = contact
+        self.host_ips = host_ips if host_ips else []
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -151,6 +153,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.update('proxy_chain', kwargs.get('proxy_chain'))
         self.update('deadman_enabled', kwargs.get('deadman_enabled'))
         self.update('contact', kwargs.get('contact'))
+        self.update('host_ips', kwargs.get('host_ips'))
 
     async def gui_modification(self, **kwargs):
         loaded = AgentFieldsSchema(only=('group', 'trusted', 'sleep_min', 'sleep_max', 'watchdog', 'pending_contact')).load(kwargs)

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -41,7 +41,7 @@ class AgentFieldsSchema(ma.Schema):
     deadman_enabled = ma.fields.Boolean()
     available_contacts = ma.fields.List(ma.fields.String())
     created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
-    host_ips = ma.fields.List(ma.fields.String())
+    host_ip_addrs = ma.fields.List(ma.fields.String())
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
@@ -75,7 +75,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
                  proxy_receivers=None, proxy_chain=None, origin_link_id=0, deadman_enabled=False,
-                 available_contacts=None, host_ips=None):
+                 available_contacts=None, host_ip_addrs=None):
         super().__init__()
         self.paw = paw if paw else self.generate_name(size=6)
         self.host = host
@@ -107,7 +107,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.deadman_enabled = deadman_enabled
         self.available_contacts = available_contacts if available_contacts else [self.contact]
         self.pending_contact = contact
-        self.host_ips = host_ips if host_ips else []
+        self.host_ip_addrs = host_ip_addrs if host_ip_addrs else []
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -153,7 +153,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         self.update('proxy_chain', kwargs.get('proxy_chain'))
         self.update('deadman_enabled', kwargs.get('deadman_enabled'))
         self.update('contact', kwargs.get('contact'))
-        self.update('host_ips', kwargs.get('host_ips'))
+        self.update('host_ip_addrs', kwargs.get('host_ip_addrs'))
 
     async def gui_modification(self, **kwargs):
         loaded = AgentFieldsSchema(only=('group', 'trusted', 'sleep_min', 'sleep_max', 'watchdog', 'pending_contact')).load(kwargs)

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -154,6 +154,10 @@
                         <td><p id="modal-executors"></p></td>
                     </tr>
                     <tr>
+                        <td>Host IP Addresses</td>
+                        <td><p id="modal-host_ips"></p></td>
+                    </tr>
+                    <tr>
                         <td>Peer-to-Peer Proxy Receivers</td>
                         <td><p id="modal-peer_receivers"></p></td>
                     </tr>
@@ -432,6 +436,7 @@
             parent.find('#modal-ppid').text(agent['ppid']);
             parent.find('#modal-executors').text(JSON.stringify(agent['executors']));
             parent.find('#modal-watchdog').text(agent['watchdog']);
+            parent.find('#modal-host_ips').text(JSON.stringify(agent['host_ips']));
 
             // Set up contact selection
             let num_contacts = agent['available_contacts'].length;

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -155,7 +155,7 @@
                     </tr>
                     <tr>
                         <td>Host IP Addresses</td>
-                        <td><p id="modal-host_ips"></p></td>
+                        <td><p id="modal-host_ip_addrs"></p></td>
                     </tr>
                     <tr>
                         <td>Peer-to-Peer Proxy Receivers</td>
@@ -436,7 +436,7 @@
             parent.find('#modal-ppid').text(agent['ppid']);
             parent.find('#modal-executors').text(JSON.stringify(agent['executors']));
             parent.find('#modal-watchdog').text(agent['watchdog']);
-            parent.find('#modal-host_ips').text(JSON.stringify(agent['host_ips']));
+            parent.find('#modal-host_ip_addrs').text(JSON.stringify(agent['host_ip_addrs']));
 
             // Set up contact selection
             let num_contacts = agent['available_contacts'].length;

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -103,7 +103,7 @@ class TestRestSvc:
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
                      'proxy_receivers': {}, 'proxy_chain': [], 'origin_link_id': 0,
                      'deadman_enabled': False, 'available_contacts': ['unknown'], 'pending_contact': 'unknown',
-                     'host_ips': []}],
+                     'host_ip_addrs': []}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -102,7 +102,8 @@ class TestRestSvc:
                      'platform': 'windows', 'host': 'unknown', 'paw': '123', 'pid': 0,
                      'display_name': 'unknown$unknown', 'group': 'red', 'location': 'unknown', 'privilege': 'User',
                      'proxy_receivers': {}, 'proxy_chain': [], 'origin_link_id': 0,
-                     'deadman_enabled': False, 'available_contacts': ['unknown'], 'pending_contact': 'unknown'}],
+                     'deadman_enabled': False, 'available_contacts': ['unknown'], 'pending_contact': 'unknown',
+                     'host_ips': []}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text'}
         internal_rest_svc = rest_svc(loop)


### PR DESCRIPTION
## Description

Modified sandcat agent to collect all non-loopback IPv4 addresses in use on its host. (https://github.com/mitre/gocat/pull/48)
Modified agent object to include a list of host IP addresses. Also added this variable to list of variables to update with heartbeat. Finally, changed the agent front-end to display the list of host IP addresses in the agent modal.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked agent modal for sandcat agent, host IP addresses were listed. For other agents, IP address list was empty.
Ran pytest, all tests passed.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
