### PR TITLE
[VIRTS-2003] Planner API v2

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -18,4 +18,7 @@ def make_app(services):
     from .handlers.config_api import ConfigApi
     ConfigApi(services).add_routes(app)
 
+    from .handlers.planner_api import PlannerApi
+    PlannerApi(services).add_routes(app)
+
     return app

--- a/app/api/v2/handlers/config_api.py
+++ b/app/api/v2/handlers/config_api.py
@@ -9,7 +9,7 @@ from app.api.v2.managers.config_api_manager import ConfigApiManager, ConfigNotFo
 
 class ConfigApi(BaseApi):
     def __init__(self, services):
-        super().__init__()
+        super().__init__(auth_svc=services['auth_svc'])
         self._api_manager = ConfigApiManager(data_svc=services['data_svc'])
 
     def add_routes(self, app: web.Application):

--- a/app/api/v2/handlers/health_api.py
+++ b/app/api/v2/handlers/health_api.py
@@ -11,7 +11,7 @@ from app.api.v2.schemas.caldera_info_schemas import CalderaInfoSchema
 
 class HealthApi(BaseApi):
     def __init__(self, services):
-        super().__init__()
+        super().__init__(auth_svc=services['auth_svc'])
         self._app_svc = services['app_svc']
 
     def add_routes(self, app: web.Application):

--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -1,0 +1,46 @@
+import aiohttp_apispec
+from aiohttp import web
+
+from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.api.v2.responses import JsonHttpNotFound
+from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
+from app.objects.c_planner import PlannerSchema
+
+
+class PlannerApi(BaseApi):
+    def __init__(self, services):
+        super().__init__(auth_svc=services['auth_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+
+    def add_routes(self, app: web.Application):
+        router = app.router
+        router.add_get('/planners', self.get_planners)
+        router.add_get('/planners/{planner_id}', self.get_planner_by_id)
+
+    @aiohttp_apispec.docs(tags=['planners'])
+    @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
+    @aiohttp_apispec.response_schema(PlannerSchema(many=True))
+    async def get_planners(self, request: web.Request):
+        sort = request['querystring'].get('sort', 'name')
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        planners = self._api_manager.get_objects_with_filters('planners', sort=sort, include=include, exclude=exclude)
+        return web.json_response(planners)
+
+    @aiohttp_apispec.docs(tags=['planners'])
+    @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
+    @aiohttp_apispec.response_schema(PlannerSchema)
+    async def get_planner_by_id(self, request: web.Request):
+        planner_id = request.match_info['planner_id']
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        search = dict(planner_id=planner_id)
+
+        planner = self._api_manager.get_object_with_filters('planners', search=search, include=include, exclude=exclude)
+        if not planner:
+            raise JsonHttpNotFound(f'Planner not found: {planner_id}')
+
+        return web.json_response(planner)

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -31,7 +31,7 @@ class BaseApiManager:
         dumped = obj.display
         if include:
             exclude_attributes = list(set(dumped.keys()) - set(include))
-            exclude = list(set(exclude + exclude_attributes)) if exclude else exclude_attributes
+            exclude = set(exclude + exclude_attributes) if exclude else exclude_attributes
         if exclude:
             for exclude_attribute in exclude:
                 dumped.pop(exclude_attribute, None)

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -28,7 +28,6 @@ class BaseApiManager:
 
     @staticmethod
     def dump_with_include_exclude(obj, include: List[str] = None, exclude: List[str] = None):
-        obj.schema.dump(obj)
         dumped = obj.display
         if include:
             exclude_attributes = list(set(dumped.keys()) - set(include))

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -1,0 +1,43 @@
+import logging
+from typing import List
+
+
+DEFAULT_LOGGER_NAME = 'rest_api_manager'
+
+
+class BaseApiManager:
+    def __init__(self, data_svc, logger=None):
+        self._data_svc = data_svc
+        self._log = logger or self._create_default_logger()
+
+    @property
+    def log(self):
+        return self._log
+
+    def get_objects_with_filters(self, object_name: str, search: dict = None, sort: str = None, include: List[str] = None,
+                                 exclude: List[str] = None):
+        objs = [self.dump_with_include_exclude(obj, include, exclude) for obj in self._data_svc.ram[object_name]
+                if not search or obj.match(search)]
+        return sorted(objs, key=lambda p: p.get(sort, 0))
+
+    def get_object_with_filters(self, object_name: str, search: dict = None, include: List[str] = None,
+                                exclude: List[str] = None):
+        for obj in self._data_svc.ram[object_name]:
+            if not search or obj.match(search):
+                return self.dump_with_include_exclude(obj, include, exclude)
+
+    @staticmethod
+    def dump_with_include_exclude(obj, include: List[str] = None, exclude: List[str] = None):
+        obj.schema.dump(obj)
+        dumped = obj.display
+        if include:
+            exclude_attributes = list(set(dumped.keys()) - set(include))
+            exclude = list(set(exclude + exclude_attributes)) if exclude else exclude_attributes
+        if exclude:
+            for exclude_attribute in exclude:
+                dumped.pop(exclude_attribute, None)
+        return dumped
+
+    @staticmethod
+    def _create_default_logger():
+        return logging.getLogger(DEFAULT_LOGGER_NAME)

--- a/app/api/v2/managers/config_api_manager.py
+++ b/app/api/v2/managers/config_api_manager.py
@@ -1,7 +1,7 @@
-import logging
 from typing import List
 
 from app.api.v2 import validation
+from app.api.v2.managers.base_api_manager import BaseApiManager
 from app.utility.base_world import BaseWorld
 
 
@@ -50,11 +50,10 @@ class ConfigNotFound(Exception):
         self.config_name = config_name
 
 
-class ConfigApiManager:
+class ConfigApiManager(BaseApiManager):
     def __init__(self, data_svc, config_interface=None):
+        super().__init__(data_svc=data_svc)
         self._config_interface = config_interface or BaseWorld
-        self._data_svc = data_svc
-        self._log = logging.getLogger('config_api_manager')
 
     def get_filtered_config(self, name):
         """Return the configuration for the input `name` with sensitive fields removed."""
@@ -125,6 +124,6 @@ class ConfigApiManager:
             elif ability_id in loaded_ability_ids:
                 abilities_to_set.append(ability_id)
             else:
-                self._log.debug('Could not find ability with id "%s"', ability_id)
+                self.log.debug('Could not find ability with id "%s"', ability_id)
 
         self._config_interface.set_config(name='agents', prop=prop, value=abilities_to_set)

--- a/app/api/v2/schemas/base_schemas.py
+++ b/app/api/v2/schemas/base_schemas.py
@@ -1,0 +1,13 @@
+from marshmallow import fields
+from marshmallow import schema
+
+
+class BaseGetAllQuerySchema(schema.Schema):
+    sort = fields.String(required=False)
+    include = fields.List(fields.String, required=False)
+    exclude = fields.List(fields.String, required=False)
+
+
+class BaseGetOneQuerySchema(schema.Schema):
+    include = fields.List(fields.String, required=False)
+    exclude = fields.List(fields.String, required=False)

--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -25,7 +25,7 @@ class PlannerSchema(ma.Schema):
 class Planner(FirstClassObjectInterface, BaseObject):
 
     schema = PlannerSchema()
-    display_schema = PlannerSchema(exclude=['planner_id', 'ignore_enforcement_modules'])
+    display_schema = PlannerSchema(exclude=['module', 'ignore_enforcement_modules'])
 
     @property
     def unique(self):

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 import aiohttp_apispec
+from aiohttp_apispec import validation_middleware
 from aiohttp import web
 
 import app.api.v2
@@ -81,6 +82,7 @@ def init_swagger_documentation(app):
         url="/api/docs/swagger.json",
         static_path="/static/swagger"
     )
+    app.middlewares.append(validation_middleware)
 
 
 if __name__ == '__main__':

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -1,0 +1,123 @@
+from app.api.v2.managers.base_api_manager import BaseApiManager
+
+
+class StubDataService:
+    def __init__(self):
+        self.ram = {}
+
+
+def test_dump(data_svc, agent):
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent)
+
+    for key in manager_dumped_agent:
+        assert manager_dumped_agent[key] == dumped_agent[key]
+
+
+def test_dump_with_exclude(data_svc, agent):
+    exclude_key = 'paw'
+
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, exclude=[exclude_key])
+
+    assert exclude_key in dumped_agent
+    assert exclude_key not in manager_dumped_agent
+    for key in manager_dumped_agent:
+        assert manager_dumped_agent[key] == dumped_agent[key]
+
+
+def test_dump_with_include(data_svc, agent):
+    include_key = 'paw'
+
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, include=[include_key])
+
+    assert include_key in dumped_agent
+    assert include_key in manager_dumped_agent
+    assert len(manager_dumped_agent.keys()) == 1
+    assert manager_dumped_agent[include_key] == dumped_agent[include_key]
+
+
+def test_get_objects(agent):
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0)
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    dumped_agents = manager.get_objects_with_filters('agents')
+
+    assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
+
+
+def test_get_objects_with_search(agent):
+    search_property = 'sleep_min'
+    search_value = 2
+
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent3', sleep_min=3, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    dumped_agents = manager.get_objects_with_filters('agents', search=search)
+
+    assert len(dumped_agents) == 2
+    for dumped_agent in dumped_agents:
+        assert dumped_agent[search_property] == search_value
+
+
+def test_get_objects_with_sort(agent):
+    sort_property = 'paw'
+
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent5', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent3', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent4', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    dumped_agents = manager.get_objects_with_filters('agents', sort=sort_property)
+
+    assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
+    prev_paw = None
+    for dumped_agent in dumped_agents:
+        assert not prev_paw or dumped_agent[sort_property] > prev_paw
+        prev_paw = dumped_agent[sort_property]
+
+
+def test_get_object(agent):
+    search_property = 'paw'
+    search_value = 'agent0'
+
+    test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        test_agent,
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    dumped_agent = manager.get_object_with_filters('agents', search=search)
+
+    assert dumped_agent == test_agent.display


### PR DESCRIPTION
## Description

Adds a new API endpoint for retrieving planner(s).

Looking for strong feelings on some choices here before we keep building these endpoints out:

- Schemas are pulled from the current objects, but any new schemas required (ex: config) are being created in `app/api/v2/schemas`. This will keep some distinction between object schemas and those required for certain API requests.
- In `BaseApiManager`, we'll use `obj.display` instead of `obj.schema.dump(obj)`, allowing the object to explicitly exclude fields for display. We could enforce these rules in the API, but it felt like that might be duplicating work.
- `BaseApi.get_request_permissions` was added, but is unused in this PR. Planner permissions are mapped to plugins, but all plugins that add planners (Stockpile) are given RED access. Blue operators would be unable to see/use planners if permissions were checked. This workaround is used when populating data for the current `operations.html`.
  - This also means `BaseApi` must have access to `auth_svc`, blurring the api / manager split. The alternative is to pass the request to the manager, also blurring the line.
  - Also, attempting to access an object without proper authorization will result in a 404. This makes the search more efficient, doing a single search for criteria instead of one search for id and another for access.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Make GET requests to the following as a logged-in user (red or blue):

- `/api/v2/planners`
- `/api/v2/planners/788107d5-dc1e-4204-9269-38df0186d3e7` (batch planner)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
