### PR TITLE
[VIRTS 1982] Break safety and testing into separate github actions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Security Checks
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: 3.6
+            toxenv: safety
+          - python-version: 3.7
+            toxenv: safety
+          - python-version: 3.8
+            toxenv: safety
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade virtualenv
+          pip install tox
+      - name: Run tests
+        env:
+          TOXENV: ${{ matrix.toxenv }}
+        run: tox
+

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         include:
           - python-version: 3.6
-            toxenv: py36,style,coverage-ci,safety
+            toxenv: py36,style,coverage-ci
           - python-version: 3.7
-            toxenv: py37,style,coverage-ci,safety
+            toxenv: py37,style,coverage-ci
           - python-version: 3.8
-            toxenv: py38,style,coverage-ci,safety
+            toxenv: py38,style,coverage-ci
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Refactor our github actions such that `safety` is performed in its own action rather than the `testing` action.

## Why?
This was done because it was easy to miss testing errors when safety reported errors. If a dependency of CALDERA was flagged as vulnerable, every PR would start reporting failures in the `testing` action and we become trained to ignore it while working on resolving the dependency vulnerability issue.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I verified that the actions were run in the branch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
