### PR TITLE
Adding file encoding/decoding capability to file service

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -56,9 +56,12 @@ class FileSvc(FileServiceInterface, BaseService):
         if headers.get('name'):
             display_name = headers.get('name')
         display_name = self.remove_xored_extension(file_path)
+        contents = await self._perform_data_encoding(headers, contents)
         return file_path, contents, display_name
 
-    async def save_file(self, filename, payload, target_dir, encrypt=True):
+    async def save_file(self, filename, payload, target_dir, encrypt=True, encoding=None):
+        if encoding:
+            payload = await self._decode_contents(payload, encoding)
         self._save(os.path.join(target_dir, filename), payload, encrypt)
 
     async def create_exfil_sub_directory(self, dir_name):
@@ -70,12 +73,14 @@ class FileSvc(FileServiceInterface, BaseService):
     async def save_multipart_file_upload(self, request, target_dir):
         try:
             reader = await request.multipart()
+            headers = CIMultiDict(request.headers)
             while True:
                 field = await reader.next()
                 if not field:
                     break
                 _, filename = os.path.split(field.filename)
-                await self.save_file(filename, bytes(await field.read()), target_dir)
+                await self.save_file(filename, bytes(await field.read()), target_dir,
+                                     encoding=headers.get('x-file-encoding'))
                 self.log.debug('Uploaded file %s/%s' % (target_dir, filename))
             return web.Response()
         except Exception as e:
@@ -225,6 +230,37 @@ class FileSvc(FileServiceInterface, BaseService):
             return await self.special_payloads[target](self.get_services(), headers)
         except Exception as e:
             self.log.error('Error loading extension handler=%s, %s' % (payload, e))
+
+    async def _perform_data_encoding(self, headers, contents):
+        requested_encoding = headers.get('x-file-encoding')
+        if requested_encoding:
+            return await self._encode_contents(contents, requested_encoding)
+        return contents
+
+    async def _get_encoder_by_name(self, encoding):
+        if encoding:
+            encoders = await self.data_svc.locate('data_encoders', match=dict(name=encoding))
+            if encoders:
+                return encoders[0]
+        self.log.error('Could not find the requested data encoder %s' % encoding)
+
+    async def _encode_contents(self, contents, encoder_name):
+        self.log.debug('Encoding file contents using %s encoding' % encoder_name)
+        encoder = await self._get_encoder_by_name(encoder_name)
+        if encoder:
+            return encoder.encode(contents)
+        else:
+            self.log.error('Failed to encode contents. Returning original contents')
+            return contents
+
+    async def _decode_contents(self, contents, encoder_name):
+        self.log.debug('Decoding file contents using %s encoding' % encoder_name)
+        encoder = await self._get_encoder_by_name(encoder_name)
+        if encoder:
+            return encoder.decode(contents)
+        else:
+            self.log.error('Failed to decode contents. Returning original contents')
+            return contents
 
 
 def _go_vars(arch, platform):


### PR DESCRIPTION
## Description
Users can now request encoded payloads from the file service, and the file service can decode encoded uploads. Use the `x-file-encoding` http header to specify encoding mechanisms for payload downloads and file uploads. The specified mechanism name must match the name of a valid existing `DataEncoder` object (currently, only `plain-text` and `base64` are supported).

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Created tests to verify file service payload encoding and upload decoding functionality.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
