### PR TITLE
[VIRTS-1885] Fix PermissionError when using --fresh and have data subfolders

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -35,13 +35,15 @@ class DataService(DataServiceInterface, BaseService):
     async def destroy():
         if os.path.exists('data/object_store'):
             os.remove('data/object_store')
+
         for d in ['data/results', 'data/adversaries', 'data/abilities', 'data/facts', 'data/sources', 'data/payloads', 'data/objectives']:
             for f in glob.glob('%s/*' % d):
-                if not f.startswith('.'):
-                    try:
-                        os.remove(f)
-                    except IsADirectoryError:
-                        shutil.rmtree(f)
+                if f.startswith('.'):  # e.g., .gitkeep
+                    continue
+                elif os.path.isdir(f):
+                    shutil.rmtree(f)
+                else:
+                    os.remove(f)
 
     async def save_state(self):
         await self._prune_non_critical_data()


### PR DESCRIPTION
## Description
Fixes an issue I ran into while running `server.py --fresh` with an ability file stored under `data/abiliites/discovery/some-uuid-filename.yml` (see error below).

```
> python server.py --insecure --fresh
2021-02-17 17:02:41 - WARNING (server.py:83 <module>) --insecure flag set. Caldera will use the default.yml config file.
2021-02-17 17:02:41 - INFO  (server.py:90 <module>) Using main config from conf/default.yml
Traceback (most recent call last):
  File "/Users/bworrell/code/caldera/server.py", line 105, in <module>
    asyncio.get_event_loop().run_until_complete(data_svc.destroy())
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/bworrell/code/caldera/app/service/data_svc.py", line 42, in destroy
    os.remove(f)
PermissionError: [Errno 1] Operation not permitted: 'data/abilities/discovery'
```

The  ability file was created when going through the training and  I created a new adversary profile along with a new ability.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I ran the server with the same commands and confirmed that the error did not appear, the folder was deleted, and my `.gitkeep` file remained.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
