### PR TITLE
[VIRTS-1986] Don't enforce A.B.C. trait/variable names

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -69,7 +69,7 @@ class Link(BaseObject):
 
     @property
     def raw_command(self):
-        return self.decode_bytes(self.command) if self.command else ""
+        return self.decode_bytes(self.command) if self.command else ''
 
     @property
     def unique(self):

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -68,6 +68,10 @@ class Link(BaseObject):
     RESERVED = dict(origin_link_id='#{origin_link_id}')
 
     @property
+    def raw_command(self):
+        return self.decode_bytes(self.command) if self.command else ""
+
+    @property
     def unique(self):
         return self.hash('%s' % self.id)
 

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -110,8 +110,8 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(self.get_service('learning_svc').learn(operation.all_facts(), link, result.output))
             else:
                 self.get_service('file_svc').write_result_file(result.id, result.output)
-        except Exception as e:
-            self.log.debug('save_results exception: %s' % e)
+        except Exception:
+            self.log.exception('Unexpected error occurred while saving link')
 
     async def _postprocess_link_result(self, result, ability):
         if ability.HOOKS and ability.executor in ability.HOOKS:

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -119,8 +119,7 @@ class BasePlanningService(BaseService):
         :param links:
         :return: updated list of links
         """
-        links[:] = [l for l in links if
-                    not re.findall(r'(#{[a-zA-Z1-9]+?\..+?})', b64decode(l.command).decode('utf-8'), flags=re.DOTALL)]
+        links[:] = [l for l in links if not BasePlanningService.re_variable.findall(b64decode(l.command).decode('utf-8'))]
         return links
 
     async def remove_links_missing_requirements(self, links, operation):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -13,18 +13,18 @@ class BasePlanningService(BaseService):
     # Matches facts/variables.
     # Group 0 returns the trait, including any limits
     # Ex: '#{server.malicious.url}' => 'server.malicious.url'
-    # Ex: '#{host.file.path[filters(technique=T1005,max=3)]' => 'host.file.path[filters(technique=T1005,max=3)]'
+    # Ex: '#{host.file.path[filters(technique=T1005,max=3)]}' => 'host.file.path[filters(technique=T1005,max=3)]'
     re_variable = re.compile(r'#{(.*?)}', flags=re.DOTALL)
 
     # Matches facts/variables that contain limits, denoted by brackets in the fact name.
-    # Ex: Matches '#{host.file.path[filters(technique=T1005,max=3)]'
+    # Ex: Matches '#{host.file.path[filters(technique=T1005,max=3)]}'
     # Ex: Does not match: '#{server.malicious.url}'
     re_limited = re.compile(r'#{.*\[*\]}')
 
     # Matches the trait of a limited fact
     # Group 0 returns the trait excluding any limits
     # Ex: Does not match non-limited fact '#{server.malicious.url}'
-    # Ex: #{host.file.path[filters(technique=T1005,max=3)] => 'host.file.path'
+    # Ex: #{host.file.path[filters(technique=T1005,max=3)]} => 'host.file.path'
     re_trait = re.compile(r'(?<=\{).+?(?=\[)')
 
     # Matches trait limits.

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -186,8 +186,8 @@ class BasePlanningService(BaseService):
             # Ex: Matches ${a}
             # Ex: Matches ${a.b.c}
             # Ex: Matches ${a.b.c[filters(max=3)]}
-            fmt_fact_pattern = r'#{(%s(?=[\[}]).*?)}'
-            re_variable = re.compile(fmt_fact_pattern % re.escape(var.trait), flags=re.DOTALL)
+            pattern = r'#{(%s(?=[\[}]).*?)}' % re.escape(var.trait)
+            re_variable = re.compile(pattern, flags=re.DOTALL)
             copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test)
         return copy_test, score, used
 

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -10,9 +10,26 @@ from app.utility.rule_set import RuleSet
 
 class BasePlanningService(BaseService):
 
+    # Matches facts/variables.
+    # Group 0 returns the trait, including any limits
+    # Ex: '#{server.malicious.url}' => 'server.malicious.url'
+    # Ex: '#{host.file.path[filters(technique=T1005,max=3)]' => 'host.file.path[filters(technique=T1005,max=3)]'
     re_variable = re.compile(r'#{(.*?)}', flags=re.DOTALL)
+
+    # Matches facts/variables that contain limits, denoted by brackets in the fact name.
+    # Ex: Matches '#{host.file.path[filters(technique=T1005,max=3)]'
+    # Ex: Does not match: '#{server.malicious.url}'
     re_limited = re.compile(r'#{.*\[*\]}')
+
+    # Matches the trait of a limited fact
+    # Group 0 returns the trait excluding any limits
+    # Ex: Does not match non-limited fact '#{server.malicious.url}'
+    # Ex: #{host.file.path[filters(technique=T1005,max=3)] => 'host.file.path'
     re_trait = re.compile(r'(?<=\{).+?(?=\[)')
+
+    # Matches trait limits.
+    # Group 0 returns the specific filters.
+    # Ex: '#{host.file.path[filters(technique=T1005,max=3)]}' => 'technique=T1005,max=3'
     re_index = re.compile(r'(?<=\[filters\().+?(?=\)\])')
 
     async def trim_links(self, operation, links, agent):

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -182,7 +182,13 @@ class BasePlanningService(BaseService):
         for var in combo:
             score += (score + var.score)
             used.append(var)
-            re_variable = re.compile(r'#{(%s.*?)}' % var.trait, flags=re.DOTALL)
+
+            # Matches a complete fact with a given trait
+            # Ex: Matches ${a}
+            # Ex: Matches ${a.b.c}
+            # Ex: Matches ${a.b.c[filters(max=3)]}
+            fmt_fact_pattern = r'#{(%s(?=[\[}]).*?)}'
+            re_variable = re.compile(fmt_fact_pattern % re.escape(var.trait), flags=re.DOTALL)
             copy_test = re.sub(re_variable, str(var.escaped(executor)).strip().encode('unicode-escape').decode('utf-8'), copy_test)
         return copy_test, score, used
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 import random
 import string
@@ -23,13 +25,16 @@ from app.objects.c_agent import Agent
 from app.objects.secondclass.c_link import Link
 from app.objects.secondclass.c_fact import Fact
 
+DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_DIR = os.path.join(DIR, '..', 'conf')
+
 
 @pytest.fixture(scope='session')
 def init_base_world():
-    with open('conf/default.yml') as c:
+    with open(os.path.join(CONFIG_DIR, 'default.yml')) as c:
         BaseWorld.apply_config('main', yaml.load(c, Loader=yaml.FullLoader))
-    BaseWorld.apply_config('agents', BaseWorld.strip_yml('conf/agents.yml')[0])
-    BaseWorld.apply_config('payloads', BaseWorld.strip_yml('conf/payloads.yml')[0])
+    BaseWorld.apply_config('agents', BaseWorld.strip_yml(os.path.join(CONFIG_DIR, 'agents.yml'))[0])
+    BaseWorld.apply_config('payloads', BaseWorld.strip_yml(os.path.join(CONFIG_DIR, 'payloads.yml'))[0])
 
 
 @pytest.fixture(scope='class')

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -147,6 +147,7 @@ class TestOperation:
         assert op.ran_ability_id('123')
 
     def test_event_logs(self, loop, op_for_event_logs, operation_agent, file_svc, data_svc):
+        loop.run_until_complete(data_svc.remove('agents', match=dict(unique=operation_agent.unique)))
         loop.run_until_complete(data_svc.store(operation_agent))
         start_time = op_for_event_logs.start.strftime('%Y-%m-%d %H:%M:%S')
         agent_creation_time = operation_agent.created.strftime('%Y-%m-%d %H:%M:%S')
@@ -215,7 +216,9 @@ class TestOperation:
         assert event_logs == want
 
     def test_writing_event_logs_to_disk(self, loop, op_for_event_logs, operation_agent, file_svc, data_svc):
+        loop.run_until_complete(data_svc.remove('agents', match=dict(unique=operation_agent.unique)))
         loop.run_until_complete(data_svc.store(operation_agent))
+
         start_time = op_for_event_logs.start.strftime('%Y-%m-%d %H:%M:%S')
         agent_creation_time = operation_agent.created.strftime('%Y-%m-%d %H:%M:%S')
         want_agent_metadata = dict(

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -450,7 +450,7 @@ class TestPlanningService:
         assert len(links) == 1
         assert links[0].raw_command == cmd
 
-    async def test_remove_links_missing_facts_removes_part_part_fact(self, ability):
+    async def test_remove_links_missing_facts_removes_one_part_fact(self, ability):
         cmd = 'a -b --foo=#{bar}'
         links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
         await BasePlanningService.remove_links_missing_facts(links)

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -359,3 +359,84 @@ class TestPlanningService:
                                                                        [l0, l1, l2, l3],
                                                                        [l0, l1, l2, l3]])
         assert 7 == len(flat_fil)
+
+    def test_trait_with_one_part(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+
+        encoded_command = BaseWorld.encode_string('#{a}')
+        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
+
+        input_facts = [
+            Fact(trait='a', value='1'),
+            Fact(trait='a.b', value='2'),
+            Fact(trait='a.b.c', value='3'),
+            Fact(trait='server', value='5')
+        ]
+
+        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        assert len(new_links) == 2
+
+        found_commands = set(x.command for x in new_links)
+        assert len(found_commands) == 2  # the original and the replaced
+        assert encoded_command in found_commands
+        assert BaseWorld.encode_string('1') in found_commands
+
+    def test_trait_with_two_parts(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        encoded_command = BaseWorld.encode_string('#{a.b}')
+        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
+
+        input_facts = [
+            Fact(trait='a', value='1'),
+            Fact(trait='a.b', value='2'),
+            Fact(trait='a.b.c', value='3'),
+            Fact(trait='server', value='5')
+        ]
+
+        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        assert len(new_links) == 2
+
+        found_commands = set(x.command for x in new_links)
+        assert len(found_commands) == 2  # the original and the replaced
+        assert encoded_command in found_commands
+        assert BaseWorld.encode_string('2') in found_commands
+
+    def test_trait_with_three_parts(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        encoded_command = BaseWorld.encode_string('#{a.b.c}')
+        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
+
+        input_facts = [
+            Fact(trait='a', value='1'),
+            Fact(trait='a.b', value='2'),
+            Fact(trait='a.b.c', value='3'),
+            Fact(trait='server', value='5')
+        ]
+
+        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        assert len(new_links) == 2
+
+        found_commands = set(x.command for x in new_links)
+        assert len(found_commands) == 2  # the original and the replaced
+        assert encoded_command in found_commands
+        assert BaseWorld.encode_string('3') in found_commands
+
+    def test_trait_with_multiple_variations_of_parts(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        encoded_command = BaseWorld.encode_string('#{a} #{a.b} #{a.b.c}')
+        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
+
+        input_facts = [
+            Fact(trait='a', value='1'),
+            Fact(trait='a.b', value='2'),
+            Fact(trait='a.b.c', value='3'),
+            Fact(trait='server', value='5')
+        ]
+
+        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        assert len(new_links) == 2
+
+        found_commands = set(x.command for x in new_links)
+        assert len(found_commands) == 2  # the original and the replaced
+        assert encoded_command in found_commands
+        assert BaseWorld.encode_string('1 2 3') in found_commands


### PR DESCRIPTION
## Description
Non-global variables/traits previously had to follow an A.B.C format (well, anything with more than two dots maybe) to be able to be substituted into a command/link.

This PR updates the base planning service to allow traits not following A.B.C formatting to be recognized and substituted.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
* Updated existing tests to recognize new naming convent
* Added new tests to verify trait/variable naming is supported
* Ran an operation and it finished successfully
* Ran an operation with an adversary containing abilities with single-part trait variables (`#{foo}`) and multi-part trait variables (`#{foo.bar}`) and used the operation fact source to inject values (this worked for both)
* Ran an operation with an ability which declared a new single-part source fact (`source: foobar`), and another ability that utilized that source fact in its command (`echo #{foobar}`) and observed it correctly being injected.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
