### PR TITLE
[VIRTS-2100] Fire events when operation changes state

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -46,9 +46,9 @@ class OperationSchema(ma.Schema):
 
 
 class Operation(FirstClassObjectInterface, BaseObject):
-    EVENT_EXCHANGE = "operation"
-    EVENT_QUEUE_STATE_CHANGED = "state_changed"
-    EVENT_QUEUE_COMPLETED = "completed"
+    EVENT_EXCHANGE = 'operation'
+    EVENT_QUEUE_STATE_CHANGED = 'state_changed'
+    EVENT_QUEUE_COMPLETED = 'completed'
 
     schema = OperationSchema()
 
@@ -71,7 +71,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     @state.setter
     def state(self, value):
-        previous_state = getattr(self, "_state", NO_PREVIOUS_STATE)
+        previous_state = getattr(self, '_state', NO_PREVIOUS_STATE)
 
         self._state = value
 

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -17,6 +17,10 @@ from app.objects.c_planner import PlannerSchema
 from app.objects.c_objective import ObjectiveSchema
 from app.objects.interfaces.i_object import FirstClassObjectInterface
 from app.utility.base_object import BaseObject
+from app.utility.base_service import BaseService
+
+
+NO_PREVIOUS_STATE = object()
 
 
 class OperationSchema(ma.Schema):
@@ -42,6 +46,9 @@ class OperationSchema(ma.Schema):
 
 
 class Operation(FirstClassObjectInterface, BaseObject):
+    EVENT_EXCHANGE = "operation"
+    EVENT_QUEUE_STATE_CHANGED = "state_changed"
+    EVENT_QUEUE_COMPLETED = "completed"
 
     schema = OperationSchema()
 
@@ -57,6 +64,27 @@ class Operation(FirstClassObjectInterface, BaseObject):
                     OUT_OF_TIME='out_of_time',
                     FINISHED='finished',
                     CLEANUP='cleanup')
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value):
+        previous_state = getattr(self, "_state", NO_PREVIOUS_STATE)
+
+        self._state = value
+
+        if previous_state is NO_PREVIOUS_STATE:
+            return
+
+        if previous_state == value:
+            return
+
+        self._emit_state_change_event(
+            from_state=previous_state,
+            to_state=value
+        )
 
     def __init__(self, name, agents, adversary, id='', jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True, visibility=50, access=None,
@@ -85,14 +113,6 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.use_learning_parsers = use_learning_parsers
         if source:
             self.rules = source.rules
-
-    @property
-    def state(self):
-        return self._state
-
-    @state.setter
-    def state(self, value):
-        self._state = value
 
     def store(self, ram):
         existing = self.retrieve(ram['operations'], self.unique)
@@ -144,7 +164,12 @@ class Operation(FirstClassObjectInterface, BaseObject):
     async def close(self, services):
         await self._cleanup_operation(services)
         await self._save_new_source(services)
-        await services.get('event_svc').fire_event(exchange='operation', queue='completed', op=self.id)
+        await services.get('event_svc').fire_event(
+            exchange=Operation.EVENT_EXCHANGE,
+            queue=Operation.EVENT_QUEUE_COMPLETED,
+            op=self.id
+        )
+
         if self.state not in [self.states['FINISHED'], self.states['OUT_OF_TIME']]:
             self.state = self.states['FINISHED']
         self.finish = self.get_current_timestamp()
@@ -389,6 +414,21 @@ class Operation(FirstClassObjectInterface, BaseObject):
         return dict(operation_name=self.name,
                     operation_start=self.start.strftime('%Y-%m-%d %H:%M:%S'),
                     operation_adversary=self.adversary.name)
+
+    def _emit_state_change_event(self, from_state, to_state):
+        event_svc = BaseService.get_service('event_svc')
+
+        task = asyncio.get_event_loop().create_task(
+            event_svc.fire_event(
+                exchange=Operation.EVENT_EXCHANGE,
+                queue=Operation.EVENT_QUEUE_STATE_CHANGED,
+                op=self.id,
+                from_state=from_state,
+                to_state=to_state
+            )
+        )
+
+        return task
 
     @staticmethod
     def _get_ability_metadata_for_event_log(ability):

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -86,6 +86,14 @@ class Operation(FirstClassObjectInterface, BaseObject):
         if source:
             self.rules = source.rules
 
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value):
+        self._state = value
+
     def store(self, ram):
         existing = self.retrieve(ram['operations'], self.unique)
         if not existing:

--- a/app/utility/base_service.py
+++ b/app/utility/base_service.py
@@ -10,6 +10,10 @@ class BaseService(BaseWorld):
         return self.create_logger(name)
 
     @classmethod
+    def remove_service(cls, name):
+        del cls._services[name]
+
+    @classmethod
     def get_service(cls, name):
         return cls._services.get(name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from app.utility.base_world import BaseWorld
 from app.service.app_svc import AppService
 from app.service.data_svc import DataService
 from app.service.contact_svc import ContactService
+from app.service.event_svc import EventService
 from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
@@ -54,6 +55,11 @@ def file_svc():
 @pytest.fixture(scope='class')
 def contact_svc():
     return ContactService()
+
+
+@pytest.fixture(scope='class')
+def event_svc(contact_svc, init_base_world):
+    return EventService()
 
 
 @pytest.fixture(scope='class')

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -290,30 +290,32 @@ class TestOperation:
             os.remove(target_path)
 
     @mock.patch.object(Operation, '_emit_state_change_event')
-    async def test_no_state_change_event_on_instantiation(self, mock_emit_state_change_method, fake_event_svc, adversary):
+    def test_no_state_change_event_on_instantiation(self, mock_emit_state_change_method, fake_event_svc, adversary):
         Operation(name='test', agents=[], adversary=adversary)
         mock_emit_state_change_method.assert_not_called()
 
     @mock.patch.object(Operation, '_emit_state_change_event')
-    async def test_no_state_change_event_fired_when_setting_same_state(self, mock_emit_state_change_method, loop, fake_event_svc, adversary):
+    def test_no_state_change_event_fired_when_setting_same_state(self, mock_emit_state_change_method, fake_event_svc, adversary):
         initial_state = 'running'
         op = Operation(name='test', agents=[], adversary=adversary, state=initial_state)
         op.state = initial_state
         mock_emit_state_change_method.assert_not_called()
 
     @mock.patch.object(Operation, '_emit_state_change_event')
-    async def test_state_change_event_fired_on_state_change(self, mock_emit_state_change_method, loop, fake_event_svc, adversary):
+    def test_state_change_event_fired_on_state_change(self, mock_emit_state_change_method, fake_event_svc, adversary):
         op = Operation(name='test', agents=[], adversary=adversary, state='running')
         op.state = 'finished'
         mock_emit_state_change_method.assert_called_with(from_state='running', to_state='finished')
 
-    async def test_emit_state_change_event(self, loop, fake_event_svc, adversary):
+    def test_emit_state_change_event(self, loop, fake_event_svc, adversary):
         op = Operation(name='test', agents=[], adversary=adversary, state='running')
         fake_event_svc.reset()
 
-        await op._emit_state_change_event(
-            from_state='running',
-            to_state='finished'
+        loop.run_until_complete(
+            op._emit_state_change_event(
+                from_state='running',
+                to_state='finished'
+            )
         )
 
         expected_key = (Operation.EVENT_EXCHANGE, Operation.EVENT_QUEUE_STATE_CHANGED)

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -1,14 +1,17 @@
 import base64
 import json
 import os
-import pytest
-
 from base64 import b64encode
 from datetime import datetime
+from unittest import mock
 from unittest.mock import MagicMock
+
+import pytest
 
 from app.objects.c_operation import Operation
 from app.objects.secondclass.c_link import Link
+from app.service.interfaces.i_event_svc import EventServiceInterface
+from app.utility.base_service import BaseService
 from app.objects.secondclass.c_result import Result
 
 
@@ -74,6 +77,29 @@ def op_for_event_logs(operation_agent, operation_adversary, ability, operation_l
                                     decide=datetime.strptime('2021-01-01 10:00:00', '%Y-%m-%d %H:%M:%S'))
     op.chain = [link_1, link_2, discarded_link]
     return op
+
+
+@pytest.fixture
+def fake_event_svc(loop):
+    class FakeEventService(BaseService, EventServiceInterface):
+        def __init__(self):
+            self.fired = {}
+
+        def reset(self):
+            self.fired = {}
+
+        async def observe_event(self, callback, exchange=None, queue=None):
+            pass
+
+        async def fire_event(self, exchange=None, queue=None, timestamp=True, **callback_kwargs):
+            self.fired[exchange, queue] = callback_kwargs
+
+    service = FakeEventService()
+    service.add_service('event_svc', service)
+
+    yield service
+
+    BaseService.remove_service('event_svc')
 
 
 @pytest.fixture
@@ -262,6 +288,41 @@ class TestOperation:
             assert recorded_log == want
         finally:
             os.remove(target_path)
+
+    @mock.patch.object(Operation, '_emit_state_change_event')
+    async def test_no_state_change_event_on_instantiation(self, mock_emit_state_change_method, fake_event_svc, adversary):
+        Operation(name='test', agents=[], adversary=adversary)
+        mock_emit_state_change_method.assert_not_called()
+
+    @mock.patch.object(Operation, '_emit_state_change_event')
+    async def test_no_state_change_event_fired_when_setting_same_state(self, mock_emit_state_change_method, loop, fake_event_svc, adversary):
+        initial_state = 'running'
+        op = Operation(name='test', agents=[], adversary=adversary, state=initial_state)
+        op.state = initial_state
+        mock_emit_state_change_method.assert_not_called()
+
+    @mock.patch.object(Operation, '_emit_state_change_event')
+    async def test_state_change_event_fired_on_state_change(self, mock_emit_state_change_method, loop, fake_event_svc, adversary):
+        op = Operation(name='test', agents=[], adversary=adversary, state='running')
+        op.state = 'finished'
+        mock_emit_state_change_method.assert_called_with(from_state='running', to_state='finished')
+
+    async def test_emit_state_change_event(self, loop, fake_event_svc, adversary):
+        op = Operation(name='test', agents=[], adversary=adversary, state='running')
+        fake_event_svc.reset()
+
+        await op._emit_state_change_event(
+            from_state='running',
+            to_state='finished'
+        )
+
+        expected_key = (Operation.EVENT_EXCHANGE, Operation.EVENT_QUEUE_STATE_CHANGED)
+        assert expected_key in fake_event_svc.fired
+
+        event_kwargs = fake_event_svc.fired[expected_key]
+        assert event_kwargs['op'] == op.id
+        assert event_kwargs['from_state'] == 'running'
+        assert event_kwargs['to_state'] == 'finished'
 
     def test_with_learning_parser(self, loop, contact_svc, data_svc, learning_svc, op_with_learning_parser, make_test_link, make_test_result):
         test_link = make_test_link(1234)

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -57,7 +57,7 @@ def planner_stub(**kwargs):
 
 
 @pytest.fixture
-def setup_planning_test(loop, ability, agent, operation, data_svc, init_base_world):
+def setup_planning_test(loop, ability, agent, operation, data_svc, event_svc, init_base_world):
     tability = ability(ability_id='123', executor='sh', platform='darwin', test=BaseWorld.encode_string('mkdir test'),
                        cleanup=BaseWorld.encode_string('rm -rf test'), variations=[], repeatable=True, buckets=['test'])
     tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin')


### PR DESCRIPTION
## Description
Update `Operation` to fire an event whenever its state is changed.

Notes:
* Does not fire an event when setting the initial state
* Does not fire an event if setting the state to its current state

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
* All tests pass
* I added tests to ensure the event service was being invoked as expected


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
