### PR TITLE
SSH Tunneling Contact

### DIFF
--- a/app/contacts/contact_ssh.py
+++ b/app/contacts/contact_ssh.py
@@ -1,0 +1,64 @@
+import os
+
+import asyncssh
+
+from app.utility.base_world import BaseWorld
+
+
+class Contact(BaseWorld):
+    def __init__(self, services):
+        self.name = 'ssh_tunneling'
+        self.description = 'Accept tunneled SSH messages'
+        self.log = self.create_logger('contact_ssh')
+        self.services = services
+        self._user_name = ''
+        self._user_password = ''
+
+    async def start(self):
+        ssh_endpoint = self.get_config('app.contact.ssh.socket')
+        addr, port = ssh_endpoint.split(':')
+        host_key_filename = self.get_config('app.contact.ssh.host_key_file')
+        host_key_filepath = os.path.join('conf', 'ssh_keys', host_key_filename)
+        host_key_passphrase = self.get_config('app.contact.ssh.host_key_passphrase')
+        host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
+        self._user_name = self.get_config('app.contact.ssh.user_name')
+        self._user_password = self.get_config('app.contact.ssh.user_password')
+        await asyncssh.create_server(self.server_factory, addr, int(port),
+                                     server_host_keys=[host_key])
+
+    def server_factory(self):
+        return SSHServerContact(self.services, self._user_name, self._user_password)
+
+
+class SSHServerContact(asyncssh.SSHServer):
+    def __init__(self, services, user_name, user_password):
+        super().__init__()
+        self.services = services
+        self.log = BaseWorld.create_logger('ssh_server')
+        self.valid_user_credentials = {
+            user_name: user_password
+        }
+
+    def connection_requested(self, dest_host, dest_port, orig_host, orig_port):
+        self.log.debug('Connection request from %s:%sd to %s:%s' % (orig_host, orig_port, dest_host, dest_port))
+        return True
+
+    def connection_made(self, conn):
+        self.log.debug('SSH connection received from %s.' % conn.get_extra_info('peername')[0])
+
+    def connection_lost(self, exc):
+        if exc:
+            self.log.error('SSH connection error: ' + str(exc))
+        else:
+            self.log.debug('SSH connection closed.')
+
+    def begin_auth(self, username):
+        # If the user's password is the empty string, no auth is required
+        return self.valid_user_credentials.get(username) != ''
+
+    def password_auth_supported(self):
+        return True
+
+    def validate_password(self, username, password):
+        valid_password = self.valid_user_credentials.get(username)
+        return valid_password and password == valid_password

--- a/app/contacts/contact_ssh.py
+++ b/app/contacts/contact_ssh.py
@@ -23,7 +23,7 @@ class Contact(BaseWorld):
         try:
             host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
         except Exception as e:
-            self.log.warn('Generating temporary SSH private key. Was unable to use provided SSH private key: %s' % e)
+            self.log.warning('Generating temporary SSH private key. Was unable to use provided SSH private key: %s' % e)
             host_key = asyncssh.generate_private_key('ssh-rsa', comment='temporary key')
         try:
             await asyncssh.create_server(self.server_factory, addr, int(port),

--- a/app/contacts/contact_ssh.py
+++ b/app/contacts/contact_ssh.py
@@ -23,7 +23,7 @@ class Contact(BaseWorld):
         try:
             host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
         except Exception as e:
-            self.log.error('Error reading provided SSH private key. Will generate temporary SSH private key. Error: %s' % e)
+            self.log.warn('Unable to use provided SSH private key: %s.\nWill generate temporary SSH private key.' % e)
             host_key = asyncssh.generate_private_key('ssh-rsa', comment='temporary key')
         try:
             await asyncssh.create_server(self.server_factory, addr, int(port),

--- a/app/contacts/contact_ssh.py
+++ b/app/contacts/contact_ssh.py
@@ -23,7 +23,8 @@ class Contact(BaseWorld):
         try:
             host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
         except Exception as e:
-            self.log.warn('Unable to use provided SSH private key: %s.\nWill generate temporary SSH private key.' % e)
+            self.log.warn('Unable to use provided SSH private key: %s' % e)
+            self.log.warn('Will generate temporary SSH private key.')
             host_key = asyncssh.generate_private_key('ssh-rsa', comment='temporary key')
         try:
             await asyncssh.create_server(self.server_factory, addr, int(port),

--- a/app/contacts/contact_ssh.py
+++ b/app/contacts/contact_ssh.py
@@ -23,8 +23,7 @@ class Contact(BaseWorld):
         try:
             host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
         except Exception as e:
-            self.log.warn('Unable to use provided SSH private key: %s' % e)
-            self.log.warn('Will generate temporary SSH private key.')
+            self.log.warn('Generating temporary SSH private key. Was unable to use provided SSH private key: %s' % e)
             host_key = asyncssh.generate_private_key('ssh-rsa', comment='temporary key')
         try:
             await asyncssh.create_server(self.server_factory, addr, int(port),

--- a/app/contacts/tunnels/tunnel_ssh.py
+++ b/app/contacts/tunnels/tunnel_ssh.py
@@ -5,21 +5,21 @@ import asyncssh
 from app.utility.base_world import BaseWorld
 
 
-class Contact(BaseWorld):
+class Tunnel(BaseWorld):
     def __init__(self, services):
         self.name = 'ssh_tunneling'
         self.description = 'Accept tunneled SSH messages'
-        self.log = self.create_logger('contact_ssh')
+        self.log = self.create_logger('tunnel_ssh')
         self.services = services
-        self._user_name = self.get_config('app.contact.ssh.user_name')
-        self._user_password = self.get_config('app.contact.ssh.user_password')
+        self._user_name = self.get_config('app.contact.tunnel.ssh.user_name')
+        self._user_password = self.get_config('app.contact.tunnel.ssh.user_password')
 
     async def start(self):
-        ssh_endpoint = self.get_config('app.contact.ssh.socket')
+        ssh_endpoint = self.get_config('app.contact.tunnel.ssh.socket')
         addr, port = ssh_endpoint.split(':')
-        host_key_filename = self.get_config('app.contact.ssh.host_key_file')
+        host_key_filename = self.get_config('app.contact.tunnel.ssh.host_key_file')
         host_key_filepath = os.path.join('conf', 'ssh_keys', host_key_filename)
-        host_key_passphrase = self.get_config('app.contact.ssh.host_key_passphrase')
+        host_key_passphrase = self.get_config('app.contact.tunnel.ssh.host_key_passphrase')
         try:
             host_key = asyncssh.read_private_key(host_key_filepath, passphrase=host_key_passphrase)
         except Exception as e:
@@ -32,10 +32,10 @@ class Contact(BaseWorld):
             self.log.error('Error starting SSH server: %s' % e)
 
     def server_factory(self):
-        return SSHServerContact(self.services, self._user_name, self._user_password)
+        return SSHServerTunnel(self.services, self._user_name, self._user_password)
 
 
-class SSHServerContact(asyncssh.SSHServer):
+class SSHServerTunnel(asyncssh.SSHServer):
     def __init__(self, services, user_name, user_password):
         super().__init__()
         self.services = services

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -135,7 +135,14 @@ class AppService(AppServiceInterface, BaseService):
         for contact_file in glob.iglob('app/contacts/*.py'):
             contact_module_name = contact_file.replace('/', '.').replace('\\', '.').replace('.py', '')
             contact_class = import_module(contact_module_name).Contact
-            await contact_svc.register(contact_class(self.get_services()))
+            await contact_svc.register_contact(contact_class(self.get_services()))
+        await self.register_contact_tunnels(contact_svc)
+
+    async def register_contact_tunnels(self, contact_svc):
+        for tunnel_file in glob.iglob('app/contacts/tunnels/*.py'):
+            tunnel_module_name = tunnel_file.replace('/', '.').replace('\\', '.').replace('.py', '')
+            tunnel_class = import_module(tunnel_module_name).Tunnel
+            await contact_svc.register_tunnel(tunnel_class(self.get_services()))
 
     async def validate_requirement(self, requirement, params):
         if not self.check_requirement(params):

--- a/app/service/interfaces/i_contact_svc.py
+++ b/app/service/interfaces/i_contact_svc.py
@@ -4,7 +4,11 @@ import abc
 class ContactServiceInterface(abc.ABC):
 
     @abc.abstractmethod
-    def register(self, contact):
+    def register_contact(self, contact):
+        pass
+
+    @abc.abstractmethod
+    def register_tunnel(self, tunnel):
         pass
 
     @abc.abstractmethod

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -6,6 +6,11 @@ app.contact.dns.socket: 0.0.0.0:8853
 app.contact.gist: API_KEY
 app.contact.html: /weather
 app.contact.http: http://0.0.0.0:8888
+app.contact.ssh.host_key_file: REPLACE_WITH_KEY_FILE_PATH
+app.contact.ssh.host_key_passphrase: REPLACE_WITH_KEY_FILE_PASSPHRASE
+app.contact.ssh.socket: 0.0.0.0:8022
+app.contact.ssh.user_name: sandcat
+app.contact.ssh.user_password: s4ndc4t!
 app.contact.tcp: 0.0.0.0:7010
 app.contact.udp: 0.0.0.0:7011
 app.contact.websocket: 0.0.0.0:7012

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -6,11 +6,11 @@ app.contact.dns.socket: 0.0.0.0:8853
 app.contact.gist: API_KEY
 app.contact.html: /weather
 app.contact.http: http://0.0.0.0:8888
-app.contact.ssh.host_key_file: REPLACE_WITH_KEY_FILE_PATH
-app.contact.ssh.host_key_passphrase: REPLACE_WITH_KEY_FILE_PASSPHRASE
-app.contact.ssh.socket: 0.0.0.0:8022
-app.contact.ssh.user_name: sandcat
-app.contact.ssh.user_password: s4ndc4t!
+app.contact.tunnel.ssh.host_key_file: REPLACE_WITH_KEY_FILE_PATH
+app.contact.tunnel.ssh.host_key_passphrase: REPLACE_WITH_KEY_FILE_PASSPHRASE
+app.contact.tunnel.ssh.socket: 0.0.0.0:8022
+app.contact.tunnel.ssh.user_name: sandcat
+app.contact.tunnel.ssh.user_password: s4ndc4t!
 app.contact.tcp: 0.0.0.0:7010
 app.contact.udp: 0.0.0.0:7011
 app.contact.websocket: 0.0.0.0:7012

--- a/conf/ssh_keys/.gitignore
+++ b/conf/ssh_keys/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ reportlab==3.5.64  # debrief
 svglib==1.0.1  # debrief
 Markdown==3.3.3  # training
 dnspython==2.1.0
+asyncssh==2.5.0

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -1,0 +1,55 @@
+import pytest
+import aiohttp
+import asyncssh
+import time
+
+from app.contacts.contact_ssh import Contact as SshContact
+from app.utility.base_world import BaseWorld
+from app.utility.file_decryptor import read as decrypt_read, get_encryptor
+
+
+@pytest.fixture(scope='session')
+def ssh_contact_base_world():
+    BaseWorld.apply_config(name='main', config={'app.contact.ssh.user_name': 'sandcat',
+                                                'app.contact.ssh.user_password': 's4ndc4t!',
+                                                'app.contact.ssh.socket': '0.0.0.0:8122',
+                                                'app.contact.ssh.host_key_file': 'REPLACE_WITH_KEY_FILE_PATH,',
+                                                'app.contact.ssh.host_key_passphrase': 'REPLACE_WITH_KEY_FILE_PASSPHRASE',
+                                                'plugins': ['sandcat', 'stockpile'],
+                                                'crypt_salt': 'BLAH',
+                                                'api_key': 'ADMIN123',
+                                                'encryption_key': 'ADMIN123',
+                                                'exfil_dir': '/tmp'})
+    BaseWorld.apply_config(name='agents', config={'sleep_max': 5,
+                                                  'sleep_min': 5,
+                                                  'untrusted_timer': 90,
+                                                  'watchdog': 0,
+                                                  'implant_name': 'splunkd',
+                                                  'bootstrap_abilities': [
+                                                      '43b3754c-def4-4699-a673-1d85648fda6a'
+                                                  ]})
+
+@pytest.fixture
+def ssh_contact(loop, app_svc, contact_svc, data_svc, file_svc, obfuscator):
+    services = app_svc(loop).get_services()
+    return SshContact(services)
+
+@pytest.mark.usefixtures(
+    'ssh_contact_base_world'
+)
+class TestContactSsh:
+    @staticmethod
+    async def web_request(url):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                print(resp.status)
+                print(await resp.text())
+
+    def test_tunnel(self, loop, ssh_contact):
+        loop.run_until_complete(ssh_contact.start())
+        conn = loop.run_until_complete(asyncssh.connect('localhost', port=8122, known_hosts=None, username='sandcat',
+                                                        password='s4ndc4t!'))
+        assert conn and conn.get_extra_info('username') == 'sandcat'
+        listener = loop.run_until_complete(conn.forward_local_port('', 61234, 'localhost', 8888))
+        assert listener and listener.get_port() == 61234
+        listener.close()

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -1,11 +1,9 @@
 import pytest
 import aiohttp
 import asyncssh
-import time
 
 from app.contacts.contact_ssh import Contact as SshContact
 from app.utility.base_world import BaseWorld
-from app.utility.file_decryptor import read as decrypt_read, get_encryptor
 
 
 @pytest.fixture(scope='session')
@@ -29,10 +27,12 @@ def ssh_contact_base_world():
                                                       '43b3754c-def4-4699-a673-1d85648fda6a'
                                                   ]})
 
+
 @pytest.fixture
 def ssh_contact(loop, app_svc, contact_svc, data_svc, file_svc, obfuscator):
     services = app_svc(loop).get_services()
     return SshContact(services)
+
 
 @pytest.mark.usefixtures(
     'ssh_contact_base_world'

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -2,17 +2,17 @@ import pytest
 import aiohttp
 import asyncssh
 
-from app.contacts.contact_ssh import Contact as SshContact
+from app.contacts.tunnels.tunnel_ssh import Tunnel as SshTunnel
 from app.utility.base_world import BaseWorld
 
 
 @pytest.fixture(scope='session')
 def ssh_contact_base_world():
-    BaseWorld.apply_config(name='main', config={'app.contact.ssh.user_name': 'sandcat',
-                                                'app.contact.ssh.user_password': 's4ndc4t!',
-                                                'app.contact.ssh.socket': '0.0.0.0:8122',
-                                                'app.contact.ssh.host_key_file': 'REPLACE_WITH_KEY_FILE_PATH,',
-                                                'app.contact.ssh.host_key_passphrase': 'REPLACE_WITH_KEY_FILE_PASSPHRASE',
+    BaseWorld.apply_config(name='main', config={'app.contact.tunnel.ssh.user_name': 'sandcat',
+                                                'app.contact.tunnel.ssh.user_password': 's4ndc4t!',
+                                                'app.contact.tunnel.ssh.socket': '0.0.0.0:8122',
+                                                'app.contact.tunnel.ssh.host_key_file': 'REPLACE_WITH_KEY_FILE_PATH,',
+                                                'app.contact.tunnel.ssh.host_key_passphrase': 'REPLACE_WITH_KEY_FILE_PASSPHRASE',
                                                 'plugins': ['sandcat', 'stockpile'],
                                                 'crypt_salt': 'BLAH',
                                                 'api_key': 'ADMIN123',
@@ -31,7 +31,7 @@ def ssh_contact_base_world():
 @pytest.fixture
 def ssh_contact(loop, app_svc, contact_svc, data_svc, file_svc, obfuscator):
     services = app_svc(loop).get_services()
-    return SshContact(services)
+    return SshTunnel(services)
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
## Description
Provide SSH tunneling contact framework. Unlike other contacts, this contact is not meant to be a standalone contact - instead, it acts as a tunnel wrapper for other existing contacts, such as HTTP. Supporting agents can use SSH tunneling to tunnel other C2 traffic.

This new framework provides several new options for the caldera config file, as represented by the changes in `conf/default.yml`:
- `app.contact.ssh.host_key_file`: File name for the server's SSH private host key. CALDERA operators can generate their own SSH private host key for the CALDERA server. The file must reside in the `conf/ssh_keys` directory. If the CALDERA server cannot find or read the provided private host key, it will generate a temporary RSA host key to use for operations. Although this would cause security warnings under normal circumstances, the sandcat agent implementation of SSH tunneling does not attempt to verify hosts, and thus should not be affected by changing or temporary host keys.
- `app.contact.ssh.host_key_passphrase`: Passphrase for the server's SSH private host key. The server will use this passphrase to read the private host key file provided in `app.contact.ssh.host_key_file`.
- `app.contact.ssh.socket`: Indicates the IP address and port that the CALDERA server will listen on for SSH tunneling connections. Default value is `0.0.0.0:8022`.
- `app.contact.ssh.user_name`: User name that agents will use to authenticate to the CALDERA server via SSH. Default is `sandcat`, which is what the sandcat implementation of SSH tunneling will use by default.
- `app.contact.ssh.user_password`: Password that agents will use to authenticate to the CALDERA server via SSH. Default is `s4ndc4t!`, which is what the sandcat implementation of SSH tunneling will use by default.

Accompanying gocat PR for sandcat agent support: https://github.com/mitre/gocat/pull/51

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (https://github.com/mitre/fieldmanual/pull/72)

## How Has This Been Tested?
- Added small tests via pytest to make sure the server can start up an SSH server and accept SSH tunneling connections.
- Tested small operations on Windows, Linux, and MacOS agents that tunneled the HTTP contact through SSH. The operations included payloads, facts, and file uploads.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (https://github.com/mitre/fieldmanual/pull/72)
- [x] I have added tests that prove my fix is effective or that my feature works