### PR TITLE
Update jinja2 dependency to 2.11.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp-jinja2==1.2.0
 aiohttp==3.6.2
 aiohttp_session==2.9.0
 aiohttp-security==0.4.0
-jinja2==2.10.3
+jinja2==2.11.3
 pyyaml>=5.1
 cryptography>=3.2
 websockets==8.1


### PR DESCRIPTION
## Description
Resolves security issue: https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994
See also: https://jinja.palletsprojects.com/en/2.11.x/changelog/

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
* All tests pass (except for existing testing issues in master)
* I ran the server and logged in as both a blue and red user and clicked through the navigation, loading different components without issue.
* Ran `pip install -r requirements.txt` and confirmed it's installed: `Successfully installed jinja2-2.11.3`
* I also reviewed the changelog for jinja2 and nothing jumped out at me as concerning in terms of backwards compatibility.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
