### PR TITLE
Making sure local ssh config isn't loaded during tests

### DIFF
--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -48,7 +48,7 @@ class TestContactSsh:
     def test_tunnel(self, loop, ssh_contact):
         loop.run_until_complete(ssh_contact.start())
         conn = loop.run_until_complete(asyncssh.connect('localhost', port=8122, known_hosts=None, username='sandcat',
-                                                        password='s4ndc4t!'))
+                                                        password='s4ndc4t!', config=None))
         assert conn and conn.get_extra_info('username') == 'sandcat'
         listener = loop.run_until_complete(conn.forward_local_port('', 61234, 'localhost', 8888))
         assert listener and listener.get_port() == 61234


### PR DESCRIPTION
## Description
Fixing bug where SSH tunneling test will fail if the user has an SSH config file in `~/.ssh/config` and CALDERA can't load it properly. The test will now explicitly ignore any local SSH configuration files.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with an invalid local SSH config file - verified that the test failed before applying the fix, and that the test passes after applying the fix.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
