### PR TITLE
[VIRTS-1986] Don't overwrite global variables with facts

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -70,6 +70,10 @@ class Ability(FirstClassObjectInterface, BaseObject):
     def raw_command(self):
         return self.decode_bytes(self._test) if self._test else ""
 
+    @classmethod
+    def is_global_variable(cls, variable):
+        return variable in cls.RESERVED
+
     def __init__(self, ability_id, tactic=None, technique_id=None, technique=None, name=None, test=None,
                  description=None, cleanup=None, executor=None, platform=None, payloads=None, parsers=None,
                  requirements=None, privilege=None, timeout=60, repeatable=False, buckets=None, access=None,

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -73,6 +73,16 @@ class Agent(FirstClassObjectInterface, BaseObject):
     def display_name(self):
         return '{}${}'.format(self.host, self.username)
 
+    @classmethod
+    def is_global_variable(cls, variable):
+        if variable.startswith('payload:'):
+            return True
+        if variable == 'payload':
+            return False
+        if variable in cls.RESERVED:
+            return True
+        return False
+
     def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
@@ -209,7 +219,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         bps = BasePlanningService()
         potential_links = [Link.load(dict(command=i.test, paw=self.paw, ability=i, deadman=deadman)) for i in await self.capabilities(abilities)]
         links = []
-        for valid in await bps.remove_links_missing_facts(
+        for valid in await bps.remove_links_with_unset_variables(
                 await bps.add_test_variants(links=potential_links, agent=self, facts=facts)):
             links.append(valid)
         links = await bps.obfuscate_commands(self, obfuscator, links)

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -123,6 +123,10 @@ class Link(BaseObject):
             to_status=value
         )
 
+    @classmethod
+    def is_global_variable(cls, variable):
+        return variable in cls.RESERVED
+
     def __init__(self, command, paw, ability, status=-3, score=0, jitter=0, cleanup=0, id='', pin=0,
                  host=None, deadman=False, used=None, relationships=None):
         super().__init__()

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -5,8 +5,8 @@ from app.utility.base_planning_svc import BasePlanningService
 
 class PlanningService(PlanningServiceInterface, BasePlanningService):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, global_variable_owners=None):
+        super().__init__(global_variable_owners=global_variable_owners)
         self.log = self.add_service('planning_svc', self)
 
     async def exhaust_bucket(self, planner, bucket, operation, agent=None, batch=False, condition_stop=True):

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -106,11 +106,6 @@ class BaseObject(BaseWorld):
 class AppConfigGlobalVariableIdentifier:
     @classmethod
     def is_global_variable(cls, variable):
-        if not variable.startswith('app.'):
-            return False
-
-        for config_key in BaseWorld.get_config().keys():
-            if variable == config_key:
-                return True
-
+        if variable.startswith('app.'):
+            return variable in BaseWorld.get_config()
         return False

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -101,3 +101,18 @@ class BaseObject(BaseWorld):
             return cls.schema.load(dict_obj)
         else:
             raise NotImplementedError
+
+
+class AppConfigGlobalVariableIdentifier:
+    @classmethod
+    def iter_app_config_variables(cls):
+        for config_key in BaseWorld.get_config().keys():
+            if config_key.startswith('app.'):
+                yield '#{%s}' % config_key
+
+    @classmethod
+    def is_global_variable(cls, variable):
+        for config_variable in cls.iter_app_config_variables():
+            if variable == config_variable:
+                return True
+        return False

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -105,14 +105,12 @@ class BaseObject(BaseWorld):
 
 class AppConfigGlobalVariableIdentifier:
     @classmethod
-    def iter_app_config_variables(cls):
-        for config_key in BaseWorld.get_config().keys():
-            if config_key.startswith('app.'):
-                yield '#{%s}' % config_key
-
-    @classmethod
     def is_global_variable(cls, variable):
-        for config_variable in cls.iter_app_config_variables():
-            if variable == config_variable:
+        if not variable.startswith('app.'):
+            return False
+
+        for config_key in BaseWorld.get_config().keys():
+            if variable == config_key:
                 return True
+
         return False

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -1,5 +1,3 @@
-import re
-
 from app.utility.base_world import BaseWorld
 
 
@@ -91,8 +89,8 @@ class BaseObject(BaseWorld):
             decoded_test = self.decode_bytes(encoded_string)
             for k, v in self.get_config().items():
                 if k.startswith('app.'):
-                    re_variable = re.compile(r'#{(%s.*?)}' % k, flags=re.DOTALL)
-                    decoded_test = re.sub(re_variable, str(v).strip(), decoded_test)
+                    var = "#{%s}" % k
+                    decoded_test = decoded_test.replace(var, str(v).strip())
             return self.encode_string(decoded_test)
 
     @classmethod

--- a/app/utility/base_object.py
+++ b/app/utility/base_object.py
@@ -89,7 +89,7 @@ class BaseObject(BaseWorld):
             decoded_test = self.decode_bytes(encoded_string)
             for k, v in self.get_config().items():
                 if k.startswith('app.'):
-                    var = "#{%s}" % k
+                    var = '#{%s}' % k
                     decoded_test = decoded_test.replace(var, str(v).strip())
             return self.encode_string(decoded_test)
 

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -41,8 +41,16 @@ class BasePlanningService(BaseService):
         """
         self._global_variable_owners = list(global_variable_owners or ())
 
-    def add_global_variable_owner(self, x):
-        self._global_variable_owners.append(x)
+    def add_global_variable_owner(self, global_variable_owner):
+        """Adds a global variable owner to the internal registry.
+
+        These will be used for identification of global variables when performing variable-fact substitution.
+
+        Args:
+            global_variable_owner: An object that exposes an is_global_variable(...) method and accepts a string
+                containing a bare/unwrapped variable.
+        """
+        self._global_variable_owners.append(global_variable_owner)
 
     def is_global_variable(self, variable):
         return any(x.is_global_variable(variable) for x in self._global_variable_owners)

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -45,7 +45,7 @@ class BasePlanningService(BaseService):
         :return: trimmed list of links
         """
         links[:] = await self.add_test_variants(links, agent, operation.all_facts(), operation.rules)
-        links = await self.remove_links_missing_facts(links)
+        links = await self.remove_links_with_unset_variables(links)
         links = await self.remove_links_missing_requirements(links, operation)
         links = await self.obfuscate_commands(agent, operation.obfuscator, links)
         links = await self.remove_completed_links(operation, agent, links)
@@ -112,9 +112,9 @@ class BasePlanningService(BaseService):
                  not any([lnk.command == x.command for x in singleton_links]))]
 
     @staticmethod
-    async def remove_links_missing_facts(links):
+    async def remove_links_with_unset_variables(links):
         """
-        Remove any links that did not have facts encoded into command
+        Remove any links that contain variables that have not been filled in.
 
         :param links:
         :return: updated list of links

--- a/server.py
+++ b/server.py
@@ -10,6 +10,9 @@ from aiohttp import web
 import app.api.v2
 from app import version
 from app.api.rest_api import RestApi
+from app.objects.c_ability import Ability
+from app.objects.c_agent import Agent
+from app.objects.secondclass.c_link import Link
 from app.service.app_svc import AppService
 from app.service.auth_svc import AuthService
 from app.service.contact_svc import ContactService
@@ -19,6 +22,7 @@ from app.service.file_svc import FileSvc
 from app.service.learning_svc import LearningService
 from app.service.planning_svc import PlanningService
 from app.service.rest_svc import RestService
+from app.utility.base_object import AppConfigGlobalVariableIdentifier
 from app.utility.base_world import BaseWorld
 from app.utility.config_generator import ensure_local_config
 
@@ -111,7 +115,14 @@ if __name__ == '__main__':
 
     data_svc = DataService()
     contact_svc = ContactService()
-    planning_svc = PlanningService()
+    planning_svc = PlanningService(
+        global_variable_owners=[
+            Ability,
+            Agent,
+            Link,
+            AppConfigGlobalVariableIdentifier
+        ]
+    )
     rest_svc = RestService()
     auth_svc = AuthService()
     file_svc = FileSvc()

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -5,10 +5,10 @@ import base64
 from app.objects.c_adversary import Adversary
 from app.objects.c_obfuscator import Obfuscator
 from app.objects.c_source import Source
+from app.objects.c_agent import Agent
 from app.objects.secondclass.c_link import Link
 from app.objects.secondclass.c_fact import Fact
 from app.utility.base_world import BaseWorld
-from app.utility.base_planning_svc import BasePlanningService
 
 
 stop_bucket_exhaustion_params = [
@@ -62,7 +62,7 @@ def planner_stub(**kwargs):
 def setup_planning_test(loop, ability, agent, operation, data_svc, event_svc, init_base_world):
     tability = ability(ability_id='123', executor='sh', platform='darwin', test=BaseWorld.encode_string('mkdir test'),
                        cleanup=BaseWorld.encode_string('rm -rf test'), variations=[], repeatable=True, buckets=['test'])
-    tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin')
+    tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin', server='http://127.0.0.1:8000')
     tsource = Source(id='123', name='test', facts=[], adjustments=[])
     toperation = operation(name='test1', agents=[tagent],
                            adversary=Adversary(name='test', description='test',
@@ -362,7 +362,7 @@ class TestPlanningService:
                                                                        [l0, l1, l2, l3]])
         assert 7 == len(flat_fil)
 
-    def test_trait_with_one_part(self, loop, setup_planning_test, planning_svc):
+    async def test_trait_with_one_part(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
 
         encoded_command = BaseWorld.encode_string('#{a}')
@@ -375,7 +375,7 @@ class TestPlanningService:
             Fact(trait='server', value='5')
         ]
 
-        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        new_links = await planning_svc.add_test_variants([link], agent, facts=input_facts)
         assert len(new_links) == 2
 
         found_commands = set(x.command for x in new_links)
@@ -383,7 +383,7 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('1') in found_commands
 
-    def test_trait_with_two_parts(self, loop, setup_planning_test, planning_svc):
+    async def test_trait_with_two_parts(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         encoded_command = BaseWorld.encode_string('#{a.b}')
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
@@ -395,7 +395,7 @@ class TestPlanningService:
             Fact(trait='server', value='5')
         ]
 
-        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        new_links = await planning_svc.add_test_variants([link], agent, facts=input_facts)
         assert len(new_links) == 2
 
         found_commands = set(x.command for x in new_links)
@@ -403,7 +403,7 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('2') in found_commands
 
-    def test_trait_with_three_parts(self, loop, setup_planning_test, planning_svc):
+    async def test_trait_with_three_parts(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         encoded_command = BaseWorld.encode_string('#{a.b.c}')
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
@@ -415,7 +415,7 @@ class TestPlanningService:
             Fact(trait='server', value='5')
         ]
 
-        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        new_links = await planning_svc.add_test_variants([link], agent, facts=input_facts)
         assert len(new_links) == 2
 
         found_commands = set(x.command for x in new_links)
@@ -423,7 +423,7 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('3') in found_commands
 
-    def test_trait_with_multiple_variations_of_parts(self, loop, setup_planning_test, planning_svc):
+    async def test_trait_with_multiple_variations_of_parts(self, loop, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         encoded_command = BaseWorld.encode_string('#{a} #{a.b} #{a.b.c}')
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
@@ -435,7 +435,7 @@ class TestPlanningService:
             Fact(trait='server', value='5')
         ]
 
-        new_links = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=input_facts))
+        new_links = await planning_svc.add_test_variants([link], agent, facts=input_facts)
         assert len(new_links) == 2
 
         found_commands = set(x.command for x in new_links)
@@ -443,27 +443,54 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('1 2 3') in found_commands
 
-    async def test_remove_links_missing_facts_keeps_link_without_facts(self, ability):
+    async def test_global_variables_not_replaced_with_facts(self, loop, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        encoded_command = BaseWorld.encode_string('#{server} #{origin_link_id}')
+        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
+
+        input_facts = [
+            Fact(trait='server', value='bad.server'),
+            Fact(trait='origin_link_id', value='bad.origin_link_id')
+        ]
+
+        planning_svc.add_global_variable_owner(Agent)  # handles #{server}
+        planning_svc.add_global_variable_owner(Link)  # handles #{origin_link_id}
+
+        new_links = await planning_svc.add_test_variants([link], agent, facts=input_facts)
+        assert len(new_links) == 1
+        assert new_links[0].raw_command == f'{agent.server} {link.id}'
+
+    async def test_remove_links_missing_facts_keeps_link_without_facts(self, planning_svc, ability):
         cmd = 'a -b --foo={bar}'  # almost includes a fact, but missing a '#' in front of '{bar}'
         links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
-        await BasePlanningService.remove_links_missing_facts(links)
+        await planning_svc.remove_links_with_unset_variables(links)
         assert len(links) == 1
         assert links[0].raw_command == cmd
 
-    async def test_remove_links_missing_facts_removes_one_part_fact(self, ability):
+    async def test_remove_links_missing_facts_removes_one_part_fact(self, planning_svc, ability):
         cmd = 'a -b --foo=#{bar}'
         links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
-        await BasePlanningService.remove_links_missing_facts(links)
+        await planning_svc.remove_links_with_unset_variables(links)
         assert len(links) == 0
 
-    async def test_remove_links_missing_facts_removes_two_part_fact(self, ability):
+    async def test_remove_links_missing_facts_removes_two_part_fact(self, planning_svc, ability):
         cmd = 'a -b --foo=#{foo.bar}'
         links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
-        await BasePlanningService.remove_links_missing_facts(links)
+        await planning_svc.remove_links_with_unset_variables(links)
         assert len(links) == 0
 
-    async def test_remove_links_missing_facts_removes_three_part_fact(self, ability):
+    async def test_remove_links_missing_facts_removes_three_part_fact(self, planning_svc, ability):
         cmd = 'a -b --foo=#{foo.bar.baz}'
         links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
-        await BasePlanningService.remove_links_missing_facts(links)
+        await planning_svc.remove_links_with_unset_variables(links)
+        assert len(links) == 0
+
+    async def test_remove_links_does_not_ignore_global_variables(self, planning_svc, ability):
+        cmd = 'a -b --foo=#{server} --bar=#{origin_link_id}'
+        links = [Link(command=BaseWorld.encode_string(cmd), paw='1', ability=ability())]
+
+        planning_svc.add_global_variable_owner(Agent)  # handles #{server}
+        planning_svc.add_global_variable_owner(Link)  # handles #{origin_link_id}
+
+        await planning_svc.remove_links_with_unset_variables(links)
         assert len(links) == 0

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -423,7 +423,7 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('3') in found_commands
 
-    async def test_trait_with_multiple_variations_of_parts(self, loop, setup_planning_test, planning_svc):
+    async def test_trait_with_multiple_variations_of_parts(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         encoded_command = BaseWorld.encode_string('#{a} #{a.b} #{a.b.c}')
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))
@@ -443,7 +443,7 @@ class TestPlanningService:
         assert encoded_command in found_commands
         assert BaseWorld.encode_string('1 2 3') in found_commands
 
-    async def test_global_variables_not_replaced_with_facts(self, loop, setup_planning_test, planning_svc):
+    async def test_global_variables_not_replaced_with_facts(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         encoded_command = BaseWorld.encode_string('#{server} #{origin_link_id}')
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, status=0))

--- a/tests/utility/test_base_object.py
+++ b/tests/utility/test_base_object.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.utility.base_object import BaseObject
+from app.utility.base_world import BaseWorld
+
+
+@pytest.fixture
+def base_world():
+    BaseWorld.apply_config(
+        name='main',
+        config={
+            'app.foo': 'foo',
+            'app.bar': 'bar'
+        }
+    )
+
+    yield BaseWorld
+
+    BaseWorld.clear_config()
+
+
+def test_replace_app_props(base_world):
+    base_object = BaseObject()
+    command = 'echo #{foo} #{app.foo} #{app.bar} #{app.foo.do.not.replace.me}'
+    replaced = base_object.replace_app_props(BaseWorld.encode_string(command))
+    expected = 'echo #{foo} foo bar #{app.foo.do.not.replace.me}'
+    assert expected == BaseWorld.decode_bytes(replaced)

--- a/tests/utility/test_base_object.py
+++ b/tests/utility/test_base_object.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.utility.base_object import BaseObject
+from app.utility.base_object import AppConfigGlobalVariableIdentifier
 from app.utility.base_world import BaseWorld
 
 
@@ -10,7 +11,8 @@ def base_world():
         name='main',
         config={
             'app.foo': 'foo',
-            'app.bar': 'bar'
+            'app.bar': 'bar',
+            'auth.baz': 'not an app. item'
         }
     )
 
@@ -25,3 +27,23 @@ def test_replace_app_props(base_world):
     replaced = base_object.replace_app_props(BaseWorld.encode_string(command))
     expected = 'echo #{foo} foo bar #{app.foo.do.not.replace.me}'
     assert expected == BaseWorld.decode_bytes(replaced)
+
+
+def test_is_global_variable_identifies_variable_starting_with_app(base_world):
+    global_variable_owner = AppConfigGlobalVariableIdentifier()
+    assert global_variable_owner.is_global_variable('app.foo')
+    assert global_variable_owner.is_global_variable('app.bar')
+
+
+def test_is_global_variable_identifies_variable_ignores_non_config_key(base_world):
+    global_variable_owner = AppConfigGlobalVariableIdentifier()
+
+    # Starts with 'app.' but not a configuration key
+    assert global_variable_owner.is_global_variable('app.this.does.not.exist') is False
+
+
+def test_is_global_variable_identifies_variable_ignores_config_keys_not_starting_with_app(base_world):
+    global_variable_owner = AppConfigGlobalVariableIdentifier()
+
+    # Is a config item but doesn't start with 'app.'
+    assert global_variable_owner.is_global_variable('auth.baz') is False


### PR DESCRIPTION
## Description
Global variables like `#{server}` are reserved and should not be replaced by discovered facts. The recent changes to variable naming conventions (not requiring `a.b.c` structure) necessitates more protections around global variable handling.

This PR updates the base planning service to allow classes to be registered as "global variable owners", which can identify a global variable. For example, the `Agent` class owns the variable `server` and `Link` owns `origin_link_id`.

Documentation changes will be made in another PR

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
* All tests pass
* Added unit tests for desired behaviors
* Manually ran an operation and verified:
    * Facts did not replace `#{origin_link_id}` (the value was the actual Link id)
    * Facts can be set for non-configured `app.*` variables

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
