### PR TITLE
Set explicit docutils version for broken bullet list bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pyyaml>=5.1
 cryptography>=3.2
 websockets==8.1
 Sphinx==3.0.4
+docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 sphinx_rtd_theme==0.4.3
 recommonmark==0.6.0
 marshmallow==3.5.1


### PR DESCRIPTION
## Description

Set explicit docutils version for broken bullet list bug

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Fieldmanual sphinx docs don't load bullet lists correctly. Explicitly setting docutils version fixes this.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
