### PR TITLE
Fact highlighting update

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -765,12 +765,12 @@
 
                 let factValues = Array.from(data.link.facts, fact => fact.value.toString());
                 factValues = Array.from(new Set(factValues));
-                factValues.sort(function(a, b) { return b.length - a.length });
-                $.each(factValues, function (i, factValue) {
+                factValues.sort((a, b) => { return b.length - a.length });
+                $.each(factValues, (i, factValue) => {
                     let encodedValue = $('<div/>').text(factValue).html();
                     resultText = resultText.replaceAll(encodedValue, '<span class="highlight">' + encodedValue + '</span>');
                 });
-                result = $('#resultView').html(resultText);
+                $('#resultView').html(resultText);
             } else {
               $('#resultView').empty();
             }

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -760,15 +760,23 @@
         function loadResults(data){
             if (data) {
                 let res = atob(data.output);
-                data.link.facts.sort(function(a, b) { return b.value.length - a.value.length });
-                $.each(data.link.facts, function (k, v) {
-                    res = res.replaceAll(v.value, "<span class='highlight'>" + v.value + "</span>");
+                $('#resultView').text(res);
+                resultText = $('#resultView').html();
+
+                let factValues = Array.from(data.link.facts, fact => fact.value.toString());
+                factValues = Array.from(new Set(factValues));
+                factValues.sort(function(a, b) { return b.length - a.length });
+                $.each(factValues, function (i, factValue) {
+                    let encodedValue = $('<div/>').text(factValue).html();
+                    resultText = resultText.replaceAll(encodedValue, '<span class="highlight">' + encodedValue + '</span>');
                 });
-                $('#resultView').html(res);
+                result = $('#resultView').html(resultText);
+            } else {
+              $('#resultView').empty();
             }
         }
         document.getElementById('more-modal').style.display='block';
-        $('#resultCmd').html(atob($(elem).attr('data-encoded-cmd')));
+        $('#resultCmd').text(atob($(elem).attr('data-encoded-cmd')));
         restRequest('POST', {'index':'result','link_id':lnk}, loadResults);
     }
 
@@ -837,7 +845,8 @@
 
     function showCommand(command){
         document.getElementById('more-modal').style.display='block';
-        $('#resultCmd').html(atob(command));
+        $('#resultCmd').text(atob(command));
+        $('#resultView').empty();
     }
     //# sourceURL=operations.js
 


### PR DESCRIPTION
## Description

- Safer output handling -- HTML characters in link output will be encoded, safely adds the span HTML after the initial encoding
- Clears output if there is no data or if only the command is meant to be shown (hitting the ? button)
- Properly sorts facts by length -- integer facts would mess this up before
- Get unique fact values before iterating over them -- prevents multiple spans in cases where multiple facts have the same values
- Doesn't use HTML to render commands

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran operations with links that produce a variety of output to ensure facts were highlighted properly, only once, and in the correct order (required integer values).

Modified the contact service to return a malicious payload for all link output: at https://github.com/mitre/caldera/blob/master/app/service/contact_svc.py#L98 added:

```
import base64
result.output = base64.b64encode(b'<img src="." onerror="alert(1)"/>').decode('utf-8')
```

Ran Hunter with a Windows agent and made sure no XSS was triggered by the "Create staging directory" output. Double-checked the DOM to make sure this was rendered as text as well. Confirmed that without these changes, this would pop up an alert box.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
