### PR TITLE
Add swagger documentation for api v2 health endpoint

### DIFF
--- a/app/api/v2/handlers/health_api.py
+++ b/app/api/v2/handlers/health_api.py
@@ -1,5 +1,6 @@
 import operator
 
+import aiohttp_apispec
 from aiohttp import web
 
 import app
@@ -17,6 +18,8 @@ class HealthApi(BaseApi):
         router = app.router
         router.add_get('/health', self.get_health_info)
 
+    @aiohttp_apispec.docs(tags=["health"])
+    @aiohttp_apispec.response_schema(CalderaInfoSchema, 200)
     @security.authentication_exempt
     async def get_health_info(self, request):
         loaded_plugins_sorted = sorted(self._app_svc.get_loaded_plugins(), key=operator.attrgetter('name'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiohttp-jinja2==1.2.0
 aiohttp==3.6.2
 aiohttp_session==2.9.0
 aiohttp-security==0.4.0
+aiohttp-apispec==2.2.1
 jinja2==2.11.3
 pyyaml>=5.1
 cryptography>=3.2


### PR DESCRIPTION
## Description
Added swagger documentation for the api v2 health endpoint.  Documentation is available at `/api/docs` (unauthenticated endpoint).

## Notes
I think aiohttp registers a `HEAD` endpoint for each `GET` endpoint. As such, the swagger docs show a `HEAD` endpoint registered that is kinda strange. We could set the corresponding `GET` endpoint to reject `HEAD` requests which fixes it, but I'm not sure if we want that tbh.
 
## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I loaded up the swagger docs page and verified that the health endpoint was listed with the correct response schema (see notes above about the `HEAD` request.

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
