### PR TITLE
Changing default dns contact port to prevent permission issues

### DIFF
--- a/conf/default.yml
+++ b/conf/default.yml
@@ -2,7 +2,7 @@ ability_refresh: 60
 api_key_blue: BLUEADMIN123
 api_key_red: ADMIN123
 app.contact.dns.domain: mycaldera.caldera
-app.contact.dns.socket: 0.0.0.0:53
+app.contact.dns.socket: 0.0.0.0:8853
 app.contact.gist: API_KEY
 app.contact.html: /weather
 app.contact.http: http://0.0.0.0:8888


### PR DESCRIPTION
## Description
Change DNS contact port in default config to 8853 instead of 53 to avoid permission issues

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested the DNS contact using the new default port

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
