### PR TITLE
Ignore reportlab vuln 39642 when running safety

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,10 +67,12 @@ commands =
     coverage report
 
 [testenv:safety]
+# Safety ignore list:
+# 39642: reportlab vuln resolved in https://github.com/mitre/debrief/pull/39
 deps =
     safety
 skip_install = true
 whitelist_externals=find
 commands =
-    safety check -r requirements.txt
+    safety check -r requirements.txt --ignore 39642
     safety check -r requirements-dev.txt


### PR DESCRIPTION
## Description
Tell `safety` to ignore the SSRF issue (39642) described here: https://snyk.io/vuln/SNYK-PYTHON-REPORTLAB-1022145.

We are ignoring it because all versions of `reportlab` are considered vulnerable by `safety` and we have resolved the issue in https://github.com/mitre/debrief/pull/39 by allowing users to leverage reportlab's `trustedHosts` configuration to limit what hosts can be contacted by reportlab.

If we don't ignore it, `safety` will continue to report failures and all PRs will me marked as broken moving forward even though we've provided a way to fix the issue. We don't want that.

## Note on implementation
I don't particularly like having to set `--ignore 39642` when invoking `saftey check ...`. I would much rather be able to register these in `setup.cfg` or by passing in an environment variable that I can more easily document. I tried to include some information in the `tox.ini` file about what that id relates to.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
* I ran `tox -e safety` and verified that `safety` ran and didn't include the `reportlab` vuln in the output.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
