### PR TITLE
Fix bug in data_svc which causes ability 'test' field to be None

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -129,8 +129,12 @@ class DataService(DataServiceInterface, BaseService):
                                 encoded_code = self.encode_string(code_data.decode('utf-8').strip())
                             else:
                                 encoded_code = self.encode_string(cleaned_code)
+                            if not encoded_test:
+                                encoded_test = encoded_code
                         else:
                             encoded_code = None
+                        if not encoded_test:
+                            encoded_test = cleanup_cmd
                         payloads = ab.pop('payloads', []) if encoded_code else info.get('payloads')
                         uploads = ab.pop('uploads', []) if encoded_code else info.get('uploads')
                         for e in name.split(','):


### PR DESCRIPTION
## Description

There was a bug in data_svc.py that resulted in the 'test' field of 3 abilities to be empty. In turn, this empty field caused the agent_configuration REST endpoint to fail. The endpoint failed because of a KeyError when trying to decode the `raw_command` (which was set to `None` in data_svc). 

The abilities which cause this bug have the following UUIDs:
0bff4ee7-42a4-4bde-b09a-9d79d8b9edd7
5a39d7ed-45c9-4a79-b581-e5fb99e24f65
4cd4eb44-29a7-4259-91ae-e457b283a880


## To recreate the bug

Start Caldera Server v3.0.0:   `python3 server.py --insecure`
Run the following curl command to attempt reaching the 'agent_configuration' endpoint:  `curl -H "KEY:$API_KEY" -X POST localhost:8888/api/rest -d ' {"index":"agent_configuration"}'`

The stack trace of the bug is below:

```
ERROR (rest_api.py:112 rest_core) TypeError("argument should be a bytes-like object or ASCII string, not 'NoneType'")
Traceback (most recent call last):
  File "/home/kali/gold_caldera/caldera3.0.0/app/api/rest_api.py", line 108, in rest_core
    return web.json_response(await options[request.method][index](data))
  File "/home/kali/gold_caldera/caldera3.0.0/app/service/rest_svc.py", line 302, in get_agent_configuration
    raw_abilities = [{'platform': ability.platform, 'executor': ability.executor,
  File "/home/kali/gold_caldera/caldera3.0.0/app/service/rest_svc.py", line 303, in <listcomp>
    'description': ability.description, 'command': ability.raw_command,
  File "/home/kali/gold_caldera/caldera3.0.0/app/objects/c_ability.py", line 71, in raw_command
    return self.decode_bytes(self._test)
  File "/home/kali/gold_caldera/caldera3.0.0/app/utility/base_world.py", line 47, in decode_bytes
    decoded = b64decode(s).decode('utf-8', errors='ignore')
  File "/usr/lib/python3.9/base64.py", line 80, in b64decode
    s = _bytes_from_decode_data(s)
  File "/usr/lib/python3.9/base64.py", line 45, in _bytes_from_decode_data
    raise TypeError("argument should be a bytes-like object or ASCII "
TypeError: argument should be a bytes-like object or ASCII string, not 'NoneType'
```

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

My code fixes a bug which prevents the REST API from functioning as intended. 

My code ensures that the test/_test field is never None. This is done by having encoded_test be set to encoded_code or cleanup_cmd (in the event that encoded_test would have otherwise been None).

## How Has This Been Tested?

Tested via recommended tox method. 
Also ran the following curl command to ensure the endpoint is working now. 
```bash
curl -H "KEY:$API_KEY" -X POST localhost:8888/api/rest -d ' {"index":"agent_configuration"}'
```

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code

