### PR TITLE
File encoding

### DIFF
--- a/app/data_encoders/base64_basic.py
+++ b/app/data_encoders/base64_basic.py
@@ -1,0 +1,20 @@
+from base64 import b64encode, b64decode
+
+from app.objects.c_data_encoder import DataEncoder
+
+
+def load():
+    return Base64Encoder()
+
+
+class Base64Encoder(DataEncoder):
+    def __init__(self):
+        super().__init__('base64', 'Encodes and decodes data in base64')
+
+    def encode(self, data, **_):
+        """Returns base64 encoded data."""
+        return b64encode(data)
+
+    def decode(self, encoded_data, **_):
+        """Returns b64 decoded bytes."""
+        return b64decode(encoded_data)

--- a/app/data_encoders/plain_text.py
+++ b/app/data_encoders/plain_text.py
@@ -1,0 +1,17 @@
+from app.objects.c_data_encoder import DataEncoder
+
+
+def load():
+    return PlainTextEncoder()
+
+
+class PlainTextEncoder(DataEncoder):
+    def __init__(self):
+        super().__init__('plain-text',
+                         'Does not encode or decode data at all, instead keeps it in plain text form')
+
+    def encode(self, data, **_):
+        return data
+
+    def decode(self, encoded_data, **_):
+        return encoded_data

--- a/app/objects/c_data_encoder.py
+++ b/app/objects/c_data_encoder.py
@@ -1,0 +1,41 @@
+from abc import abstractmethod
+
+import marshmallow as ma
+
+from app.objects.interfaces.i_object import FirstClassObjectInterface
+from app.utility.base_object import BaseObject
+
+
+class DataEncoderSchema(ma.Schema):
+    name = ma.fields.String()
+    description = ma.fields.String()
+    module = ma.fields.String()
+
+
+class DataEncoder(FirstClassObjectInterface, BaseObject):
+    schema = DataEncoderSchema()
+    display_schema = DataEncoderSchema(exclude=['module'])
+
+    @property
+    def unique(self):
+        return self.hash('%s' % self.name)
+
+    def __init__(self, name, description):
+        super().__init__()
+        self.name = name
+        self.description = description
+
+    def store(self, ram):
+        existing = self.retrieve(ram['data_encoders'], self.unique)
+        if not existing:
+            ram['data_encoders'].append(self)
+            return self.retrieve(ram['data_encoders'], self.unique)
+        return existing
+
+    @abstractmethod
+    def encode(self, data, **_):
+        pass
+
+    @abstractmethod
+    def decode(self, data, **_):
+        pass

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -42,7 +42,7 @@ class DataService(DataServiceInterface, BaseService):
     def __init__(self):
         self.log = self.add_service('data_svc', self)
         self.schema = dict(agents=[], planners=[], adversaries=[], abilities=[], sources=[], operations=[],
-                           schedules=[], plugins=[], obfuscators=[], objectives=[])
+                           schedules=[], plugins=[], obfuscators=[], objectives=[], data_encoders=[])
         self.ram = copy.deepcopy(self.schema)
 
     @staticmethod
@@ -235,6 +235,7 @@ class DataService(DataServiceInterface, BaseService):
             for task in async_tasks:
                 await task
             await self._load_extensions()
+            await self._load_data_encoders(plugins)
             await self._verify_data_sets()
         except Exception as e:
             self.log.debug(repr(e), exc_info=True)
@@ -297,6 +298,15 @@ class DataService(DataServiceInterface, BaseService):
             if await packer.check_dependencies(self.get_service('app_svc')):
                 plug_packers[packer.name] = packer
         self.get_service('file_svc').packers.update(plug_packers)
+
+    async def _load_data_encoders(self, plugins):
+        glob_paths = ['app/data_encoders/**.py'] + \
+                     ['plugins/%s/app/data_encoders/**.py' % plugin.name for plugin in plugins]
+        for glob_path in glob_paths:
+            for module_path in glob.iglob(glob_path):
+                imported_module = import_module(module_path.replace('/', '.').replace('\\', '.').replace('.py', ''))
+                encoder = imported_module.load()
+                await self.store(encoder)
 
     async def _create_ability(self, ability_id, tactic=None, technique_name=None, technique_id=None, name=None,
                               test=None, description=None, executor=None, platform=None, cleanup=None, payloads=None,

--- a/tests/objects/test_data_encoder.py
+++ b/tests/objects/test_data_encoder.py
@@ -1,0 +1,53 @@
+import pytest
+
+from base64 import b64encode
+
+from app.data_encoders.plain_text import PlainTextEncoder
+from app.data_encoders.base64_basic import Base64Encoder
+
+
+@pytest.fixture
+def plaintext_encoder():
+    return PlainTextEncoder()
+
+
+@pytest.fixture
+def base64_encoder():
+    return Base64Encoder()
+
+
+@pytest.fixture
+def setup_data_encoders(loop, data_svc, plaintext_encoder, base64_encoder):
+    loop.run_until_complete(data_svc.store(plaintext_encoder))
+    loop.run_until_complete(data_svc.store(base64_encoder))
+
+
+@pytest.mark.usefixtures(
+    'setup_data_encoders'
+)
+class TestDataEncoders:
+    def test_retrieval(self, loop, data_svc):
+        results = loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='plain-text')))
+        assert len(results) == 1
+        plaintext_encoder = results[0]
+        assert plaintext_encoder and isinstance(plaintext_encoder, PlainTextEncoder)
+
+        results = loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='base64')))
+        assert len(results) == 1
+        base64_encoder = results[0]
+        assert base64_encoder and isinstance(base64_encoder, Base64Encoder)
+
+    def test_plaintext_encoding(self, plaintext_encoder):
+        data = b'this will be encoded/decoded in plaintext'
+        encoded = plaintext_encoder.encode(data)
+        assert encoded == data
+        decoded = plaintext_encoder.decode(encoded)
+        assert decoded == data
+
+    def test_base64_encoding(self, base64_encoder):
+        data = b'this will be encoded/decoded in base64'
+        encoded = base64_encoder.encode(data)
+        expected_encoded = b64encode(data)
+        assert encoded == expected_encoded
+        decoded = base64_encoder.decode(encoded)
+        assert decoded == data

--- a/tests/objects/test_data_encoder.py
+++ b/tests/objects/test_data_encoder.py
@@ -17,9 +17,8 @@ def base64_encoder():
 
 
 @pytest.fixture
-def setup_data_encoders(loop, data_svc, plaintext_encoder, base64_encoder):
-    loop.run_until_complete(data_svc.store(plaintext_encoder))
-    loop.run_until_complete(data_svc.store(base64_encoder))
+def setup_data_encoders(loop, data_svc):
+    loop.run_until_complete(data_svc._load_data_encoders([]))
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
## Description
Part 1/N for setting up file encoding framework.

Adds new first-class object that will be stored by the data service - `DataEncoder`. Python classes extending this object must implement the `encode` and `decode` methods, which handle data encoding/decoding. See `app/data_encoders/` for examples. `app/data_encoders/` contains `plain-text` and `base64` encoders to start with. The data service will load encoders in `app/data_encoders/` as well as any encoders in `plugins/plugin_name/app/data_encoders/` if available.

Future PRs will use these data encoders as part of operations to encode/decode payloads and file uploads.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (will update documentation once the data encoders actually start getting used in operations)

## How Has This Been Tested?
Added tests to verify encoder retrieval from data service and to verify encoding/decoding functionality for the plaintext and base64 encoders.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
