### PR TITLE
Link schema updates

### DIFF
--- a/app/objects/secondclass/c_fact.py
+++ b/app/objects/secondclass/c_fact.py
@@ -22,12 +22,15 @@ escape_ref = {
 
 class FactSchema(ma.Schema):
 
+    class Meta:
+        unknown = ma.EXCLUDE
+
     unique = ma.fields.String()
     trait = ma.fields.String()
     value = ma.fields.Function(lambda x: x.value, deserialize=lambda x: str(x), allow_none=True)
     score = ma.fields.Integer()
-    collected_by = ma.fields.String()
-    technique_id = ma.fields.String()
+    collected_by = ma.fields.String(allow_none=True)
+    technique_id = ma.fields.String(allow_none=True)
 
     @ma.post_load()
     def build_fact(self, data, **_):

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -7,6 +7,7 @@ import marshmallow as ma
 
 from app.objects.c_ability import Ability, AbilitySchema
 from app.objects.secondclass.c_fact import Fact, FactSchema
+from app.objects.secondclass.c_relationship import RelationshipSchema
 from app.objects.secondclass.c_visibility import Visibility, VisibilitySchema
 from app.utility.base_object import BaseObject
 
@@ -26,6 +27,8 @@ class LinkSchema(ma.Schema):
     pin = ma.fields.Integer(missing=0)
     pid = ma.fields.String()
     facts = ma.fields.List(ma.fields.Nested(FactSchema()))
+    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema()))
+    used = ma.fields.List(ma.fields.Nested(FactSchema()))
     unique = ma.fields.String()
     collect = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', default='')
     finish = ma.fields.String()
@@ -87,7 +90,7 @@ class Link(BaseObject):
                     TIMEOUT=124)
 
     def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0,
-                 host=None, deadman=False):
+                 host=None, deadman=False, used=[], relationships=[]):
         super().__init__()
         self.id = id
         self.command = command
@@ -104,8 +107,8 @@ class Link(BaseObject):
         self.collect = None
         self.finish = None
         self.facts = []
-        self.relationships = []
-        self.used = []
+        self.relationships = relationships
+        self.used = used
         self.visibility = Visibility()
         self._pin = pin
         self.output = False

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -90,7 +90,7 @@ class Link(BaseObject):
                     TIMEOUT=124)
 
     def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id=None, pin=0,
-                 host=None, deadman=False, used=[], relationships=[]):
+                 host=None, deadman=False, used=None, relationships=None):
         super().__init__()
         self.id = id
         self.command = command
@@ -107,8 +107,8 @@ class Link(BaseObject):
         self.collect = None
         self.finish = None
         self.facts = []
-        self.relationships = relationships
-        self.used = used
+        self.relationships = relationships if relationships else []
+        self.used = used if used else []
         self.visibility = Visibility()
         self._pin = pin
         self.output = False

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -62,7 +62,7 @@ class Link(BaseObject):
     schema = LinkSchema()
     display_schema = LinkSchema(exclude=['jitter'])
     load_schema = LinkSchema(exclude=['decide', 'pid', 'facts', 'unique', 'collect', 'finish', 'visibility',
-                                      'output'])
+                                      'output', 'used.unique'])
 
     RESERVED = dict(origin_link_id='#{origin_link_id}')
 


### PR DESCRIPTION
## Description

When running operations in manual mode, the potential link applied to an operation is a new Link created from the data passed from the front end to the back end (it is _not_ the actual Link object stored in an operation's `potential_links`) and this data was missing the `used` and `relationships` attributes since they were not included in the Link schema. This created a bug in the Debrief plugin Fact graph since the operation Links did not have the expected used facts and relationships.

Proposed changes:
- Added `used` and `relationships` to Link schema
- Ignore Fact `unique` when loading a Link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Ran operations in autonomous and manual mode

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
