### PR TITLE
virts-1872: Adding Recoverable Feature

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -84,7 +84,6 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.technique_id = technique_id
         self.name = name
         self.description = description
-        self.cleanup = [cleanup] if cleanup else []
         self.executor = executor
         self.platform = platform
         self.payloads = payloads if payloads else []
@@ -106,6 +105,14 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.additional_info = additional_info or dict()
         self.additional_info.update(**kwargs)
         self.tags = set(tags) if tags else set()
+
+        if not cleanup:
+            self.cleanup = []
+        else:
+            if isinstance(cleanup, list):
+                self.cleanup = cleanup
+            else:
+                self.cleanup = [cleanup]
 
     def __getattr__(self, item):
         try:

--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -37,6 +37,7 @@ class AbilitySchema(ma.Schema):
     access = ma.fields.Nested(AccessSchema, missing=None)
     test = ma.fields.String(missing=None)
     singleton = ma.fields.Bool(missing=None)
+    recoverable = ma.fields.Bool(missing=None)
 
     @ma.post_load
     def build_ability(self, data, **_):
@@ -74,7 +75,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,
                  variations=None, language=None, code=None, build_target=None, additional_info=None, tags=None,
-                 singleton=False, uploads=None, **kwargs):
+                 singleton=False, recoverable=False, uploads=None, **kwargs):
         super().__init__()
         self._test = test
         self.ability_id = ability_id
@@ -99,6 +100,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.variations = get_variations(variations)
         self.buckets = buckets if buckets else []
         self.singleton = singleton
+        self.recoverable = recoverable
         if access:
             self.access = self.Access(access)
         self.additional_info = additional_info or dict()

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -88,7 +88,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, name, agents, adversary, id=None, jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True, visibility=50, access=None,
-                 use_learning_parsers=True):
+                 use_learning_parsers=True, enable_recovery=True):
         super().__init__()
         self.id = str(id)
         self.start, self.finish = None, None
@@ -107,6 +107,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.obfuscator = obfuscator
         self.auto_close = auto_close
         self.visibility = visibility
+        self.enable_recovery = enable_recovery
         self.objective = None
         self.chain, self.potential_links, self.rules = [], [], []
         self.access = access if access else self.Access.APP

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -261,6 +261,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
                                    platform=step.ability.platform,
                                    executor=step.ability.executor,
                                    pid=step.pid,
+                                   repeated=step.recovery,
                                    description=step.ability.description,
                                    name=step.ability.name,
                                    attack=dict(tactic=step.ability.tactic,
@@ -374,7 +375,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.agents = await services.get('rest_svc').construct_agents_for_group(self.group)
 
     async def _unfinished_links_for_agent(self, paw):
-        return [l for l in self.chain if l.paw == paw and not l.finish and not l.can_ignore()]
+        return [link for link in self.chain if link.paw == paw and not link.finish and not link.can_ignore()]
 
     async def _get_all_possible_abilities_by_agent(self, data_svc):
         abilities = {'all_abilities': [ab for ab_id in self.adversary.atomic_ordering

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -86,9 +86,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
             to_state=value
         )
 
-    def __init__(self, name, agents, adversary, id='', jitter='2/8', source=None, planner=None, state='running',
+    def __init__(self, name, agents, adversary, id=None, jitter='2/8', source=None, planner=None, state='running',
                  autonomous=True, obfuscator='plain-text', group=None, auto_close=True, visibility=50, access=None,
-                 timeout=30, use_learning_parsers=True):
+                 use_learning_parsers=True):
         super().__init__()
         self.id = str(id)
         self.start, self.finish = None, None

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -146,6 +146,7 @@ class Link(BaseObject):
         self.visibility = Visibility()
         self._pin = pin
         self.output = False
+        self.recovery = False
         self.deadman = deadman
 
     def __eq__(self, other):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -146,7 +146,7 @@ class ContactService(ContactServiceInterface, BaseService):
         for link in [c for op in ops for c in op.chain
                      if c.paw == agent.paw and not c.collect and c.status == c.states['EXECUTE']]:
             instructions.append(self._convert_link_to_instruction(link))
-        for link in [l for l in agent.links if not l.collect]:
+        for link in [s_link for s_link in agent.links if not s_link.collect]:
             instructions.append(self._convert_link_to_instruction(link))
         return instructions
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -41,8 +41,8 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
             links = await self.get_links(operation, [bucket], agent)
             if len(links) == 0:
                 break
-            for l in links:
-                l_id = await operation.apply(l)
+            for s_link in links:
+                l_id = await operation.apply(s_link)
                 if batch:
                     l_ids.append(l_id)
                 else:
@@ -371,7 +371,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         :rtype: list(Link)
         """
         links = []
-        for link in [l for l in operation.chain if l.paw == agent.paw]:
+        for link in [s_link for s_link in operation.chain if s_link.paw == agent.paw]:
             matched_abilities = await self.get_service('data_svc').locate('abilities',
                                                                           match=dict(unique=link.ability.unique))
             if matched_abilities:
@@ -381,7 +381,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
                     variant, _, _ = await self._build_single_test_variant(decoded_cmd, link.used, link.ability.executor)
                     lnk = Link.load(dict(command=self.encode_string(variant), paw=agent.paw, cleanup=1,
                                          ability=ability, score=0, jitter=2, status=link_status))
-                    if lnk.command not in [l.command for l in links]:
+                    if lnk.command not in [a_link.command for a_link in links]:
                         lnk.apply_id(agent.host)
                         links.append(lnk)
         return links
@@ -395,8 +395,8 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
         :param links: Links to apply adjustments to
         :type links: list(Link)
         """
-        for l in links:
-            for adjustment in [a for a in operation.source.adjustments if a.ability_id == l.ability.ability_id]:
+        for s_link in links:
+            for adjustment in [a for a in operation.source.adjustments if a.ability_id == s_link.ability.ability_id]:
                 if operation.has_fact(trait=adjustment.trait, value=adjustment.value):
-                    l.visibility.apply(adjustment)
-                    l.status = l.states['HIGH_VIZ']
+                    s_link.visibility.apply(adjustment)
+                    s_link.status = s_link.states['HIGH_VIZ']

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -206,7 +206,7 @@ class RestService(RestServiceInterface, BaseService):
         agents = await self.get_service('data_svc').locate('agents', match=dict(paw=paw)) if paw else operation.agents
         potential_abilities = await self._build_potential_abilities(operation)
         operation.potential_links = await self._build_potential_links(operation, agents, potential_abilities)
-        return dict(links=[l.display for l in operation.potential_links])
+        return dict(links=[link.display for link in operation.potential_links])
 
     async def apply_potential_link(self, link):
         operation = await self.get_service('app_svc').find_op_with_link(link.id)

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -340,7 +340,6 @@ class RestService(RestServiceInterface, BaseService):
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          obfuscator=data.pop('obfuscator', 'plain-text'),
                          auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')),
-                         timeout=int(data.pop('timeout', 30)),
                          use_learning_parsers=bool(int(data.pop('use_learning_parsers', 0))))
 
     def _get_allowed_from_access(self, access):

--- a/app/service/rest_svc.py
+++ b/app/service/rest_svc.py
@@ -340,7 +340,8 @@ class RestService(RestServiceInterface, BaseService):
                          state=data.pop('state', 'running'), autonomous=int(data.pop('autonomous', 1)), access=allowed,
                          obfuscator=data.pop('obfuscator', 'plain-text'),
                          auto_close=bool(int(data.pop('auto_close', 0))), visibility=int(data.pop('visibility', '50')),
-                         use_learning_parsers=bool(int(data.pop('use_learning_parsers', 0))))
+                         use_learning_parsers=bool(int(data.pop('use_learning_parsers', 0))),
+                         enable_recovery=bool(int(data.pop('enable_recovery', 1))))
 
     def _get_allowed_from_access(self, access):
         if self.Access.HIDDEN in access['access']:

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -50,7 +50,8 @@ class BasePlanningService(BaseService):
         links = await self.remove_links_missing_requirements(links, operation)
         links = await self.obfuscate_commands(agent, operation.obfuscator, links)
         links = await self.remove_completed_links(operation, agent, links)
-        links = await self.restore_dead_agent_links(operation, agent, links)
+        if operation.enable_recovery:
+            links = await self.restore_dead_agent_links(operation, agent, links)
         return links
 
     async def add_test_variants(self, links, agent, facts=(), rules=()):

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -98,6 +98,10 @@
                 <option value="1" selected>Use default parsers</option>
                 <option value="0">Do not use default parsers</option>
               </select>
+              <select name="recovery" id="queueRecovery" class="queueOption" style="opacity:0.5" disabled="true">
+                  <option value="1" selected>Enable automated recovery</option>
+                  <option value="0">Disable automated recovery</option>
+              </select>
               <p style="margin-bottom:-10px">Cleanup Timeout (secs)</p>
               <input id="queueTimeout" class="queueOption" type="number" value="30" min="0" max="300"
                       onchange="stream('The number of seconds Caldera will wait per cleanup action to complete before continuing.')">
@@ -419,6 +423,7 @@
             "obfuscator":document.getElementById("queueObfuscated").value,
             "auto_close": document.getElementById("queueAutoClose").value,
             "use_learning_parsers": document.getElementById("queueDefaultParsers").value,
+            "enable_recovery": document.getElementById("queueRecovery").value,
             "jitter":jitter,
             "source":document.getElementById("queueSource").value,
             "visibility": document.getElementById("queueVisibility").value,

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -20,7 +20,7 @@ def dns_contact_base_world():
                                                 'crypt_salt': 'BLAH',
                                                 'api_key': 'ADMIN123',
                                                 'encryption_key': 'ADMIN123',
-                                                'exfil_dir': os.path.normpath('/')})
+                                                'exfil_dir': '/tmp'})
     BaseWorld.apply_config(name='agents', config={'sleep_max': 5,
                                                   'sleep_min': 5,
                                                   'untrusted_timer': 90,
@@ -225,8 +225,8 @@ class TestContactDns:
         hostname = 'testhost'
         directory = '%s-%s' % (hostname, paw)
         upload_metadata = dict(paw=paw, file=filename, directory=directory)
-        target_dir = os.path.normpath('/' + directory)
-        target_path = os.path.join(target_dir, f"{filename}-{message_id}")
+        target_dir = '/tmp/%s' % directory
+        target_path = '%s/%s-%s' % (target_dir, filename, message_id)
         file_data = b'thiswilltakemultiplednsrequests' * 100
         metadata_hex_chunks = get_hex_chunks(json.dumps(upload_metadata).encode('utf-8'))
         file_data_hex_chunks = get_hex_chunks(file_data)

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -20,7 +20,7 @@ def dns_contact_base_world():
                                                 'crypt_salt': 'BLAH',
                                                 'api_key': 'ADMIN123',
                                                 'encryption_key': 'ADMIN123',
-                                                'exfil_dir': '/tmp'})
+                                                'exfil_dir': os.path.normpath('/')})
     BaseWorld.apply_config(name='agents', config={'sleep_max': 5,
                                                   'sleep_min': 5,
                                                   'untrusted_timer': 90,
@@ -225,8 +225,8 @@ class TestContactDns:
         hostname = 'testhost'
         directory = '%s-%s' % (hostname, paw)
         upload_metadata = dict(paw=paw, file=filename, directory=directory)
-        target_dir = '/tmp/%s' % directory
-        target_path = '%s/%s-%s' % (target_dir, filename, message_id)
+        target_dir = os.path.normpath('/' + directory)
+        target_path = os.path.join(target_dir, f"{filename}-{message_id}")
         file_data = b'thiswilltakemultiplednsrequests' * 100
         metadata_hex_chunks = get_hex_chunks(json.dumps(upload_metadata).encode('utf-8'))
         file_data_hex_chunks = get_hex_chunks(file_data)

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -47,7 +47,7 @@ class TestContactSsh:
 
     def test_tunnel(self, loop, ssh_contact):
         loop.run_until_complete(ssh_contact.start())
-        conn = loop.run_until_complete(asyncssh.connect('localhost', port=8122, known_hosts=None, username='sandcat',
+        conn = loop.run_until_complete(asyncssh.connect('127.0.0.1', port=8122, known_hosts=None, username='sandcat',
                                                         password='s4ndc4t!'))
         assert conn and conn.get_extra_info('username') == 'sandcat'
         listener = loop.run_until_complete(conn.forward_local_port('', 61234, 'localhost', 8888))

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -491,8 +491,8 @@ class TestPlanningService:
 
         # verify that we can generate a new copy of a link for a now dead agent
         agent.paw = 'a.b.d'  # force paw to be something we can predict
-                             # (The planner just accepts that .d exists, even if it doesn't) - it only forcibly checks
-                             # dead agents here... and the agent that 'died' is on host 'a.b.e' (see init)
+        # (The planner just accepts that .d exists, even if it doesn't) - it only forcibly checks
+        # dead agents here... and the agent that 'died' is on host 'a.b.e' (see init)
         recovered = loop.run_until_complete(planning_svc.restore_dead_agent_links(operation, agent, []))
         assert len(recovered) == 1
 


### PR DESCRIPTION
## Description

Adds the ability for Caldera to run 'recovery' actions, if an agent dies. The specific process is this:

1) An agent dies
2) Caldera detects the agent dies, and if the operation is configured to do so (which is the default), it will process the existing chain of links to see if any use a fact that includes the host of the dead agent. 
3) If matches were found, the system will create new versions of these matches, assuming this is the first time it has done so (repeat failures are ignored).
4) A new agent spawns on the host the previous agent died on. 

This system runs actively during the operation, but is suppressed during cleanup, for obvious reasons. There are also various cleanup tweaks present in this merge request for formatting and compatibility reasons. 

Associated stockpile changes here - https://github.com/mitre/stockpile/pull/527

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

These changes have been tested using an AWS environment and the Alice adversary, as well as with a collection of new tests.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation (Not yet - curious to what degree we want to document this - it's largely self contained and invisible to users outside of the one new field)
- [X] I have added tests that prove my fix is effective or that my feature works
