### PR TITLE
remove parens from "(auto-generated)"

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -311,7 +311,7 @@ class DataService(DataServiceInterface, BaseService):
         for ability in await self.locate('abilities'):
             for field in required_fields:
                 if not getattr(ability, field):
-                    setattr(ability, field, '(auto-generated)')
+                    setattr(ability, field, 'auto-generated')
                     self.log.warning('Missing required field in ability %s: %s' % (ability.ability_id, field))
             for payload in ability.payloads:
                 payload_name = payload


### PR DESCRIPTION
## Description

Make `data_svc` consistent with convention from https://github.com/mitre/caldera/pull/2020 . 

Remove parenthesis from `(auto-generated)` string so that it will be `auto-generated`.  The parentheses were sometimes awkward since they were illegal characters for some places they were being used.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

✅ Pytest 
✅ Launched agent
✅ Launched operation with adversary profile
✅ Launched operation w/ manual commands and potential links
✅ Recursively searched through entire codebase (including mainline plugins) for other instances of the `(auto-generated)` -- there are none. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
