### PR TITLE
Fix bug in c_ability

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -68,7 +68,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
 
     @property
     def raw_command(self):
-        return self.decode_bytes(self._test)
+        return self.decode_bytes(self._test) if self._test else ""
 
     def __init__(self, ability_id, tactic=None, technique_id=None, technique=None, name=None, test=None,
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,


### PR DESCRIPTION
## Description
Resolves an issue reported by @jbooz1 effecting `data_svc.py` causing the agent_configuration REST endpoint to fail.
Root fix in raw_command() which needs to be able to handle situations where the `test` field is `None` e.g, for 'csharp' etc and skip decoding accordingly.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested via tox and pytest as well as via manual curl command e.g.

```
curl --location --request POST 'localhost:8888/api/rest' \
--header 'KEY: $API_KEY' \
--header 'Content-Type: application/json' \
--data-raw '{"index":"agent_configuration"}'
```

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
