### PR TITLE
Optional learning parser

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -60,7 +60,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, name, agents, adversary, id='', jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True, visibility=50, access=None,
-                 timeout=30, use_learning_parsers=False):
+                 timeout=30, use_learning_parsers=True):
         super().__init__()
         self.id = str(id)
         self.start, self.finish = None, None

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -34,6 +34,7 @@ class OperationSchema(ma.Schema):
     auto_close = ma.fields.Boolean()
     visibility = ma.fields.Integer()
     objective = ma.fields.Nested(ObjectiveSchema())
+    use_learning_parsers = ma.fields.Boolean()
 
     @ma.post_load
     def build_planner(self, data, **_):
@@ -59,7 +60,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, name, agents, adversary, id='', jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True, visibility=50, access=None,
-                 timeout=30):
+                 timeout=30, use_learning_parsers=False):
         super().__init__()
         self.id = str(id)
         self.start, self.finish = None, None
@@ -81,6 +82,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.objective = None
         self.chain, self.potential_links, self.rules = [], [], []
         self.access = access if access else self.Access.APP
+        self.use_learning_parsers = use_learning_parsers
         if source:
             self.rules = source.rules
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -106,7 +106,7 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(link.parse(None, result.output))
                     elif link.ability.parsers:
                         loop.create_task(link.parse(operation, result.output))
-                    else:
+                    elif operation.use_learning_parsers:
                         loop.create_task(self.get_service('learning_svc').learn(operation.all_facts(), link, result.output))
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -340,7 +340,8 @@ class RestService(RestServiceInterface, BaseService):
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          obfuscator=data.pop('obfuscator', 'plain-text'),
                          auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')),
-                         timeout=int(data.pop('timeout', 30)))
+                         timeout=int(data.pop('timeout', 30)),
+                         use_learning_parsers=bool(int(data.pop('use_learning_parsers', 0))))
 
     def _get_allowed_from_access(self, access):
         if self.Access.HIDDEN in access['access']:

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -94,6 +94,10 @@
                     <option value="{{ s.name|e }}">Use {{ s.name|e }} facts</option>
                 {% endfor %}
               </select>
+              <select name="parsers" id="queueLearningParsers" class="queueOption" style="opacity:0.5" disabled="true">
+                <option value="0" selected>Do not use learning parsers</option>
+                <option value="1">Use learning parsers</option>
+              </select>
               <p style="margin-bottom:-10px">Cleanup Timeout (secs)</p>
               <input id="queueTimeout" class="queueOption" type="number" value="30" min="0" max="300"
                       onchange="stream('The number of seconds Caldera will wait per cleanup action to complete before continuing.')">
@@ -414,6 +418,7 @@
             "autonomous":document.getElementById("queueAuto").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
+            "use_learning_parsers": document.getElementById("queueLearningParsers").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value,

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -94,9 +94,9 @@
                     <option value="{{ s.name|e }}">Use {{ s.name|e }} facts</option>
                 {% endfor %}
               </select>
-              <select name="parsers" id="queueLearningParsers" class="queueOption" style="opacity:0.5" disabled="true">
-                <option value="0" selected>Do not use learning parsers</option>
-                <option value="1">Use learning parsers</option>
+              <select name="parsers" id="queueDefaultParsers" class="queueOption" style="opacity:0.5" disabled="true">
+                <option value="1" selected>Use default parsers</option>
+                <option value="0">Do not use default parsers</option>
               </select>
               <p style="margin-bottom:-10px">Cleanup Timeout (secs)</p>
               <input id="queueTimeout" class="queueOption" type="number" value="30" min="0" max="300"
@@ -418,7 +418,7 @@
             "autonomous":document.getElementById("queueAuto").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
-            "use_learning_parsers": document.getElementById("queueLearningParsers").value,
+            "use_default_parsers": document.getElementById("queueDefaultParsers").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value,

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -418,7 +418,7 @@
             "autonomous":document.getElementById("queueAuto").value,
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
-            "use_default_parsers": document.getElementById("queueDefaultParsers").value,
+            "use_learning_parsers": document.getElementById("queueDefaultParsers").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value,

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -109,7 +109,7 @@ def op_with_learning_parser(ability, adversary):
 
 @pytest.fixture
 def op_without_learning_parser(ability, adversary):
-    op = Operation(name='test', agents=[], adversary=adversary)
+    op = Operation(name='test', agents=[], adversary=adversary, use_learning_parsers=False)
     return op
 
 

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import pytest
@@ -8,6 +9,7 @@ from unittest.mock import MagicMock
 
 from app.objects.c_operation import Operation
 from app.objects.secondclass.c_link import Link
+from app.objects.secondclass.c_result import Result
 
 
 @pytest.fixture
@@ -71,6 +73,43 @@ def op_for_event_logs(operation_agent, operation_adversary, ability, operation_l
                                     command=encoded_command_2, status=-2, host=operation_agent.host, pid=7891,
                                     decide=datetime.strptime('2021-01-01 10:00:00', '%Y-%m-%d %H:%M:%S'))
     op.chain = [link_1, link_2, discarded_link]
+    return op
+
+
+@pytest.fixture
+def test_ability(ability):
+    return ability(ability_id='123')
+
+
+@pytest.fixture
+def make_test_link(test_ability):
+    def _make_link(link_id):
+        return Link(command='', paw='123456', ability=test_ability, id=link_id)
+    return _make_link
+
+
+@pytest.fixture
+def make_test_result():
+    def _make_result(link_id):
+        result = dict(
+            id=link_id,
+            output=str(base64.b64encode('10.10.10.10'.encode('utf-8')).decode('utf-8')),
+            pid=0,
+            status=0
+        )
+        return Result(**result)
+    return _make_result
+
+
+@pytest.fixture
+def op_with_learning_parser(ability, adversary):
+    op = Operation(name='test', agents=[], adversary=adversary, use_learning_parsers=True)
+    return op
+
+
+@pytest.fixture
+def op_without_learning_parser(ability, adversary):
+    op = Operation(name='test', agents=[], adversary=adversary)
     return op
 
 
@@ -223,3 +262,22 @@ class TestOperation:
             assert recorded_log == want
         finally:
             os.remove(target_path)
+
+    def test_with_learning_parser(self, loop, contact_svc, data_svc, learning_svc, op_with_learning_parser, make_test_link, make_test_result):
+        test_link = make_test_link(1234)
+        op_with_learning_parser.add_link(test_link)
+        test_result = make_test_result(test_link.id)
+        loop.run_until_complete(data_svc.store(op_with_learning_parser))
+        loop.run_until_complete(contact_svc._save(test_result))
+        assert len(test_link.facts) == 1
+        fact = test_link.facts[0]
+        assert fact.trait == 'host.ip.address'
+        assert fact.value == '10.10.10.10'
+
+    def test_without_learning_parser(self, loop, contact_svc, data_svc, learning_svc, op_without_learning_parser, make_test_link, make_test_result):
+        test_link = make_test_link(5678)
+        op_without_learning_parser.add_link(test_link)
+        test_result = make_test_result(test_link.id)
+        loop.run_until_complete(data_svc.store(op_without_learning_parser))
+        loop.run_until_complete(contact_svc._save(test_result))
+        assert len(test_link.facts) == 0

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -85,14 +85,15 @@ class TestRestSvc:
                                               'available_contacts': ['unknown'], 'pending_contact': 'unknown',
                                               'host_ip_addrs': [], 'upstream_dest': '://None:None'}],
                               'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False,
-                              'obfuscator': 'plain-text', 'objective': {'goals': [{'value': 'complete',
-                                                                                   'operator': '==',
-                                                                                   'target': 'exhaustion',
-                                                                                   'achieved': False,
-                                                                                   'count': 1048576}],
-                                                                        'percentage': 0.0, 'description': '',
-                                                                        'id': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
-                                                                        'name': 'default'}}
+                              'obfuscator': 'plain-text', 'use_learning_parsers': False,
+                              'objective': {'goals': [{'value': 'complete',
+                                                                'operator': '==',
+                                                                'target': 'exhaustion',
+                                                                'achieved': False,
+                                                                'count': 1048576}],
+                                                     'percentage': 0.0, 'description': '',
+                                                     'id': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
+                                                     'name': 'default'}}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),
@@ -154,7 +155,7 @@ class TestRestSvc:
                      'deadman_enabled': False, 'available_contacts': ['unknown'], 'pending_contact': 'unknown',
                      'host_ip_addrs': [], 'upstream_dest': '://None:None'}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
-                'obfuscator': 'plain-text'}
+                'obfuscator': 'plain-text', 'use_learning_parsers': False}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -91,9 +91,9 @@ class TestRestSvc:
                                                                 'target': 'exhaustion',
                                                                 'achieved': False,
                                                                 'count': 1048576}],
-                                                     'percentage': 0.0, 'description': '',
-                                                     'id': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
-                                                     'name': 'default'}}
+                                            'percentage': 0.0, 'description': '',
+                                            'id': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
+                                            'name': 'default'}}
         internal_rest_svc = rest_svc(loop)
         operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),


### PR DESCRIPTION
## Description
Create new operation option to enable/disable learning parsers for the operation. Users can toggle the option via GUI menu under the "Autonomous" options section.  Learning parsers will be disabled by default for the operation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Created tests to make sure that new facts are generated when learning parsers are enabled and given proper input, and that new facts are not generated when learning parsers are disabled.

Also tested by manually running operations with the option enabled and disabled.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
