### PR TITLE
[VIRTS-2099] Fire event when link status changes

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -73,7 +73,7 @@ class Link(BaseObject):
     RESERVED = dict(origin_link_id='#{origin_link_id}')
 
     EVENT_EXCHANGE = 'link'
-    EVENT_QUEUE_STATUS_CHANGE = 'status_change'
+    EVENT_QUEUE_STATUS_CHANGED = 'status_changed'
 
     @property
     def unique(self):
@@ -183,7 +183,7 @@ class Link(BaseObject):
         task = asyncio.get_event_loop().create_task(
             event_svc.fire_event(
                 exchange=Link.EVENT_EXCHANGE,
-                queue=Link.EVENT_QUEUE_STATUS_CHANGE,
+                queue=Link.EVENT_QUEUE_STATUS_CHANGED,
                 link=self.id,
                 from_status=from_status,
                 to_status=to_status

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from base64 import b64decode
@@ -11,6 +12,10 @@ from app.objects.secondclass.c_fact import Fact, FactSchema
 from app.objects.secondclass.c_relationship import RelationshipSchema
 from app.objects.secondclass.c_visibility import Visibility, VisibilitySchema
 from app.utility.base_object import BaseObject
+from app.utility.base_service import BaseService
+
+
+NO_STATUS_SET = object()
 
 
 class LinkSchema(ma.Schema):
@@ -67,6 +72,9 @@ class Link(BaseObject):
 
     RESERVED = dict(origin_link_id='#{origin_link_id}')
 
+    EVENT_EXCHANGE = 'link'
+    EVENT_QUEUE_STATUS_CHANGE = 'status_change'
+
     @property
     def unique(self):
         return self.hash('%s' % self.id)
@@ -89,6 +97,27 @@ class Link(BaseObject):
                     SUCCESS=0,
                     ERROR=1,
                     TIMEOUT=124)
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, value):
+        previous_status = getattr(self, '_status', NO_STATUS_SET)
+
+        self._status = value
+
+        if previous_status is NO_STATUS_SET:
+            return
+
+        if previous_status == value:
+            return
+
+        self._emit_status_change_event(
+            from_status=previous_status,
+            to_status=value
+        )
 
     def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id='', pin=0,
                  host=None, deadman=False, used=None, relationships=None):
@@ -147,6 +176,21 @@ class Link(BaseObject):
         self.command = self.encode_string(decoded_cmd.replace(self.RESERVED['origin_link_id'], self.id))
 
     """ PRIVATE """
+
+    def _emit_status_change_event(self, from_status, to_status):
+        event_svc = BaseService.get_service('event_svc')
+
+        task = asyncio.get_event_loop().create_task(
+            event_svc.fire_event(
+                exchange=Link.EVENT_EXCHANGE,
+                queue=Link.EVENT_QUEUE_STATUS_CHANGE,
+                link=self.id,
+                from_status=from_status,
+                to_status=to_status
+            )
+        )
+
+        return task
 
     async def _parse_link_result(self, result, parser, source_facts):
         blob = b64decode(result).decode('utf-8')

--- a/tests/objects/test_link.py
+++ b/tests/objects/test_link.py
@@ -28,6 +28,8 @@ def fake_event_svc(loop):
 
     yield service
 
+    service.remove_service('event_svc')
+
 
 class TestLink:
 

--- a/tests/objects/test_link.py
+++ b/tests/objects/test_link.py
@@ -1,5 +1,32 @@
+from unittest import mock
+
+import pytest
+
 from app.objects.secondclass.c_link import Link
 from app.objects.secondclass.c_fact import Fact
+from app.service.interfaces.i_event_svc import EventServiceInterface
+from app.utility.base_service import BaseService
+
+
+@pytest.fixture
+def fake_event_svc(loop):
+    class FakeEventService(BaseService, EventServiceInterface):
+        def __init__(self):
+            self.fired = {}
+
+        def reset(self):
+            self.fired = {}
+
+        async def observe_event(self, callback, exchange=None, queue=None):
+            pass
+
+        async def fire_event(self, exchange=None, queue=None, timestamp=True, **callback_kwargs):
+            self.fired[exchange, queue] = callback_kwargs
+
+    service = FakeEventService()
+    service.add_service('event_svc', service)
+
+    yield service
 
 
 class TestLink:
@@ -24,3 +51,39 @@ class TestLink:
         test_link_b = Link(command='net user b', paw='123456', ability=test_ability, id=222222)
         test_link_b.used = [fact_b]
         assert test_link_a != test_link_b
+
+    @mock.patch.object(Link, '_emit_status_change_event')
+    def test_no_status_change_event_on_instantiation(self, mock_emit_status_change_method, ability):
+        Link(command='net user a', paw='123456', ability=ability())
+        mock_emit_status_change_method.assert_not_called()
+
+    @mock.patch.object(Link, '_emit_status_change_event')
+    def test_no_status_change_event_fired_when_setting_same_status(self, mock_emit_status_change_method, ability):
+        link = Link(command='net user a', paw='123456', ability=ability(), status=-3)
+        link.status = link.status
+        mock_emit_status_change_method.assert_not_called()
+
+    @mock.patch.object(Link, '_emit_status_change_event')
+    def test_status_change_event_fired_on_status_change(self, mock_emit_status_change_method, ability):
+        link = Link(command='net user a', paw='123456', ability=ability(), status=-3)
+        link.status = -5
+        mock_emit_status_change_method.assert_called_with(from_status=-3, to_status=-5)
+
+    def test_emit_status_change_event(self, loop, fake_event_svc, ability):
+        link = Link(command='net user a', paw='123456', ability=ability(), status=-3)
+        fake_event_svc.reset()
+
+        loop.run_until_complete(
+            link._emit_status_change_event(
+                from_status=-3,
+                to_status=-5
+            )
+        )
+
+        expected_key = (Link.EVENT_EXCHANGE, Link.EVENT_QUEUE_STATUS_CHANGED)
+        assert expected_key in fake_event_svc.fired
+
+        event_kwargs = fake_event_svc.fired[expected_key]
+        assert event_kwargs['link'] == link.id
+        assert event_kwargs['from_status'] == -3
+        assert event_kwargs['to_status'] == -5

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -326,7 +326,7 @@ class TestOperation:
         assert event_kwargs['from_state'] == 'running'
         assert event_kwargs['to_state'] == 'finished'
 
-    def test_with_learning_parser(self, loop, contact_svc, data_svc, learning_svc, op_with_learning_parser, make_test_link, make_test_result):
+    def test_with_learning_parser(self, loop, contact_svc, data_svc, learning_svc, event_svc, op_with_learning_parser, make_test_link, make_test_result):
         test_link = make_test_link(1234)
         op_with_learning_parser.add_link(test_link)
         test_result = make_test_result(test_link.id)
@@ -337,7 +337,8 @@ class TestOperation:
         assert fact.trait == 'host.ip.address'
         assert fact.value == '10.10.10.10'
 
-    def test_without_learning_parser(self, loop, contact_svc, data_svc, learning_svc, op_without_learning_parser, make_test_link, make_test_result):
+    def test_without_learning_parser(self, loop, app_svc, contact_svc, data_svc, learning_svc, event_svc, op_without_learning_parser, make_test_link, make_test_result):
+        app_svc = app_svc(loop)  # contact_svc._save(...) needs app service registered
         test_link = make_test_link(5678)
         op_without_learning_parser.add_link(test_link)
         test_result = make_test_result(test_link.id)

--- a/tests/services/test_contact_svc.py
+++ b/tests/services/test_contact_svc.py
@@ -40,7 +40,7 @@ def setup_contact_service(loop, data_svc, agent, ability, operation, link, adver
     'obfuscator'
 )
 class TestContactSvc:
-    async def test_save_ability_hooks(self, setup_contact_service, contact_svc):
+    async def test_save_ability_hooks(self, setup_contact_service, contact_svc, event_svc):
         test_string = b'test_string'
         link = setup_contact_service
         rest_svc = RestService()


### PR DESCRIPTION
## Description
Related: #2112 

~Note that this is currently based off of the #2112 branch. I will change the base branch after it gets merged.~ Done.

Fire an event whenever the status of a link is changed.

Events are not fired when...
* The status is set for the first time via the initializer
* The status is set (e.g., `link.status = -3`) but the value is the same as its current value

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
* All tests pass
* Added unit tests to verify events are fired when expected
* Ran an operation successfully
* After operation I shut down the server and restarted it without `--fresh` to make sure pickle didn't have any issues.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
