### PR TITLE
[VIRTS-2056] Suppress aiohttp in safety report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,10 +69,11 @@ commands =
 [testenv:safety]
 # Safety ignore list:
 # 39642: reportlab vuln resolved in https://github.com/mitre/debrief/pull/39
+# 39659: aiohttp cannot be upgraded to 3.7.4: https://github.com/mitre/caldera/pull/2062
 deps =
     safety
 skip_install = true
 whitelist_externals=find
 commands =
-    safety check -r requirements.txt --ignore 39642
+    safety check -r requirements.txt --ignore 39642 --ignore 39659
     safety check -r requirements-dev.txt


### PR DESCRIPTION
## Description
Our `safety` check in github actions is reporting that the current version of `aiohttp` is vulnerable and that we should upgrade to 3.7.4. Unfortunately, we cannot upgrade to 3.7.4 because there is an issue with cookies not being set on responses when using exceptions for the responses.

See: https://github.com/mitre/caldera/pull/2062


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
I ran the following command (the one in the tox file) and verified that aiohttp is no longer included in the safety report.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
