### PR TITLE
Login handler

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -58,9 +58,9 @@ class RestApi(BaseWorld):
         await self.auth_svc.logout_user(request)
 
     async def landing(self, request):
-        """If user doesn't have access, server will attempt to redirect to login."""
         access = await self.auth_svc.get_permissions(request)
         if not access:
+            # If user doesn't have access, server will attempt to redirect to login.
             return await self.auth_svc.login_redirect(request)
         plugins = await self.data_svc.locate('plugins', {'access': tuple(access), **dict(enabled=True)})
         data = dict(plugins=[p.display for p in plugins], errors=self.app_svc.errors + self._request_errors(request))

--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -58,9 +58,10 @@ class RestApi(BaseWorld):
         await self.auth_svc.logout_user(request)
 
     async def landing(self, request):
+        """If user doesn't have access, server will attempt to redirect to login."""
         access = await self.auth_svc.get_permissions(request)
         if not access:
-            return render_template('login.html', request, dict())
+            return await self.auth_svc.login_redirect(request)
         plugins = await self.data_svc.locate('plugins', {'access': tuple(access), **dict(enabled=True)})
         data = dict(plugins=[p.display for p in plugins], errors=self.app_svc.errors + self._request_errors(request))
         return render_template('%s.html' % access[0].name, request, data)

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -186,7 +186,7 @@ class AuthService(AuthServiceInterface, BaseService):
         login_handler_module_path = self.get_config('auth.login.handler.module')
         if login_handler_module_path and login_handler_module_path != 'default':
             try:
-                login_handler = getattr(import_module(login_handler_module_path), 'load_login_handler')(self.get_services())
+                login_handler = import_module(login_handler_module_path).load_login_handler(self.get_services())
                 if isinstance(login_handler, LoginHandlerInterface):
                     self.log.info('Setting primary login handler: %s' % login_handler_module_path)
                     return login_handler

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -102,7 +102,7 @@ class AuthService(AuthServiceInterface, BaseService):
         except (web.HTTPRedirection, web.HTTPUnauthorized, web.HTTPForbidden, web.HTTPSuccessful) as allowed_exception:
             raise allowed_exception
         except Exception as e:
-            self.log.exception('Exception when handling login request: %s', e)
+            self.log.exception('Exception when handling login request.')
 
             # Fallback if not already using default login handler
             if not isinstance(self._login_handler, DefaultLoginHandler):
@@ -127,7 +127,7 @@ class AuthService(AuthServiceInterface, BaseService):
         except (web.HTTPRedirection, web.HTTPUnauthorized, web.HTTPForbidden, web.HTTPSuccessful) as allowed_exception:
             raise allowed_exception
         except Exception as e:
-            self.log.exception('Exception when handling login redirect: %s', e)
+            self.log.exception('Exception when handling login redirect.')
 
             # Fallback if not already using default login handler
             if not isinstance(self._login_handler, DefaultLoginHandler):

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -198,7 +198,6 @@ class AuthService(AuthServiceInterface, BaseService):
         self.log.info('Using default login handler.')
         return self._default_login_handler
 
-
     class DefaultLoginHandler(LoginHandlerInterface):
         def __init__(self, services):
             self.log = logging.getLogger('default_login_handler')

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -112,7 +112,8 @@ class AuthService(AuthServiceInterface, BaseService):
     async def login_redirect(self, request, use_template=True):
         """Redirect user to login page using the configured login handler. If using the default login handler
         and use_template is set to true, method will return the login.html template. If use_template is set to False
-        and the default login handler is configured, it will redirect to '/login' by raising HTTPFound exception."""
+        and the default login handler is configured, it will redirect to '/login' by raising HTTPFound exception.
+        """
 
         try:
             self.log.debug('Using login handler "%s" for login redirect', self._login_handler.name)

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -1,8 +1,10 @@
 import base64
+import logging
 from collections import namedtuple
 
 from aiohttp import web, web_request
 from aiohttp.web_exceptions import HTTPUnauthorized, HTTPForbidden
+from aiohttp_jinja2 import render_template
 from aiohttp_security import api as aiohttp_security_api
 from aiohttp_security import SessionIdentityPolicy, check_permission, remember, forget
 from aiohttp_security import setup as setup_security
@@ -10,10 +12,12 @@ from aiohttp_security.abc import AbstractAuthorizationPolicy
 from aiohttp_session import setup as setup_session
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
 from cryptography import fernet
+from importlib import import_module
 import ldap3
 from ldap3.core.exceptions import LDAPAttributeError, LDAPException
 
 from app.service.interfaces.i_auth_svc import AuthServiceInterface
+from app.service.interfaces.i_login_handler import LoginHandlerInterface
 from app.utility.base_service import BaseService
 
 
@@ -52,13 +56,17 @@ def check_authorization(func):
 
 
 class AuthService(AuthServiceInterface, BaseService):
-
     User = namedtuple('User', ['username', 'password', 'permissions'])
 
     def __init__(self):
         self.user_map = dict()
         self.log = self.add_service('auth_svc', self)
-        self.ldap_config = self.get_config('ldap')
+        self._default_login_handler = self.DefaultLoginHandler(self.get_services())
+        self._login_handler = self._get_primary_login_handler()
+
+    @property
+    def default_login_handler(self):
+        return self._default_login_handler
 
     async def apply(self, app, users):
         if users:
@@ -88,21 +96,36 @@ class AuthService(AuthServiceInterface, BaseService):
         :param request:
         :return: the response/location of where the user is trying to navigate
         """
-        data = await request.post()
-        username = data.get('username')
-        password = data.get('password')
-        if self.ldap_config:
-            verified = await self._ldap_login(username, password)
-        else:
-            verified = await self._check_credentials(request.app.user_map, username, password)
+        try:
+            self.log.debug('Using login handler "%s" for login' % self._login_handler.name)
+            await self._login_handler.handle_login(request)
+        except web.HTTPRedirection as http_redirect:
+            raise http_redirect
+        except Exception as e:
+            self.log.error('Exception when handling login request: %s' % e)
 
-        if verified:
-            self.log.debug('%s logging in:' % username)
-            response = web.HTTPFound('/')
-            await remember(request, response, username)
-            raise response
-        self.log.debug('%s failed login attempt: ' % username)
-        raise web.HTTPFound('/login')
+        # Fallback if not already using default login handler
+        if not isinstance(self._login_handler, self.DefaultLoginHandler):
+            self.log.debug('Falling back to default login handler')
+            return await self._default_login_handler.handle_login(request)
+
+    async def login_redirect(self, request, use_template=True):
+        """Redirect user to login page using the configured login handler. If using the default login handler
+        and use_template is set to true, method will return the login.html template. If use_template is set to False
+        and the default login handler is configured, it will redirect to '/login' by raising HTTPFound exception."""
+
+        try:
+            self.log.debug('Using login handler "%s" for login redirect' % self._login_handler.name)
+            return await self._login_handler.handle_login_redirect(request, use_template=use_template)
+        except web.HTTPRedirection as http_redirect:
+            raise http_redirect
+        except Exception as e:
+            self.log.error('Exception when handling login redirect: %s' % e)
+
+        # Fallback if not already using default login handler
+        if not isinstance(self._login_handler, self.DefaultLoginHandler):
+            self.log.debug('Falling back to default login handler')
+            return await self._default_login_handler.handle_login_redirect(request, use_template=use_template)
 
     def request_has_valid_api_key(self, request):
         api_key = request.headers.get(HEADER_API_KEY)
@@ -118,13 +141,19 @@ class AuthService(AuthServiceInterface, BaseService):
     async def request_has_valid_user_session(self, request):
         return await aiohttp_security_api.authorized_userid(request) is not None
 
+    async def provide_verified_login_response(self, request, username):
+        self.log.debug('%s logging in:' % username)
+        response = web.HTTPFound('/')
+        await remember(request, response, username)
+        raise response
+
     async def check_permissions(self, group, request):
         try:
             if self.request_has_valid_api_key(request):
                 return True
             await check_permission(request, group)
         except (HTTPUnauthorized, HTTPForbidden):
-            raise web.HTTPFound('/login')
+            return await self.login_redirect(request, use_template=False)
 
     async def get_permissions(self, request):
         identity_policy = request.config_dict.get('aiohttp_security_identity_policy')
@@ -144,47 +173,107 @@ class AuthService(AuthServiceInterface, BaseService):
 
     """ PRIVATE """
 
-    @staticmethod
-    async def _check_credentials(user_map, username, password):
-        user = user_map.get(username)
-        if not user:
+    def _get_primary_login_handler(self):
+        """
+        Returns the login handler for the auth service as specified in the config file.
+        This login handler will take priority for login methods during login_user and redirects during
+        check_permissions. If no login handler was specified in the config file, the default handler will be returned.
+        """
+        login_handler_module_path = self.get_config('auth.login.handler.module')
+        if login_handler_module_path and login_handler_module_path != 'default':
+            try:
+                login_handler = getattr(import_module(login_handler_module_path), 'load_login_handler')(self.get_services())
+                if isinstance(login_handler, LoginHandlerInterface):
+                    self.log.info('Setting primary login handler: %s' % login_handler_module_path)
+                    return login_handler
+                else:
+                    self.log.warn('Attempted to set login handler that does not implement LoginHandlerInterface.')
+            except Exception as e:
+                self.log.error('Invalid login handler module: %s' % e)
+
+        self.log.info('Using default login handler.')
+        return self._default_login_handler
+
+
+    class DefaultLoginHandler(LoginHandlerInterface):
+        def __init__(self, services):
+            self.log = logging.getLogger('default_login_handler')
+            self.auth_svc = services.get('auth_svc')
+            self._ldap_config = self.get_config('ldap')
+            self._name = 'Default Login Handler'
+
+        @property
+        def name(self):
+            return self._name
+
+        """ LoginHandlerInterface implementation """
+
+        async def handle_login(self, request, **kwargs):
+            self.log.debug('Handling default login')
+            data = await request.post()
+            username = data.get('username')
+            password = data.get('password')
+            if username and password:
+                if self._ldap_config:
+                    verified = await self._ldap_login(username, password)
+                else:
+                    verified = await self._check_credentials(request.app.user_map, username, password)
+
+                if verified:
+                    await self.auth_svc.provide_verified_login_response(request, username)
+                self.log.debug('%s failed login attempt: ' % username)
+            raise web.HTTPFound('/login')
+
+        async def handle_login_redirect(self, request, **kwargs):
+            self.log.debug('Handling default login redirect')
+            if kwargs.get('use_template'):
+                return render_template('login.html', request, dict())
+            else:
+                raise web.HTTPFound('/login')
+
+        """ PRIVATE """
+
+        @staticmethod
+        async def _check_credentials(user_map, username, password):
+            user = user_map.get(username)
+            if not user:
+                return False
+            return user.password == password
+
+        async def _ldap_login(self, username, password):
+            server = ldap3.Server(self._ldap_config.get('server'))
+            dn = self._ldap_config.get('dn')
+            user_attr = self._ldap_config.get('user_attr') or 'uid'
+            user_string = '%s=%s,%s' % (user_attr, username, dn)
+
+            try:
+                with ldap3.Connection(server, user=user_string, password=password) as conn:
+                    if conn.bind():
+                        if username not in self.user_map:
+                            group = await self._ldap_get_group(conn, dn, username, user_attr)
+                            await self.create_user(username, None, group)
+                        return True
+            except LDAPException:
+                self.log.error('Unable to connect to LDAP server')
+
             return False
-        return user.password == password
 
-    async def _ldap_login(self, username, password):
-        server = ldap3.Server(self.ldap_config.get('server'))
-        dn = self.ldap_config.get('dn')
-        user_attr = self.ldap_config.get('user_attr') or 'uid'
-        user_string = '%s=%s,%s' % (user_attr, username, dn)
+        async def _ldap_get_group(self, connection, dn, username, user_attr):
+            group_attr = self._ldap_config.get('group_attr') or 'objectClass'
+            red_group_name = self._ldap_config.get('red_group') or 'red'
 
-        try:
-            with ldap3.Connection(server, user=user_string, password=password) as conn:
-                if conn.bind():
-                    if username not in self.user_map:
-                        group = await self._ldap_get_group(conn, dn, username, user_attr)
-                        await self.create_user(username, None, group)
-                    return True
-        except LDAPException:
-            self.log.error('Unable to connect to LDAP server')
+            try:
+                connection.search(dn, '(%s=%s)' % (user_attr, username), attributes=[group_attr])
+            except LDAPAttributeError:
+                self.log.error('Invalid group_attr in config: %s' % group_attr)
+                return 'blue'
 
-        return False
-
-    async def _ldap_get_group(self, connection, dn, username, user_attr):
-        group_attr = self.ldap_config.get('group_attr') or 'objectClass'
-        red_group_name = self.ldap_config.get('red_group') or 'red'
-
-        try:
-            connection.search(dn, '(%s=%s)' % (user_attr, username), attributes=[group_attr])
-        except LDAPAttributeError:
-            self.log.error('Invalid group_attr in config: %s' % group_attr)
-            return 'blue'
-
-        groups_result = connection.entries[0][group_attr].value
-        if ((isinstance(groups_result, list) and red_group_name in groups_result)
-                or red_group_name == groups_result):
-            return 'red'
-        else:
-            return 'blue'
+            groups_result = connection.entries[0][group_attr].value
+            if ((isinstance(groups_result, list) and red_group_name in groups_result)
+                    or red_group_name == groups_result):
+                return 'red'
+            else:
+                return 'blue'
 
 
 class DictionaryAuthorizationPolicy(AbstractAuthorizationPolicy):

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -62,7 +62,7 @@ class AuthService(AuthServiceInterface, BaseService):
         self.user_map = dict()
         self.log = self.add_service('auth_svc', self)
         self._default_login_handler = self.DefaultLoginHandler(self.get_services())
-        self._login_handler = self._get_primary_login_handler()
+        self._login_handler = self._set_primary_login_handler()
 
     @property
     def default_login_handler(self):
@@ -101,6 +101,8 @@ class AuthService(AuthServiceInterface, BaseService):
             await self._login_handler.handle_login(request)
         except web.HTTPRedirection as http_redirect:
             raise http_redirect
+        except web.HTTPUnauthorized as http_unauthorized:
+            raise http_unauthorized
         except Exception as e:
             self.log.error('Exception when handling login request: %s' % e)
 
@@ -119,6 +121,8 @@ class AuthService(AuthServiceInterface, BaseService):
             return await self._login_handler.handle_login_redirect(request, use_template=use_template)
         except web.HTTPRedirection as http_redirect:
             raise http_redirect
+        except web.HTTPUnauthorized as http_unauthorized:
+            raise http_unauthorized
         except Exception as e:
             self.log.error('Exception when handling login redirect: %s' % e)
 
@@ -173,7 +177,7 @@ class AuthService(AuthServiceInterface, BaseService):
 
     """ PRIVATE """
 
-    def _get_primary_login_handler(self):
+    def _set_primary_login_handler(self):
         """
         Returns the login handler for the auth service as specified in the config file.
         This login handler will take priority for login methods during login_user and redirects during

--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -1,10 +1,9 @@
 import base64
-import logging
 from collections import namedtuple
+from importlib import import_module
 
 from aiohttp import web, web_request
 from aiohttp.web_exceptions import HTTPUnauthorized, HTTPForbidden
-from aiohttp_jinja2 import render_template
 from aiohttp_security import api as aiohttp_security_api
 from aiohttp_security import SessionIdentityPolicy, check_permission, remember, forget
 from aiohttp_security import setup as setup_security
@@ -12,12 +11,10 @@ from aiohttp_security.abc import AbstractAuthorizationPolicy
 from aiohttp_session import setup as setup_session
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
 from cryptography import fernet
-from importlib import import_module
-import ldap3
-from ldap3.core.exceptions import LDAPAttributeError, LDAPException
 
 from app.service.interfaces.i_auth_svc import AuthServiceInterface
 from app.service.interfaces.i_login_handler import LoginHandlerInterface
+from app.service.login_handlers.default import DefaultLoginHandler
 from app.utility.base_service import BaseService
 
 
@@ -25,6 +22,7 @@ HEADER_API_KEY = 'KEY'
 COOKIE_SESSION = 'API_SESSION'
 CONFIG_API_KEY_RED = 'api_key_red'
 CONFIG_API_KEY_BLUE = 'api_key_blue'
+CONFIG_AUTH_LOGIN_HANDLER = 'auth.login.handler.module'
 
 
 def for_all_public_methods(decorator):
@@ -40,8 +38,7 @@ def for_all_public_methods(decorator):
 
 
 def check_authorization(func):
-    """
-    Authorization Decorator
+    """Authorization Decorator
     This requires that the calling class have `self.auth_svc` set to the authentication service.
     """
     async def process(func, *args, **params):
@@ -57,12 +54,12 @@ def check_authorization(func):
 
 class AuthService(AuthServiceInterface, BaseService):
     User = namedtuple('User', ['username', 'password', 'permissions'])
+    _default_login_handler = None
 
     def __init__(self):
         self.user_map = dict()
         self.log = self.add_service('auth_svc', self)
-        self._default_login_handler = self.DefaultLoginHandler(self.get_services())
-        self._login_handler = self._set_primary_login_handler()
+        self._login_handler = None
 
     @property
     def default_login_handler(self):
@@ -71,7 +68,7 @@ class AuthService(AuthServiceInterface, BaseService):
     async def apply(self, app, users):
         if users:
             for group, user in users.items():
-                self.log.debug('Created authentication group: %s' % group)
+                self.log.debug('Created authentication group: %s', group)
                 for username, password in user.items():
                     await self.create_user(username, password, group)
         app.user_map = self.user_map
@@ -91,25 +88,26 @@ class AuthService(AuthServiceInterface, BaseService):
         raise web.HTTPFound('/login')
 
     async def login_user(self, request):
-        """
-        Log a user in and save the session
+        """Log a user in and save the session
+
         :param request:
         :return: the response/location of where the user is trying to navigate
         """
         try:
-            self.log.debug('Using login handler "%s" for login' % self._login_handler.name)
+            self.log.debug('Using login handler "%s" for login', self._login_handler.name)
             await self._login_handler.handle_login(request)
-        except web.HTTPRedirection as http_redirect:
-            raise http_redirect
-        except web.HTTPUnauthorized as http_unauthorized:
-            raise http_unauthorized
+        except (web.HTTPRedirection, web.HTTPUnauthorized, web.HTTPForbidden, web.HTTPSuccessful) as allowed_exception:
+            raise allowed_exception
         except Exception as e:
-            self.log.error('Exception when handling login request: %s' % e)
+            self.log.exception('Exception when handling login request: %s', e)
 
-        # Fallback if not already using default login handler
-        if not isinstance(self._login_handler, self.DefaultLoginHandler):
-            self.log.debug('Falling back to default login handler')
-            return await self._default_login_handler.handle_login(request)
+            # Fallback if not already using default login handler
+            if not isinstance(self._login_handler, DefaultLoginHandler):
+                self.log.debug('Falling back to default login handler')
+                return await self._default_login_handler.handle_login(request)
+            else:
+                # We ran into an unexpected exception when using the default login handler.
+                raise e
 
     async def login_redirect(self, request, use_template=True):
         """Redirect user to login page using the configured login handler. If using the default login handler
@@ -117,19 +115,20 @@ class AuthService(AuthServiceInterface, BaseService):
         and the default login handler is configured, it will redirect to '/login' by raising HTTPFound exception."""
 
         try:
-            self.log.debug('Using login handler "%s" for login redirect' % self._login_handler.name)
+            self.log.debug('Using login handler "%s" for login redirect', self._login_handler.name)
             return await self._login_handler.handle_login_redirect(request, use_template=use_template)
-        except web.HTTPRedirection as http_redirect:
-            raise http_redirect
-        except web.HTTPUnauthorized as http_unauthorized:
-            raise http_unauthorized
+        except (web.HTTPRedirection, web.HTTPUnauthorized, web.HTTPForbidden, web.HTTPSuccessful) as allowed_exception:
+            raise allowed_exception
         except Exception as e:
-            self.log.error('Exception when handling login redirect: %s' % e)
+            self.log.exception('Exception when handling login redirect: %s', e)
 
-        # Fallback if not already using default login handler
-        if not isinstance(self._login_handler, self.DefaultLoginHandler):
-            self.log.debug('Falling back to default login handler')
-            return await self._default_login_handler.handle_login_redirect(request, use_template=use_template)
+            # Fallback if not already using default login handler
+            if not isinstance(self._login_handler, DefaultLoginHandler):
+                self.log.debug('Falling back to default login handler')
+                return await self._default_login_handler.handle_login_redirect(request, use_template=use_template)
+            else:
+                # We ran into an unexpected exception when using the default login handler.
+                raise e
 
     def request_has_valid_api_key(self, request):
         api_key = request.headers.get(HEADER_API_KEY)
@@ -146,7 +145,7 @@ class AuthService(AuthServiceInterface, BaseService):
         return await aiohttp_security_api.authorized_userid(request) is not None
 
     async def provide_verified_login_response(self, request, username):
-        self.log.debug('%s logging in:' % username)
+        self.log.debug('%s logging in:', username)
         response = web.HTTPFound('/')
         await remember(request, response, username)
         raise response
@@ -175,108 +174,29 @@ class AuthService(AuthServiceInterface, BaseService):
             return True
         return await self.request_has_valid_user_session(request)
 
-    """ PRIVATE """
-
-    def _set_primary_login_handler(self):
+    async def set_login_handlers(self, services):
+        """Sets the default login handler for the auth service, as well as the custom login handler if specified in the
+        config file. This login handler will take priority for login methods during login_user and redirects during
+        check_permissions. If no login handler was specified in the config file, the auth service will use the
+        default handler.
+        Will raise a TypeError exception if the provided login handler does not implement the LoginHandlerInterface.
         """
-        Returns the login handler for the auth service as specified in the config file.
-        This login handler will take priority for login methods during login_user and redirects during
-        check_permissions. If no login handler was specified in the config file, the default handler will be returned.
-        """
-        login_handler_module_path = self.get_config('auth.login.handler.module')
+        self._configure_default_login_handler(services)
+        login_handler_module_path = self.get_config(CONFIG_AUTH_LOGIN_HANDLER)
         if login_handler_module_path and login_handler_module_path != 'default':
-            try:
-                login_handler = import_module(login_handler_module_path).load_login_handler(self.get_services())
-                if isinstance(login_handler, LoginHandlerInterface):
-                    self.log.info('Setting primary login handler: %s' % login_handler_module_path)
-                    return login_handler
-                else:
-                    self.log.warn('Attempted to set login handler that does not implement LoginHandlerInterface.')
-            except Exception as e:
-                self.log.error('Invalid login handler module: %s' % e)
-
-        self.log.info('Using default login handler.')
-        return self._default_login_handler
-
-    class DefaultLoginHandler(LoginHandlerInterface):
-        def __init__(self, services):
-            self.log = logging.getLogger('default_login_handler')
-            self.auth_svc = services.get('auth_svc')
-            self._ldap_config = self.get_config('ldap')
-            self._name = 'Default Login Handler'
-
-        @property
-        def name(self):
-            return self._name
-
-        """ LoginHandlerInterface implementation """
-
-        async def handle_login(self, request, **kwargs):
-            self.log.debug('Handling default login')
-            data = await request.post()
-            username = data.get('username')
-            password = data.get('password')
-            if username and password:
-                if self._ldap_config:
-                    verified = await self._ldap_login(username, password)
-                else:
-                    verified = await self._check_credentials(request.app.user_map, username, password)
-
-                if verified:
-                    await self.auth_svc.provide_verified_login_response(request, username)
-                self.log.debug('%s failed login attempt: ' % username)
-            raise web.HTTPFound('/login')
-
-        async def handle_login_redirect(self, request, **kwargs):
-            self.log.debug('Handling default login redirect')
-            if kwargs.get('use_template'):
-                return render_template('login.html', request, dict())
+            login_handler = import_module(login_handler_module_path).load_login_handler(services)
+            if isinstance(login_handler, LoginHandlerInterface):
+                self.log.info('Setting primary login handler: %s', login_handler_module_path)
+                self._login_handler = login_handler
             else:
-                raise web.HTTPFound('/login')
+                raise TypeError('Attempted to set login handler that does not implement LoginHandlerInterface.')
+        else:
+            self.log.info('Using default login handler.')
+            self._login_handler = self._default_login_handler
 
-        """ PRIVATE """
-
-        @staticmethod
-        async def _check_credentials(user_map, username, password):
-            user = user_map.get(username)
-            if not user:
-                return False
-            return user.password == password
-
-        async def _ldap_login(self, username, password):
-            server = ldap3.Server(self._ldap_config.get('server'))
-            dn = self._ldap_config.get('dn')
-            user_attr = self._ldap_config.get('user_attr') or 'uid'
-            user_string = '%s=%s,%s' % (user_attr, username, dn)
-
-            try:
-                with ldap3.Connection(server, user=user_string, password=password) as conn:
-                    if conn.bind():
-                        if username not in self.user_map:
-                            group = await self._ldap_get_group(conn, dn, username, user_attr)
-                            await self.create_user(username, None, group)
-                        return True
-            except LDAPException:
-                self.log.error('Unable to connect to LDAP server')
-
-            return False
-
-        async def _ldap_get_group(self, connection, dn, username, user_attr):
-            group_attr = self._ldap_config.get('group_attr') or 'objectClass'
-            red_group_name = self._ldap_config.get('red_group') or 'red'
-
-            try:
-                connection.search(dn, '(%s=%s)' % (user_attr, username), attributes=[group_attr])
-            except LDAPAttributeError:
-                self.log.error('Invalid group_attr in config: %s' % group_attr)
-                return 'blue'
-
-            groups_result = connection.entries[0][group_attr].value
-            if ((isinstance(groups_result, list) and red_group_name in groups_result)
-                    or red_group_name == groups_result):
-                return 'red'
-            else:
-                return 'blue'
+    @classmethod
+    def _configure_default_login_handler(cls, services):
+        cls._default_login_handler = DefaultLoginHandler(services)
 
 
 class DictionaryAuthorizationPolicy(AbstractAuthorizationPolicy):

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -1,0 +1,28 @@
+import abc
+from app.utility.base_object import BaseObject
+
+
+class LoginHandlerInterface(abc.ABC, BaseObject):
+    _name = 'Login Handler Interface'
+
+    @abc.abstractmethod
+    async def handle_login(self, request, **kwargs):
+        """
+        Handle login request
+        :param request:
+        :return: the response/location of where the user is trying to navigate
+        """
+        pass
+
+    @abc.abstractmethod
+    async def handle_login_redirect(self, request, **kwargs):
+        """
+        Handle redirect to login
+        :param request:
+        :return: the response/location of where the user is trying to navigate
+        """
+        pass
+
+    @property
+    def name(self):
+        return self._name

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -13,6 +13,7 @@ class LoginHandlerInterface(abc.ABC, BaseObject):
 
         :param request:
         :return: the response/location of where the user is trying to navigate
+        :raises: HTTP exception, such as HTTPFound for redirect, or HTTPUnauthorized
         """
         pass
 
@@ -22,6 +23,7 @@ class LoginHandlerInterface(abc.ABC, BaseObject):
 
         :param request:
         :return: the response/location of where the user is trying to navigate
+        :raises: HTTP exception, such as HTTPFound for redirect, or HTTPUnauthorized
         """
         pass
 

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -1,4 +1,5 @@
 import abc
+
 from app.utility.base_object import BaseObject
 
 

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -4,7 +4,8 @@ from app.utility.base_object import BaseObject
 
 
 class LoginHandlerInterface(abc.ABC, BaseObject):
-    def __init__(self, name):
+    def __init__(self, services, name):
+        self.services = services
         self._name = name
 
     @abc.abstractmethod

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -3,12 +3,13 @@ from app.utility.base_object import BaseObject
 
 
 class LoginHandlerInterface(abc.ABC, BaseObject):
-    _name = 'Login Handler Interface'
+    def __init__(self, name):
+        self._name = name
 
     @abc.abstractmethod
     async def handle_login(self, request, **kwargs):
-        """
-        Handle login request
+        """Handle login request
+
         :param request:
         :return: the response/location of where the user is trying to navigate
         """
@@ -16,8 +17,8 @@ class LoginHandlerInterface(abc.ABC, BaseObject):
 
     @abc.abstractmethod
     async def handle_login_redirect(self, request, **kwargs):
-        """
-        Handle redirect to login
+        """Handle redirect to login
+
         :param request:
         :return: the response/location of where the user is trying to navigate
         """

--- a/app/service/login_handlers/default.py
+++ b/app/service/login_handlers/default.py
@@ -1,0 +1,81 @@
+import logging
+import ldap3
+
+from aiohttp import web
+from aiohttp_jinja2 import render_template
+from ldap3.core.exceptions import LDAPAttributeError, LDAPException
+
+from app.service.interfaces.i_login_handler import LoginHandlerInterface
+
+HANDLER_NAME = 'Default Login Handler'
+
+
+class DefaultLoginHandler(LoginHandlerInterface):
+    def __init__(self, services):
+        super().__init__(HANDLER_NAME)
+        self.log = logging.getLogger('default_login_handler')
+        self.auth_svc = services.get('auth_svc')
+        self._ldap_config = self.get_config('ldap')
+
+    async def handle_login(self, request, **kwargs):
+        data = await request.post()
+        username = data.get('username')
+        password = data.get('password')
+        if username and password:
+            if self._ldap_config:
+                verified = await self._ldap_login(username, password)
+            else:
+                verified = await self._check_credentials(request.app.user_map, username, password)
+
+            if verified:
+                await self.auth_svc.provide_verified_login_response(request, username)
+            self.log.debug('%s failed login attempt: ', username)
+        raise web.HTTPFound('/login')
+
+    async def handle_login_redirect(self, request, **kwargs):
+        if kwargs.get('use_template'):
+            return render_template('login.html', request, dict())
+        else:
+            raise web.HTTPFound('/login')
+
+    @staticmethod
+    async def _check_credentials(user_map, username, password):
+        user = user_map.get(username)
+        if not user:
+            return False
+        return user.password == password
+
+    async def _ldap_login(self, username, password):
+        server = ldap3.Server(self._ldap_config.get('server'))
+        dn = self._ldap_config.get('dn')
+        user_attr = self._ldap_config.get('user_attr') or 'uid'
+        user_string = '%s=%s,%s' % (user_attr, username, dn)
+
+        try:
+            with ldap3.Connection(server, user=user_string, password=password) as conn:
+                if conn.bind():
+                    if username not in self.user_map:
+                        group = await self._ldap_get_group(conn, dn, username, user_attr)
+                        await self.create_user(username, None, group)
+                    return True
+        except LDAPException:
+            self.log.error('Unable to connect to LDAP server')
+
+        return False
+
+    async def _ldap_get_group(self, connection, dn, username, user_attr):
+        group_attr = self._ldap_config.get('group_attr') or 'objectClass'
+        red_group_name = self._ldap_config.get('red_group') or 'red'
+
+        try:
+            connection.search(dn, '(%s=%s)' % (user_attr, username), attributes=[group_attr])
+        except LDAPAttributeError:
+            self.log.error('Invalid group_attr in config: %s', group_attr)
+            return 'blue'
+
+        groups_result = connection.entries[0][group_attr].value
+        if ((isinstance(groups_result, list) and red_group_name in groups_result)
+                or red_group_name == groups_result):
+            return 'red'
+        else:
+            return 'blue'

--- a/app/service/login_handlers/default.py
+++ b/app/service/login_handlers/default.py
@@ -12,9 +12,8 @@ HANDLER_NAME = 'Default Login Handler'
 
 class DefaultLoginHandler(LoginHandlerInterface):
     def __init__(self, services):
-        super().__init__(HANDLER_NAME)
+        super().__init__(services, HANDLER_NAME)
         self.log = logging.getLogger('default_login_handler')
-        self.services = services
         self._ldap_config = self.get_config('ldap')
 
     async def handle_login(self, request, **kwargs):
@@ -28,7 +27,10 @@ class DefaultLoginHandler(LoginHandlerInterface):
                 verified = await self._check_credentials(request.app.user_map, username, password)
 
             if verified:
-                await self.services.get('auth_svc').handle_successful_login(request, username)
+                auth_svc = self.services.get('auth_svc')
+                if not auth_svc:
+                    raise Exception('Auth service not available.')
+                await auth_svc.handle_successful_login(request, username)
             self.log.debug('%s failed login attempt: ', username)
         raise web.HTTPFound('/login')
 

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -27,6 +27,7 @@ plugins:
 - training
 port: 8888
 reports_dir: /tmp
+auth.login.handler.module: default
 requirements:
   go:
     command: go version

--- a/server.py
+++ b/server.py
@@ -51,6 +51,7 @@ def run_tasks(services):
     loop.run_until_complete(app_svc.load_plugins(args.plugins))
     loop.run_until_complete(data_svc.load_data(loop.run_until_complete(data_svc.locate('plugins', dict(enabled=True)))))
     loop.run_until_complete(app_svc.load_plugin_expansions(loop.run_until_complete(data_svc.locate('plugins', dict(enabled=True)))))
+    loop.run_until_complete(auth_svc.set_login_handlers(services))
     loop.create_task(app_svc.start_sniffer_untrusted_agents())
     loop.create_task(app_svc.resume_operations())
     loop.create_task(app_svc.run_scheduler())

--- a/tests/api/v2/test_security.py
+++ b/tests/api/v2/test_security.py
@@ -56,6 +56,7 @@ def simple_webapp(loop, base_world):
             users=base_world.get_config('users')
         )
     )
+    loop.run_until_complete(auth_svc.set_login_handlers(auth_svc.get_services()))
 
     # The authentication_required middleware needs to run after the session middleware.
     # AuthService.apply(...) adds session middleware to the app, so we can append the

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -45,6 +45,7 @@ def aiohttp_client(loop, aiohttp_client):
         await app_svc.load_plugins(['sandcat', 'ssl'])
         _ = await RestApi(services).enable()
         await auth_svc.apply(app_svc.application, auth_svc.get_config('users'))
+        await auth_svc.set_login_handlers(services)
         return app_svc.application
 
     app = loop.run_until_complete(initialize())
@@ -185,7 +186,7 @@ async def test_custom_accepting_login_handler(aiohttp_client):
             # Always accept login
             data = await request.post()
             username = data.get('username', 'default username')
-            await self.auth_svc.provide_verified_login_response(request, username)
+            await self.auth_svc.handle_successful_login(request, username)
 
         async def handle_login_redirect(self, request, **kwargs):
             await self.handle_login(request, **kwargs)

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -16,6 +16,7 @@ from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
 from app.service.rest_svc import RestService
+from app.service.interfaces.i_login_handler import LoginHandlerInterface
 from app.utility.base_service import BaseService
 from app.utility.base_world import BaseWorld
 
@@ -140,3 +141,29 @@ async def test_command_overwrite_failure(aiohttp_client, authorized_cookies):
     assert resp.status == HTTPStatus.OK
     config_dict = await resp.json()
     assert config_dict.get('requirements', dict()).get('go', dict()).get('command') == 'go version'
+
+async def test_custom_login_handler(aiohttp_client):
+    class RejectAllLoginHandler(LoginHandlerInterface):
+        def __init__(self, services):
+            self.auth_svc = services.get('auth_svc')
+            self._name = 'Reject All Logins'
+
+        """ LoginHandlerInterface implementation """
+
+        async def handle_login(self, request, **kwargs):
+            # Always reject login and return 401
+            raise web.HTTPUnauthorized(text='Automatic rejection')
+
+        async def handle_login_redirect(self, request, **kwargs):
+            # Always reject and return 401
+            print('Handling redirect')
+            raise web.HTTPUnauthorized(text='Automatic rejection')
+
+    BaseService.get_service('auth_svc')._login_handler = RejectAllLoginHandler(BaseService.get_services())
+    resp = await aiohttp_client.post('/enter', allow_redirects=False, data=dict(username='admin', password='admin'))
+    assert resp.status == 401
+    assert await resp.text() == 'Automatic rejection'
+
+    resp = await aiohttp_client.get('/', allow_redirects=False)
+    assert resp.status == 401
+    assert await resp.text() == 'Automatic rejection'

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -157,10 +157,15 @@ async def test_custom_rejecting_login_handler(aiohttp_client):
             # Always reject and return 401
             raise web.HTTPUnauthorized(text='Automatic rejection')
 
-    BaseService.get_service('auth_svc')._login_handler = RejectAllLoginHandler(
+    login_handler = RejectAllLoginHandler(
         BaseService.get_services(),
         'Reject All Login Handler',
     )
+    await BaseService.get_service('auth_svc').set_login_handlers(
+        BaseService.get_services(),
+        login_handler
+    )
+
     resp = await aiohttp_client.post('/enter', allow_redirects=False, data=dict(username='admin', password='admin'))
     assert resp.status == HTTPStatus.UNAUTHORIZED
     assert await resp.text() == 'Automatic rejection'
@@ -185,9 +190,13 @@ async def test_custom_accepting_login_handler(aiohttp_client):
         async def handle_login_redirect(self, request, **kwargs):
             await self.handle_login(request, **kwargs)
 
-    BaseService.get_service('auth_svc')._login_handler = AcceptAllLoginHandler(
+    login_handler = AcceptAllLoginHandler(
         BaseService.get_services(),
         'Accept All Login Handler',
+    )
+    await BaseService.get_service('auth_svc').set_login_handlers(
+        BaseService.get_services(),
+        login_handler
     )
     resp = await aiohttp_client.post('/enter', allow_redirects=False, data=dict(username='invalid', password='invalid'))
     assert resp.status == HTTPStatus.FOUND


### PR DESCRIPTION
## Description
Restructuring the way the auth service handles logins to allow users to provide custom login handlers. A new interface is available under `app/service/interfaces/i_login_handler.py` called `LoginHandlerInterface`. Classes extending this interface need to implement the `handle_login` and `handle_login_redirect` methods, which handle authentication requests and redirecting unauthorized requests to the login page. When creating the auth service, a default login handler is created and set - this default login handler will handle logins as before by checking if the provided credentials are valid or not. If the caldera config file specifies a python import path under `auth.login.handler.module` entry, the auth service will load the login handler provided by that module and use that as the primary login handler. This allows users to specify custom login handlers in separate plugins (e.g. SAML). If the custom login handler fails to function properly, then the default login handler will take over.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Created tests using two custom login handlers - one rejects all logins, and the other accepts all logins. Made sure that the HTTP responses were generated accordingly.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
