### PR TITLE
Auto event log generation when operation finishes

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -268,6 +268,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         event_logs_dir = await file_svc.create_exfil_sub_directory('%s/event_logs' % self.get_config('reports_dir'))
         file_name = 'operation_%s.json' % self.id
         await self._write_logs_to_disk(event_logs, file_name, event_logs_dir, file_svc)
+        logging.debug('Wrote event logs for operation %s to disk at %s/%s' % (self.name, event_logs_dir, file_name))
 
     """ PRIVATE """
 

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -1,3 +1,5 @@
+import json
+import os
 import pytest
 
 from base64 import b64encode
@@ -146,3 +148,78 @@ class TestOperation:
         ]
         event_logs = loop.run_until_complete(op_for_event_logs.event_logs(file_svc, data_svc))
         assert event_logs == want
+
+    def test_writing_event_logs_to_disk(self, loop, op_for_event_logs, operation_agent, file_svc, data_svc):
+        loop.run_until_complete(data_svc.store(operation_agent))
+        start_time = op_for_event_logs.start.strftime('%Y-%m-%d %H:%M:%S')
+        agent_creation_time = operation_agent.created.strftime('%Y-%m-%d %H:%M:%S')
+        want_agent_metadata = dict(
+            paw='testpaw',
+            group='red',
+            architecture='amd64',
+            username='testagent',
+            location='C:\\Users\\Public\\test.exe',
+            pid=1234,
+            ppid=123,
+            privilege='User',
+            host='WORKSTATION',
+            contact='unknown',
+            created=agent_creation_time,
+        )
+        want_operation_metadata = dict(
+            operation_name='test',
+            operation_start=start_time,
+            operation_adversary='test adversary',
+        )
+        want_attack_metadata = dict(
+            tactic='test tactic',
+            technique_name='test technique',
+            technique_id='T0000',
+        )
+        want = [
+            dict(
+                command='d2hvYW1p',
+                delegated_timestamp='2021-01-01 08:00:00',
+                collected_timestamp='2021-01-01 08:01:00',
+                finished_timestamp='2021-01-01 08:02:00',
+                status=0,
+                platform='windows',
+                executor='psh',
+                pid=789,
+                agent_metadata=want_agent_metadata,
+                ability_metadata=dict(
+                    ability_id='123',
+                    ability_name='test ability',
+                    ability_description='test ability desc',
+                ),
+                operation_metadata=want_operation_metadata,
+                attack_metadata=want_attack_metadata,
+            ),
+            dict(
+                command='aG9zdG5hbWU=',
+                delegated_timestamp='2021-01-01 09:00:00',
+                collected_timestamp='2021-01-01 09:01:00',
+                finished_timestamp='2021-01-01 09:02:00',
+                status=0,
+                platform='windows',
+                executor='psh',
+                pid=7890,
+                agent_metadata=want_agent_metadata,
+                ability_metadata=dict(
+                    ability_id='456',
+                    ability_name='test ability 2',
+                    ability_description='test ability 2 desc',
+                ),
+                operation_metadata=want_operation_metadata,
+                attack_metadata=want_attack_metadata,
+            ),
+        ]
+        loop.run_until_complete(op_for_event_logs.write_event_logs_to_disk(file_svc, data_svc))
+        target_path = '/tmp/event_logs/operation_%s.json' % op_for_event_logs.id
+        assert os.path.isfile(target_path)
+        try:
+            with open(target_path, 'rb') as log_file:
+                recorded_log = json.load(log_file)
+            assert recorded_log == want
+        finally:
+            os.remove(target_path)

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -13,7 +13,7 @@ from app.objects.secondclass.c_link import Link
 @pytest.fixture
 def operation_agent(agent):
     return agent(sleep_min=30, sleep_max=60, watchdog=0, platform='windows', host='WORKSTATION',
-                 username='testagent', architecture='amd64', group='red', location='C:\\Users\\Public\\test.exe',
+                 username='testagent', architecture='amd64', group='red', location=r'C:\Users\Public\test.exe',
                  pid=1234, ppid=123, executors=['psh'], privilege='User', exe_name='test.exe', contact='unknown',
                  paw='testpaw')
 
@@ -90,7 +90,7 @@ class TestOperation:
             group='red',
             architecture='amd64',
             username='testagent',
-            location='C:\\Users\\Public\\test.exe',
+            location=r'C:\Users\Public\test.exe',
             pid=1234,
             ppid=123,
             privilege='User',
@@ -158,7 +158,7 @@ class TestOperation:
             group='red',
             architecture='amd64',
             username='testagent',
-            location='C:\\Users\\Public\\test.exe',
+            location=r'C:\Users\Public\test.exe',
             pid=1234,
             ppid=123,
             privilege='User',


### PR DESCRIPTION
## Description
Event logs are automatically generated and written to disk when an operation finishes. The event log directory is placed in the `event_logs` subdirectory of the `reports_dir` directory as specified in the CALDERA configuration (e.g. `/tmp/event_logs`). The event log file is of the format `operation_$ID.json`, where `$ID` is the operation's ID number.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Added a test to verify the operation method to generate the event log file.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
