### PR TITLE
[VIRTS-1970] Move files aside on --fresh instead of deleting them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ data/sources/*
 !data/sources/.gitkeep
 data/objectives/*
 !data/objectives/.gitkeep
+data/backup/*
 .tox/
 
 # coverage reports

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ data/sources/*
 data/objectives/*
 !data/objectives/.gitkeep
 data/backup/*
+!data/backup/.gitkeep
 .tox/
 
 # coverage reports

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -51,7 +51,7 @@ class DataService(DataServiceInterface, BaseService):
         will begin with "data/".
 
         Note:
-            This will skip any files starting with '.' (e.g., 'gitkeep').
+            This will skip any files starting with '.' (e.g., '.gitkeep').
         """
         for data_glob in DATA_FILE_GLOBS:
             for f in glob.glob(data_glob):
@@ -62,8 +62,9 @@ class DataService(DataServiceInterface, BaseService):
         """Delete all files and subdirectories under `path`.
 
         Note:
-            This uses `glob` and thus, ignores files files that
-            start with a '.' (e.g., '.gitkeep')
+            This uses `glob` and thus, ignores top-level files
+            that start with a '.' (e.g., '.gitkeep'. Any subdirectories
+            are deleted entirely (even if they contain '.' files).
         """
         if not os.path.exists(path):
             return
@@ -81,9 +82,8 @@ class DataService(DataServiceInterface, BaseService):
     async def destroy():
         """Clear the caldera data directory and server state.
 
-        This moves all data files and the object store to the specified
-        backup directory. The original data file paths are preserved
-        under the backup directory.
+        This moves all data files and the object store to the data backup directory.
+        The original data file paths are preserved under the backup directory.
 
         Example (original path -> new backup path):
             data/results/23deddf-ff3f2.yml -> backup/data/results/23deddf-ff3f2.yml

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -70,9 +70,9 @@ class DataService(DataServiceInterface, BaseService):
             return
 
         if not os.path.isdir(path):
-            raise ValueError(f"Input path must be a directory. Received {path}")
+            raise ValueError(f'Input path must be a directory. Received {path}')
 
-        for path in glob.glob(f"{path}/*"):
+        for path in glob.glob(f'{path}/*'):
             if os.path.isdir(path):
                 shutil.rmtree(path)
             else:

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ from app.api.rest_api import RestApi
 from app.service.app_svc import AppService
 from app.service.auth_svc import AuthService
 from app.service.contact_svc import ContactService
-from app.service.data_svc import DataService
+from app.service.data_svc import DataService, DATA_BACKUP_DIR
 from app.service.event_svc import EventService
 from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
@@ -122,7 +122,7 @@ if __name__ == '__main__':
     init_swagger_documentation(app_svc.application)
 
     if args.fresh:
-        logging.info("Fresh startup: removing server data files")
+        logging.info("Fresh startup: resetting server data. See %s directory for data backups.", DATA_BACKUP_DIR)
         asyncio.get_event_loop().run_until_complete(data_svc.destroy())
 
     run_tasks(services=app_svc.get_services())

--- a/server.py
+++ b/server.py
@@ -122,6 +122,7 @@ if __name__ == '__main__':
     init_swagger_documentation(app_svc.application)
 
     if args.fresh:
+        logging.info("Fresh startup: removing server data files")
         asyncio.get_event_loop().run_until_complete(data_svc.destroy())
 
     run_tasks(services=app_svc.get_services())


### PR DESCRIPTION
## Description
Depends on: https://github.com/mitre/fieldmanual/pull/73

When running `server.py --fresh`, we currently delete the files under the `data` directory to reset the server state. This changes the behavior to back up the files before deleting them (creating a timestamped, gzipped tarball containing the files that are about to be deleted)

## Note
Every time you run the server with `--fresh` you will generate a new backup tarball. The backup filenames include a timestamp so you can always fine the most recent one.

Examples of directory structure pre/post `--fresh` (I didn't run `tree -a` so .gitkeep files don't appear, but they are there!):

Before:
```
data
├── abilities
│   ├── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
│   └── testdir
│       └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
├── adversaries
│   └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
├── backup
├── object_store
├── objectives
│   └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
├── payloads
│   └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
├── results
│   └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
└── sources
    └── 7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
```

After running w/ `--fresh`
```
data
├── abilities
├── adversaries
├── backup
│   └── backup-20210406130339.tar.gz
├── object_store
├── objectives
├── payloads
├── results
└── sources
```

Contents of the tarball
```
> tar -tzvf data/backup/backup-20210406125823.tar.gz
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/abilities/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
drwxr-xr-x  0 bworrell staff       0 Apr  6 08:58 data/abilities/testdir/
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/abilities/testdir/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/adversaries/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/objectives/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/payloads/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/results/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff     603 Apr  6 08:58 data/sources/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
-rw-r--r--  0 bworrell staff 1137539 Apr  6 08:58 data/object_store
```


## Why?
Sometimes users run the server with `--fresh` on accident and end up accidentally deleting all their progress/work. This allows users to restore their files in this case. Note that the restore procedure is not actually documented anywhere at this time. We may choose to provide some sort of `--restore-previous-state` flag that could load the files out of the `backup` directory.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Still working on this. But I've run the server with `--fresh` and observed that  the tarball is created as expected. Note that this does not remove the `.gitkeep` file under each `data/*` subdirectory.

I also ran the following command to restore a  backup state:
```
> cd /path/to/caldera/repo
> tar -zxvf data/backup/backup-20210406125823.tar.gz
```

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
