### PR TITLE
[VIRTS-1944] Authenticated health endpoint

### DIFF
--- a/app/api/v2/handlers/health_api.py
+++ b/app/api/v2/handlers/health_api.py
@@ -16,11 +16,11 @@ class HealthApi(BaseApi):
 
     def add_routes(self, app: web.Application):
         router = app.router
-        router.add_get('/health', self.get_health_info)
+        router.add_get('/health', security.authentication_exempt(self.get_health_info))
+        router.add_get('/health-authenticated', self.get_health_info)
 
     @aiohttp_apispec.docs(tags=["health"])
     @aiohttp_apispec.response_schema(CalderaInfoSchema, 200)
-    @security.authentication_exempt
     async def get_health_info(self, request):
         loaded_plugins_sorted = sorted(self._app_svc.get_loaded_plugins(), key=operator.attrgetter('name'))
 

--- a/app/api/v2/security.py
+++ b/app/api/v2/security.py
@@ -1,3 +1,7 @@
+import inspect
+import functools
+import types
+
 from aiohttp import web
 
 
@@ -14,6 +18,20 @@ def is_handler_authentication_exempt(handler):
     return is_unauthenticated
 
 
+def _wrap_async_method(method: types.MethodType):
+    """Wrap the input bound async method in an async function."""
+    async def wrapper(*args, **kwargs):
+        return await method(*args, **kwargs)
+    return functools.wraps(method)(wrapper)
+
+
+def _wrap_method(method: types.MethodType):
+    """Wrap the input bound method in an async function."""
+    def wrapper(*args, **kwargs):
+        return method(*args, **kwargs)
+    return functools.wraps(method)(wrapper)
+
+
 def authentication_exempt(handler):
     """Mark the endpoint handler as not requiring authentication.
 
@@ -21,6 +39,14 @@ def authentication_exempt(handler):
         This only applies when the authentication_required_middleware is
         being used.
     """
+    # Can't set attributes directly on a bound method so we need to
+    # wrap it in a function that we can mark it as unauthenticated
+    if inspect.ismethod(handler):
+        if inspect.iscoroutinefunction(handler):
+            handler = _wrap_async_method(handler)
+        else:
+            handler = _wrap_method(handler)
+
     set_handler_authentication_exempt(handler)
     return handler
 

--- a/app/api/v2/security.py
+++ b/app/api/v2/security.py
@@ -5,10 +5,6 @@ import types
 from aiohttp import web
 
 
-def set_handler_authentication_exempt(handler):
-    handler.__caldera_unauthenticated__ = True
-
-
 def is_handler_authentication_exempt(handler):
     """Return True if the endpoint handler is authentication exempt."""
     try:
@@ -47,7 +43,7 @@ def authentication_exempt(handler):
         else:
             handler = _wrap_method(handler)
 
-    set_handler_authentication_exempt(handler)
+    handler.__caldera_unauthenticated__ = True
     return handler
 
 

--- a/tests/api/v2/test_security.py
+++ b/tests/api/v2/test_security.py
@@ -66,6 +66,46 @@ def simple_webapp(loop, base_world):
     return app
 
 
+@pytest.fixture
+def class_based_webapp(loop, base_world):
+    async def index(request):
+        return web.Response(status=200, text='hello!')
+
+    @security.authentication_exempt
+    async def public(request):
+        return web.Response(status=200, text='public')
+
+    async def private(request):
+        return web.Response(status=200, text='private')
+
+    @security.authentication_exempt
+    async def login(request):
+        await auth_svc.login_user(request)  # Note: auth_svc defined in context function
+
+    app = web.Application()
+    app.router.add_get('/', index)
+    app.router.add_post('/login', login)
+    app.router.add_get('/public', public)
+    app.router.add_get('/private', private)
+
+    auth_svc = AuthService()
+
+    loop.run_until_complete(
+        auth_svc.apply(
+            app=app,
+            users=base_world.get_config('users')
+        )
+    )
+
+    # The authentication_required middleware needs to run after the session middleware.
+    # AuthService.apply(...) adds session middleware to the app, so we can append the
+    # the auth middleware after. Not doing this will cause a 500 in regards to the
+    # session middleware not being set up correctly.
+    app.middlewares.append(security.authentication_required_middleware_factory(auth_svc))
+
+    return app
+
+
 def test_set_handler_authentication_exempt():
     def fake_handler(request):
         return None
@@ -73,6 +113,16 @@ def test_set_handler_authentication_exempt():
     assert security.is_handler_authentication_exempt(fake_handler) is False
     security.set_handler_authentication_exempt(fake_handler)
     assert security.is_handler_authentication_exempt(fake_handler) is True
+
+
+def test_bound_method_is_authentication_exempt():
+    class Api:
+        def handler(self, request):
+            return None
+
+    api = Api()
+    assert security.is_handler_authentication_exempt(api.handler) is False
+    assert security.is_handler_authentication_exempt(security.authentication_exempt(api.handler)) is True
 
 
 async def test_authentication_required_middleware_authenticated_endpoint_returns_401(simple_webapp, aiohttp_client):
@@ -114,3 +164,25 @@ async def test_authentication_required_middleware_authenticated_endpoint_accepts
     # Internally the test client keeps track of the session and will forward any relavent cookies.
     index_response = await client.get('/private')
     assert index_response.status == 200
+
+
+async def test_authentication_exempt_bound_method_returns_200(base_world, aiohttp_client):
+    class Api:
+        async def public(self, request):
+            return web.Response(status=200, text='hello!')
+
+    api = Api()
+    app = web.Application()
+    app.router.add_get('/public', security.authentication_exempt(api.public))
+
+    auth_svc = AuthService()
+    await auth_svc.apply(
+        app=app,
+        users=base_world.get_config('users')
+    )
+
+    app.middlewares.append(security.authentication_required_middleware_factory(auth_svc))
+
+    client = await aiohttp_client(app)
+    resp = await client.get('/public')
+    assert resp.status == 200


### PR DESCRIPTION
## Description
Added a health endpoint that can only be accessed via an authenticated request (session auth or api key auth).

Endpoint added:
* `GET /api/v2/health-authenticated`

This also necessitated changes to the way in which handlers are marked as authentication exempt so that I could mark a bound method as auth exempt as I registered the same method under two paths and applied different authentication rules to them.

## Why
A means to perform easy authentication testing and verification via the healthcheck endpoint.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
* Verified that `/api/v2/health` returns data in response to an  unauthenticated request
* Verified that `/api/v2/health-authenticated` returns a 401 if not authenticated
* Verified that `/api/v2/health-authenticated` returns 200 w/ data in browser with active session
* Verified that `/api/v2/health-authenticated` returns a 200 w/ data via `curl` when passing a valid api key header
* Verified that `/api/v2/health-authenticated` returns a 401 w/ data via `curl` when passing an invalid API key header
* Verified swagger docs load for both health endpoints

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
