### PR TITLE
[VIRTS-1996,1997,2001,2006] API Additions

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -21,4 +21,7 @@ def make_app(services):
     from .handlers.planner_api import PlannerApi
     PlannerApi(services).add_routes(app)
 
+    from .handlers.fact_source_api import FactSourceApi
+    FactSourceApi(services).add_routes(app)
+
     return app

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -27,4 +27,7 @@ def make_app(services):
     from .handlers.objective_api import ObjectiveApi
     ObjectiveApi(services).add_routes(app)
 
+    from .handlers.adversary_api import AdversaryApi
+    AdversaryApi(services).add_routes(app)
+
     return app

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -24,4 +24,7 @@ def make_app(services):
     from .handlers.fact_source_api import FactSourceApi
     FactSourceApi(services).add_routes(app)
 
+    from .handlers.objective_api import ObjectiveApi
+    ObjectiveApi(services).add_routes(app)
+
     return app

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -30,4 +30,7 @@ def make_app(services):
     from .handlers.adversary_api import AdversaryApi
     AdversaryApi(services).add_routes(app)
 
+    from .handlers.agent_api import AgentApi
+    AgentApi(services).add_routes(app)
+
     return app

--- a/app/api/v2/handlers/adversary_api.py
+++ b/app/api/v2/handlers/adversary_api.py
@@ -1,0 +1,130 @@
+import aiohttp_apispec
+from aiohttp import web
+
+from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.managers.adversary_api_manager import AdversaryApiManager
+from app.api.v2.responses import JsonHttpBadRequest, JsonHttpForbidden, JsonHttpNotFound
+from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
+from app.objects.c_adversary import AdversarySchema
+
+
+class AdversaryApi(BaseApi):
+    def __init__(self, services):
+        super().__init__(auth_svc=services['auth_svc'])
+        self._api_manager = AdversaryApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
+
+    def add_routes(self, app: web.Application):
+        router = app.router
+        router.add_get('/adversaries', self.get_adversaries)
+        router.add_get('/adversaries/{adversary_id}', self.get_adversary_by_id)
+        router.add_post('/adversaries', self.create_adversary)
+        router.add_patch('/adversaries/{adversary_id}', self.update_adversary)
+        router.add_put('/adversaries/{adversary_id}', self.create_or_update_adversary)
+        router.add_delete('/adversaries/{adversary_id}', self.delete_adversary)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema(many=True, partial=True))
+    async def get_adversaries(self, request: web.Request):
+        sort = request['querystring'].get('sort', 'name')
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+
+        adversaries = self._api_manager.find_and_dump_objects('adversaries', access, sort, include, exclude)
+        return web.json_response(adversaries)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema(partial=True))
+    async def get_adversary_by_id(self, request: web.Request):
+        adversary_id = request.match_info['adversary_id']
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+        query = dict(adversary_id=adversary_id)
+        search = {**query, **access}
+
+        adversary = self._api_manager.find_and_dump_object('adversaries', search, include, exclude)
+        if not adversary:
+            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
+
+        return web.json_response(adversary)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.request_schema(AdversarySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema)
+    async def create_adversary(self, request: web.Request):
+        adversary_data = await request.json()
+        access = await self.get_request_permissions(request)
+
+        adversary_id = adversary_data.get('adversary_id')
+        if adversary_id:
+            search = dict(adversary_id=adversary_id)
+            search_adversary = next(self._api_manager.find_objects('adversaries', search), None)
+            if search_adversary is not None:
+                raise JsonHttpBadRequest(f'An adversary exists with the given id: {adversary_id}')
+
+        adversary = await self._api_manager.create_adversary(adversary_data, access)
+        return web.json_response(adversary.display)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
+    @aiohttp_apispec.response_schema(AdversarySchema)
+    async def update_adversary(self, request: web.Request):
+        adversary_id = request.match_info['adversary_id']
+        adversary_data = await request.json()
+        adversary_data['adversary_id'] = adversary_id
+
+        access = await self.get_request_permissions(request)
+        query = dict(adversary_id=adversary_id)
+        search = {**query, **access}
+
+        adversary = await self._api_manager.update_adversary(adversary_data, search)
+        if not adversary:
+            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
+
+        return web.json_response(adversary.display)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
+    @aiohttp_apispec.response_schema(AdversarySchema)
+    async def create_or_update_adversary(self, request: web.Request):
+        adversary_id = request.match_info['adversary_id']
+        adversary_data = await request.json()
+        adversary_data['adversary_id'] = adversary_id
+
+        access = await self.get_request_permissions(request)
+        search = dict(adversary_id=adversary_id)
+
+        search_adversary = next(self._api_manager.find_objects('adversaries', search), None)
+        if search_adversary is None:
+            adversary = await self._api_manager.create_adversary(adversary_data, access)
+        else:
+            if search_adversary.access in access['access']:
+                adversary = await self._api_manager.replace_adversary(search_adversary, adversary_data)
+            else:
+                raise JsonHttpForbidden(f'Cannot update adversary due to insufficient permissions: {adversary_id}')
+
+        return web.json_response(adversary.display)
+
+    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.response_schema(AdversarySchema)
+    async def delete_adversary(self, request: web.Request):
+        adversary_id = request.match_info['adversary_id']
+
+        access = await self.get_request_permissions(request)
+        query = dict(adversary_id=adversary_id)
+        search = {**query, **access}
+
+        adversary = self._api_manager.find_and_dump_object('adversaries', search)
+        if not adversary:
+            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
+
+        await self._api_manager.remove_object_from_memory_by_id(ram_key='adversaries', id_value=adversary_id,
+                                                                id_attribute='adversary_id')
+        await self._api_manager.remove_object_from_disk_by_id(ram_key='adversaries', id_value=adversary_id)
+
+        return web.HTTPNoContent()

--- a/app/api/v2/handlers/adversary_api.py
+++ b/app/api/v2/handlers/adversary_api.py
@@ -1,16 +1,16 @@
 import aiohttp_apispec
 from aiohttp import web
 
-from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.handlers.base_object_api import BaseObjectApi
 from app.api.v2.managers.adversary_api_manager import AdversaryApiManager
-from app.api.v2.responses import JsonHttpBadRequest, JsonHttpForbidden, JsonHttpNotFound
 from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
-from app.objects.c_adversary import AdversarySchema
+from app.objects.c_adversary import Adversary, AdversarySchema
 
 
-class AdversaryApi(BaseApi):
+class AdversaryApi(BaseObjectApi):
     def __init__(self, services):
-        super().__init__(auth_svc=services['auth_svc'])
+        super().__init__(description='adversary', obj_class=Adversary, schema=AdversarySchema, ram_key='adversaries',
+                         id_property='adversary_id', auth_svc=services['auth_svc'])
         self._api_manager = AdversaryApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
@@ -26,105 +26,42 @@ class AdversaryApi(BaseApi):
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
     @aiohttp_apispec.response_schema(AdversarySchema(many=True, partial=True))
     async def get_adversaries(self, request: web.Request):
-        sort = request['querystring'].get('sort', 'name')
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-
-        adversaries = self._api_manager.find_and_dump_objects('adversaries', access, sort, include, exclude)
+        adversaries = await self.get_all_objects(request)
         return web.json_response(adversaries)
 
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
     @aiohttp_apispec.response_schema(AdversarySchema(partial=True))
     async def get_adversary_by_id(self, request: web.Request):
-        adversary_id = request.match_info['adversary_id']
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-        query = dict(adversary_id=adversary_id)
-        search = {**query, **access}
-
-        adversary = self._api_manager.find_and_dump_object('adversaries', search, include, exclude)
-        if not adversary:
-            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
-
+        adversary = await self.get_object(request)
         return web.json_response(adversary)
 
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.request_schema(AdversarySchema)
     @aiohttp_apispec.response_schema(AdversarySchema)
     async def create_adversary(self, request: web.Request):
-        adversary_data = await request.json()
-        access = await self.get_request_permissions(request)
-
-        adversary_id = adversary_data.get('adversary_id')
-        if adversary_id:
-            search = dict(adversary_id=adversary_id)
-            search_adversary = next(self._api_manager.find_objects('adversaries', search), None)
-            if search_adversary is not None:
-                raise JsonHttpBadRequest(f'An adversary exists with the given id: {adversary_id}')
-
-        adversary = await self._api_manager.create_adversary(adversary_data, access)
+        adversary = await self.create_on_disk_object(request)
+        adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
     @aiohttp_apispec.response_schema(AdversarySchema)
     async def update_adversary(self, request: web.Request):
-        adversary_id = request.match_info['adversary_id']
-        adversary_data = await request.json()
-        adversary_data['adversary_id'] = adversary_id
-
-        access = await self.get_request_permissions(request)
-        query = dict(adversary_id=adversary_id)
-        search = {**query, **access}
-
-        adversary = await self._api_manager.update_adversary(adversary_data, search)
-        if not adversary:
-            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
-
+        adversary = await self.update_on_disk_object(request)
+        adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
     @aiohttp_apispec.response_schema(AdversarySchema)
     async def create_or_update_adversary(self, request: web.Request):
-        adversary_id = request.match_info['adversary_id']
-        adversary_data = await request.json()
-        adversary_data['adversary_id'] = adversary_id
-
-        access = await self.get_request_permissions(request)
-        search = dict(adversary_id=adversary_id)
-
-        search_adversary = next(self._api_manager.find_objects('adversaries', search), None)
-        if search_adversary is None:
-            adversary = await self._api_manager.create_adversary(adversary_data, access)
-        else:
-            if search_adversary.access in access['access']:
-                adversary = await self._api_manager.replace_adversary(search_adversary, adversary_data)
-            else:
-                raise JsonHttpForbidden(f'Cannot update adversary due to insufficient permissions: {adversary_id}')
-
+        adversary = await self.create_or_update_on_disk_object(request)
+        adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.response_schema(AdversarySchema)
     async def delete_adversary(self, request: web.Request):
-        adversary_id = request.match_info['adversary_id']
-
-        access = await self.get_request_permissions(request)
-        query = dict(adversary_id=adversary_id)
-        search = {**query, **access}
-
-        adversary = self._api_manager.find_and_dump_object('adversaries', search)
-        if not adversary:
-            raise JsonHttpNotFound(f'Adversary not found: {adversary_id}')
-
-        await self._api_manager.remove_object_from_memory_by_id(ram_key='adversaries', id_value=adversary_id,
-                                                                id_attribute='adversary_id')
-        await self._api_manager.remove_object_from_disk_by_id(ram_key='adversaries', id_value=adversary_id)
-
+        await self.delete_on_disk_object(request)
         return web.HTTPNoContent()

--- a/app/api/v2/handlers/agent_api.py
+++ b/app/api/v2/handlers/agent_api.py
@@ -1,0 +1,74 @@
+import aiohttp_apispec
+from aiohttp import web
+
+from app.api.v2.handlers.base_object_api import BaseObjectApi
+from app.api.v2.managers.agent_api_manager import AgentApiManager
+from app.api.v2.schemas.deploy_command_schemas import DeployCommandsSchema
+from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
+from app.objects.c_agent import Agent, AgentSchema
+
+
+class AgentApi(BaseObjectApi):
+    def __init__(self, services):
+        super().__init__(description='agent', obj_class=Agent, schema=AgentSchema, ram_key='agents',
+                         id_property='paw', auth_svc=services['auth_svc'])
+        self._api_manager = AgentApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
+
+    def add_routes(self, app: web.Application):
+        router = app.router
+        router.add_get('/agents', self.get_agents)
+        router.add_get('/agents/{paw}', self.get_agent_by_id)
+        router.add_post('/agents', self.create_agent)
+        router.add_patch('/agents/{paw}', self.update_agent)
+        router.add_put('/agents/{paw}', self.create_or_update_agent)
+        router.add_delete('/agents/{paw}', self.delete_agent)
+
+        router.add_get('/deploy_commands/{ability_id}', self.get_deploy_commands)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
+    @aiohttp_apispec.response_schema(AgentSchema(many=True, partial=True))
+    async def get_agents(self, request: web.Request):
+        agents = await self.get_all_objects(request)
+        return web.json_response(agents)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
+    @aiohttp_apispec.response_schema(AgentSchema(partial=True))
+    async def get_agent_by_id(self, request: web.Request):
+        agent = await self.get_object(request)
+        return web.json_response(agent)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.request_schema(AgentSchema)
+    @aiohttp_apispec.response_schema(AgentSchema)
+    async def create_agent(self, request: web.Request):
+        agent = await self.create_object(request)
+        return web.json_response(agent.display)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.request_schema(AgentSchema(partial=True))
+    @aiohttp_apispec.response_schema(AgentSchema)
+    async def update_agent(self, request: web.Request):
+        agent = await self.update_object(request)
+        return web.json_response(agent.display)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.request_schema(AgentSchema(partial=True))
+    @aiohttp_apispec.response_schema(AgentSchema)
+    async def create_or_update_agent(self, request: web.Request):
+        agent = await self.create_or_update_object(request)
+        return web.json_response(agent.display)
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.response_schema(AgentSchema)
+    async def delete_agent(self, request: web.Request):
+        await self.delete_object(request)
+        return web.HTTPNoContent()
+
+    @aiohttp_apispec.docs(tags=['agents'])
+    @aiohttp_apispec.response_schema(DeployCommandsSchema)
+    async def get_deploy_commands(self, request: web.Request):
+        ability_id = request.match_info.get('ability_id')
+        deploy_commands = await self._api_manager.get_deploy_commands(ability_id)
+        return web.json_response(deploy_commands)

--- a/app/api/v2/handlers/base_object_api.py
+++ b/app/api/v2/handlers/base_object_api.py
@@ -121,7 +121,7 @@ class BaseObjectApi(BaseApi):
 
     """DELETE"""
 
-    async def delete_on_disk_object(self, request: web.Request):
+    async def delete_object(self, request: web.Request):
         obj_id = request.match_info.get(self.id_property)
 
         access = await self.get_request_permissions(request)
@@ -131,9 +131,14 @@ class BaseObjectApi(BaseApi):
         if not self._api_manager.find_object(self.ram_key, search):
             raise JsonHttpNotFound(f'{self.description.capitalize()} not found: {obj_id}')
 
-        await self._api_manager.remove_object_from_memory_by_id(id_value=obj_id, ram_key=self.ram_key,
+        await self._api_manager.remove_object_from_memory_by_id(identifier=obj_id, ram_key=self.ram_key,
                                                                 id_property=self.id_property)
-        await self._api_manager.remove_object_from_disk_by_id(id_value=obj_id, ram_key=self.ram_key)
+
+    async def delete_on_disk_object(self, request: web.Request):
+        await self.delete_object(request)
+
+        obj_id = request.match_info.get(self.id_property)
+        await self._api_manager.remove_object_from_disk_by_id(identifier=obj_id, ram_key=self.ram_key)
 
     """Helpers"""
 

--- a/app/api/v2/handlers/base_object_api.py
+++ b/app/api/v2/handlers/base_object_api.py
@@ -1,0 +1,153 @@
+import abc
+
+from aiohttp import web
+
+from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.responses import JsonHttpBadRequest, JsonHttpForbidden, JsonHttpNotFound
+
+
+class BaseObjectApi(BaseApi):
+    def __init__(self, description, obj_class, schema, ram_key, id_property, auth_svc, logger=None):
+        super().__init__(auth_svc=auth_svc, logger=logger)
+
+        self.description = description
+        self.obj_class = obj_class
+        self.schema = schema
+        self.ram_key = ram_key
+        self.id_property = id_property
+
+        self._api_manager = None
+
+    @abc.abstractmethod
+    def add_routes(self, app: web.Application):
+        pass
+
+    """GET"""
+
+    async def get_all_objects(self, request: web.Request):
+        access = await self.get_request_permissions(request)
+
+        sort = request['querystring'].get('sort', 'name')
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        return self._api_manager.find_and_dump_objects(self.ram_key, access, sort, include, exclude)
+
+    async def get_object(self, request: web.Request):
+        data, access, obj_id, query, search = await self._parse_common_data_from_request(request)
+
+        obj = self._api_manager.find_object(self.ram_key, query)
+        if not obj:
+            raise JsonHttpNotFound(f'{self.description.capitalize()} not found: {obj_id}')
+        elif obj.access not in access['access']:
+            raise JsonHttpForbidden(f'Cannot view {self.description} due to insufficient permissions: {obj_id}')
+
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        return self._api_manager.dump_object_with_filters(obj, include, exclude)
+
+    """POST"""
+
+    async def create_object(self, request: web.Request):
+        data = await request.json()
+
+        await self._error_if_object_with_id_exists(data.get(self.id_property))
+
+        access = await self.get_request_permissions(request)
+        return self._api_manager.create_object_from_schema(self.schema, data, access)
+
+    async def create_on_disk_object(self, request: web.Request):
+        data = await request.json()
+
+        await self._error_if_object_with_id_exists(data.get(self.id_property))
+
+        access = await self.get_request_permissions(request)
+        obj = await self._api_manager.create_on_disk_object(data, access, self.ram_key, self.id_property,
+                                                            self.obj_class)
+        return obj
+
+    async def _error_if_object_with_id_exists(self, obj_id: str):
+        """Throw an error if an object (of the same type) exists with the given id"""
+        if obj_id:
+            search = {self.id_property: obj_id}
+            if self._api_manager.find_object(self.ram_key, search):
+                raise JsonHttpBadRequest(f'{self.description.capitalize()} with given id already exists: {obj_id}')
+
+    """PATCH"""
+
+    async def update_object(self, request: web.Request):
+        data, access, obj_id, query, search = await self._parse_common_data_from_request(request)
+
+        obj = self._api_manager.find_and_update_object(self.ram_key, data, search)
+        if not obj:
+            raise JsonHttpNotFound(f'{self.description.capitalize()} not found: {obj_id}')
+        return obj
+
+    async def update_on_disk_object(self, request: web.Request):
+        data, access, obj_id, query, search = await self._parse_common_data_from_request(request)
+
+        obj = await self._api_manager.find_and_update_on_disk_object(data, search, self.ram_key, self.id_property,
+                                                                     self.obj_class)
+        if not obj:
+            raise JsonHttpNotFound(f'{self.description.capitalize()} not found: {obj_id}')
+        return obj
+
+    """PUT"""
+
+    async def create_or_update_object(self, request: web.Request):
+        data, access, obj_id, query, search = await self._parse_common_data_from_request(request)
+
+        matched_obj = self._api_manager.find_object(self.ram_key, query)
+        if matched_obj and matched_obj.access not in access['access']:
+            raise JsonHttpForbidden(f'Cannot update {self.description} due to insufficient permissions: {obj_id}')
+
+        return self._api_manager.create_object_from_schema(self.schema, data, access)
+
+    async def create_or_update_on_disk_object(self, request: web.Request):
+        data, access, obj_id, query, search = await self._parse_common_data_from_request(request)
+
+        matched_obj = self._api_manager.find_object(self.ram_key, query)
+        if not matched_obj:
+            obj = await self._api_manager.create_on_disk_object(data, access, self.ram_key, self.id_property,
+                                                                self.obj_class)
+        else:
+            if matched_obj.access in access['access']:
+                obj = await self._api_manager.replace_on_disk_object(matched_obj, data, self.ram_key, self.id_property)
+            else:
+                raise JsonHttpForbidden(f'Cannot update {self.description} due to insufficient permissions: {obj_id}')
+
+        return obj
+
+    """DELETE"""
+
+    async def delete_on_disk_object(self, request: web.Request):
+        obj_id = request.match_info.get(self.id_property)
+
+        access = await self.get_request_permissions(request)
+        query = {self.id_property: obj_id}
+        search = {**query, **access}
+
+        if not self._api_manager.find_object(self.ram_key, search):
+            raise JsonHttpNotFound(f'{self.description.capitalize()} not found: {obj_id}')
+
+        await self._api_manager.remove_object_from_memory_by_id(id_value=obj_id, ram_key=self.ram_key,
+                                                                id_property=self.id_property)
+        await self._api_manager.remove_object_from_disk_by_id(id_value=obj_id, ram_key=self.ram_key)
+
+    """Helpers"""
+
+    async def _parse_common_data_from_request(self, request) -> (dict, dict, str, dict, dict):
+        data = {}
+        if request.body_exists:
+            data = await request.json()
+
+        obj_id = request.match_info.get(self.id_property, '')
+        if obj_id:
+            data[self.id_property] = obj_id
+
+        access = await self.get_request_permissions(request)
+        query = {self.id_property: obj_id}
+        search = {**query, **access}
+
+        return data, access, obj_id, query, search

--- a/app/api/v2/handlers/config_api.py
+++ b/app/api/v2/handlers/config_api.py
@@ -10,7 +10,7 @@ from app.api.v2.managers.config_api_manager import ConfigApiManager, ConfigNotFo
 class ConfigApi(BaseApi):
     def __init__(self, services):
         super().__init__(auth_svc=services['auth_svc'])
-        self._api_manager = ConfigApiManager(data_svc=services['data_svc'])
+        self._api_manager = ConfigApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -49,7 +49,7 @@ class FactSourceApi(BaseObjectApi):
         source = await self.update_on_disk_object(request)
         return web.json_response(source.display)
 
-    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.request_schema(SourceSchema(partial=True))
     @aiohttp_apispec.response_schema(SourceSchema)
     async def create_or_update_source(self, request: web.Request):

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -1,107 +1,57 @@
 import aiohttp_apispec
 from aiohttp import web
 
-from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.handlers.base_object_api import BaseObjectApi
 from app.api.v2.managers.base_api_manager import BaseApiManager
-from app.api.v2.responses import JsonHttpBadRequest, JsonHttpForbidden, JsonHttpNotFound
 from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
-from app.objects.c_source import SourceSchema
+from app.objects.c_source import Source, SourceSchema
 
 
-class FactSourceApi(BaseApi):
+class FactSourceApi(BaseObjectApi):
     def __init__(self, services):
-        super().__init__(auth_svc=services['auth_svc'])
+        super().__init__(description='fact source', obj_class=Source, schema=SourceSchema, ram_key='sources',
+                         id_property='id', auth_svc=services['auth_svc'])
         self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router
         router.add_get('/sources', self.get_fact_sources)
-        router.add_get('/sources/{source_id}', self.get_fact_source_by_id)
+        router.add_get('/sources/{id}', self.get_fact_source_by_id)
         router.add_post('/sources', self.create_fact_source)
-        router.add_patch('/sources/{source_id}', self.update_fact_source)
-        router.add_put('/sources/{source_id}', self.create_or_update_source)
+        router.add_patch('/sources/{id}', self.update_fact_source)
+        router.add_put('/sources/{id}', self.create_or_update_source)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
     @aiohttp_apispec.response_schema(SourceSchema(many=True, partial=True))
     async def get_fact_sources(self, request: web.Request):
-        sort = request['querystring'].get('sort', 'name')
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-
-        sources = self._api_manager.find_and_dump_objects('sources', access, sort, include, exclude)
+        sources = await self.get_all_objects(request)
         return web.json_response(sources)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
     @aiohttp_apispec.response_schema(SourceSchema(partial=True))
     async def get_fact_source_by_id(self, request: web.Request):
-        source_id = request.match_info['source_id']
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-        query = dict(id=source_id)
-        search = {**query, **access}
-
-        source = self._api_manager.find_and_dump_object('sources', search, include, exclude)
-        if not source:
-            raise JsonHttpNotFound(f'Fact source not found: {source_id}')
-
+        source = await self.get_object(request)
         return web.json_response(source)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.request_schema(SourceSchema)
     @aiohttp_apispec.response_schema(SourceSchema)
     async def create_fact_source(self, request: web.Request):
-        source_data = await request.json()
-
-        source_id = source_data.get('id')
-        if source_id:
-            search = dict(id=source_id)
-            search_source = next(self._api_manager.find_objects('sources', search), None)
-            if search_source is not None:
-                raise JsonHttpBadRequest(f'An fact source exists with the given id: {source_id}')
-
-        access = await self.get_request_permissions(request)
-
-        source = self._api_manager.create_object_from_schema(SourceSchema, source_data, access)
+        source = await self.create_on_disk_object(request)
         return web.json_response(source.display)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.request_schema(SourceSchema(partial=True))
     @aiohttp_apispec.response_schema(SourceSchema)
     async def update_fact_source(self, request: web.Request):
-        source_id = request.match_info['source_id']
-        source_data = await request.json()
-        source_data['id'] = source_id
-
-        access = await self.get_request_permissions(request)
-        query = dict(id=source_id)
-        search = {**query, **access}
-
-        source = self._api_manager.find_and_update_object('sources', source_data, search)
-        if not source:
-            raise JsonHttpNotFound(f'Fact source not found: {source_id}')
-
+        source = await self.update_on_disk_object(request)
         return web.json_response(source.display)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.request_schema(SourceSchema(partial=True))
     @aiohttp_apispec.response_schema(SourceSchema)
     async def create_or_update_source(self, request: web.Request):
-        source_id = request.match_info['source_id']
-        source_data = await request.json()
-        source_data['id'] = source_id
-
-        access = await self.get_request_permissions(request)
-        search = dict(id=source_id)
-
-        search_source = next(self._api_manager.find_objects('sources', search), None)
-        if search_source is not None and search_source.access not in access['access']:
-            raise JsonHttpForbidden(f'Cannot update fact source due to insufficient permissions: {source_id}')
-
-        objective = self._api_manager.create_object_from_schema(SourceSchema, source_data, access)
-        return web.json_response(objective.display)
+        source = await self.create_or_update_on_disk_object(request)
+        return web.json_response(source.display)

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -63,14 +63,15 @@ class FactSourceApi(BaseApi):
     @aiohttp_apispec.request_schema(SourceSchema(partial=True))
     @aiohttp_apispec.response_schema(SourceSchema)
     async def update_fact_source(self, request: web.Request):
-        source_id = request.match_info['source_id']
         source_data = await request.json()
+        source_data.pop('id', None)
 
+        source_id = request.match_info['source_id']
         access = await self.get_request_permissions(request)
         query = dict(id=source_id)
         search = {**query, **access}
 
-        source = self._api_manager.update_object('sources', source_data, search)
+        source = self._api_manager.update_object('sources', 'id', source_data, search)
         if not source:
             raise JsonHttpNotFound(f'Fact source not found: {source_id}')
 

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -17,6 +17,7 @@ class FactSourceApi(BaseApi):
         router = app.router
         router.add_get('/sources', self.get_fact_sources)
         router.add_get('/sources/{source_id}', self.get_fact_source_by_id)
+        router.add_post('/sources', self.create_fact_source)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
@@ -48,3 +49,11 @@ class FactSourceApi(BaseApi):
             raise JsonHttpNotFound(f'Fact source not found: {source_id}')
 
         return web.json_response(source)
+
+    @aiohttp_apispec.docs(tags=['sources'])
+    @aiohttp_apispec.request_schema(SourceSchema)
+    @aiohttp_apispec.response_schema(SourceSchema)
+    async def create_fact_source(self, request: web.Request):
+        source_data = await request.json()
+        source = self._api_manager.store_json_as_schema(SourceSchema, source_data)
+        return web.json_response(source.display)

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -3,7 +3,7 @@ from aiohttp import web
 
 from app.api.v2.handlers.base_api import BaseApi
 from app.api.v2.managers.base_api_manager import BaseApiManager
-from app.api.v2.responses import JsonHttpNotFound
+from app.api.v2.responses import JsonHttpNotFound, JsonHttpForbidden
 from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
 from app.objects.c_source import SourceSchema
 
@@ -19,6 +19,7 @@ class FactSourceApi(BaseApi):
         router.add_get('/sources/{source_id}', self.get_fact_source_by_id)
         router.add_post('/sources', self.create_fact_source)
         router.add_patch('/sources/{source_id}', self.update_fact_source)
+        router.add_put('/sources/{source_id}', self.create_or_update_source)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
@@ -56,23 +57,42 @@ class FactSourceApi(BaseApi):
     @aiohttp_apispec.response_schema(SourceSchema)
     async def create_fact_source(self, request: web.Request):
         source_data = await request.json()
-        source = self._api_manager.store_json_as_schema(SourceSchema, source_data)
+        source = self._api_manager.create_object_from_schema(SourceSchema, source_data)
         return web.json_response(source.display)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.request_schema(SourceSchema(partial=True))
     @aiohttp_apispec.response_schema(SourceSchema)
     async def update_fact_source(self, request: web.Request):
-        source_data = await request.json()
-        source_data.pop('id', None)
-
         source_id = request.match_info['source_id']
+        source_data = await request.json()
+        source_data['id'] = source_id
+
         access = await self.get_request_permissions(request)
         query = dict(id=source_id)
         search = {**query, **access}
 
-        source = self._api_manager.update_object('sources', 'id', source_data, search)
+        source = self._api_manager.find_and_update_object('sources', source_data, search)
         if not source:
             raise JsonHttpNotFound(f'Fact source not found: {source_id}')
 
         return web.json_response(source.display)
+
+    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.request_schema(SourceSchema(partial=True))
+    @aiohttp_apispec.response_schema(SourceSchema)
+    async def create_or_update_source(self, request: web.Request):
+        source_id = request.match_info['source_id']
+        source_data = await request.json()
+        source_data['id'] = source_id
+
+        access = await self.get_request_permissions(request)
+        query = dict(id=source_data)
+        search = {**query, **access}
+
+        search_source = next(self._api_manager.find_objects('sources', search), None)
+        if search_source is not None and search_source.access not in access['access']:
+            raise JsonHttpForbidden(f'Cannot update fact source due to insufficient permissions: {source_id}')
+
+        objective = self._api_manager.create_object_from_schema(SourceSchema, source_data)
+        return web.json_response(objective.display)

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -1,0 +1,50 @@
+import aiohttp_apispec
+from aiohttp import web
+
+from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.api.v2.responses import JsonHttpNotFound
+from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
+from app.objects.c_source import SourceSchema
+
+
+class FactSourceApi(BaseApi):
+    def __init__(self, services):
+        super().__init__(auth_svc=services['auth_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+
+    def add_routes(self, app: web.Application):
+        router = app.router
+        router.add_get('/sources', self.get_fact_sources)
+        router.add_get('/sources/{source_id}', self.get_fact_source_by_id)
+
+    @aiohttp_apispec.docs(tags=['sources'])
+    @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
+    @aiohttp_apispec.response_schema(SourceSchema(many=True))
+    async def get_fact_sources(self, request: web.Request):
+        sort = request['querystring'].get('sort', 'name')
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+
+        sources = self._api_manager.get_objects_with_filters('sources', access, sort, include, exclude)
+        return web.json_response(sources)
+
+    @aiohttp_apispec.docs(tags=['sources'])
+    @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
+    @aiohttp_apispec.response_schema(SourceSchema)
+    async def get_fact_source_by_id(self, request: web.Request):
+        source_id = request.match_info['source_id']
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+        query = dict(id=source_id)
+        search = {**query, **access}
+
+        source = self._api_manager.get_object_with_filters('sources', search, include, exclude)
+        if not source:
+            raise JsonHttpNotFound(f'Fact source not found: {source_id}')
+
+        return web.json_response(source)

--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -11,7 +11,7 @@ from app.objects.c_source import SourceSchema
 class FactSourceApi(BaseApi):
     def __init__(self, services):
         super().__init__(auth_svc=services['auth_svc'])
-        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router

--- a/app/api/v2/handlers/objective_api.py
+++ b/app/api/v2/handlers/objective_api.py
@@ -1,107 +1,57 @@
 import aiohttp_apispec
 from aiohttp import web
 
-from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.handlers.base_object_api import BaseObjectApi
 from app.api.v2.managers.base_api_manager import BaseApiManager
-from app.api.v2.responses import JsonHttpBadRequest, JsonHttpForbidden, JsonHttpNotFound
 from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
-from app.objects.c_objective import ObjectiveSchema
+from app.objects.c_objective import Objective, ObjectiveSchema
 
 
-class ObjectiveApi(BaseApi):
+class ObjectiveApi(BaseObjectApi):
     def __init__(self, services):
-        super().__init__(auth_svc=services['auth_svc'])
+        super().__init__(description='objective', obj_class=Objective, schema=ObjectiveSchema, ram_key='objectives',
+                         id_property='id', auth_svc=services['auth_svc'])
         self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router
         router.add_get('/objectives', self.get_objectives)
-        router.add_get('/objectives/{objective_id}', self.get_objective_by_id)
+        router.add_get('/objectives/{id}', self.get_objective_by_id)
         router.add_post('/objectives', self.create_objective)
-        router.add_patch('/objectives/{objective_id}', self.update_objective)
-        router.add_put('/objectives/{objective_id}', self.create_or_update_objective)
+        router.add_patch('/objectives/{id}', self.update_objective)
+        router.add_put('/objectives/{id}', self.create_or_update_objective)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
     @aiohttp_apispec.response_schema(ObjectiveSchema(many=True, partial=True))
     async def get_objectives(self, request: web.Request):
-        sort = request['querystring'].get('sort', 'name')
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-
-        objectives = self._api_manager.find_and_dump_objects('objectives', access, sort, include, exclude)
+        objectives = await self.get_all_objects(request)
         return web.json_response(objectives)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
     @aiohttp_apispec.response_schema(ObjectiveSchema(partial=True))
     async def get_objective_by_id(self, request: web.Request):
-        objective_id = request.match_info['objective_id']
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        access = await self.get_request_permissions(request)
-        query = dict(id=objective_id)
-        search = {**query, **access}
-
-        objective = self._api_manager.find_and_dump_object('objectives', search, include, exclude)
-        if not objective:
-            raise JsonHttpNotFound(f'Objective not found: {objective_id}')
-
+        objective = await self.get_object(request)
         return web.json_response(objective)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.request_schema(ObjectiveSchema)
     @aiohttp_apispec.response_schema(ObjectiveSchema)
     async def create_objective(self, request: web.Request):
-        objective_data = await request.json()
-
-        objective_id = objective_data.get('id')
-        if objective_id:
-            search = dict(id=objective_id)
-            search_objective = next(self._api_manager.find_objects('objectives', search), None)
-            if search_objective is not None:
-                raise JsonHttpBadRequest(f'An fact source exists with the given id: {objective_id}')
-
-        access = await self.get_request_permissions(request)
-
-        objective = self._api_manager.create_object_from_schema(ObjectiveSchema, objective_data, access)
+        objective = await self.create_on_disk_object(request)
         return web.json_response(objective.display)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.request_schema(ObjectiveSchema(partial=True))
     @aiohttp_apispec.response_schema(ObjectiveSchema)
     async def update_objective(self, request: web.Request):
-        objective_id = request.match_info['objective_id']
-        objective_data = await request.json()
-        objective_data['id'] = objective_id
-
-        access = await self.get_request_permissions(request)
-        query = dict(id=objective_id)
-        search = {**query, **access}
-
-        objective = self._api_manager.find_and_update_object('objectives', objective_data, search)
-        if not objective:
-            raise JsonHttpNotFound(f'Objective not found: {objective_id}')
-
+        objective = await self.update_on_disk_object(request)
         return web.json_response(objective.display)
 
     @aiohttp_apispec.docs(tags=['objectives'])
     @aiohttp_apispec.request_schema(ObjectiveSchema(partial=True))
     @aiohttp_apispec.response_schema(ObjectiveSchema)
     async def create_or_update_objective(self, request: web.Request):
-        objective_id = request.match_info['objective_id']
-        objective_data = await request.json()
-        objective_data['id'] = objective_id
-
-        access = await self.get_request_permissions(request)
-        search = dict(id=objective_id)
-
-        search_objective = next(self._api_manager.find_objects('objectives', search), None)
-        if search_objective is not None and search_objective.access not in access['access']:
-            raise JsonHttpForbidden(f'Cannot update objective due to insufficient permissions: {objective_id}')
-
-        objective = self._api_manager.create_object_from_schema(ObjectiveSchema, objective_data, access)
+        objective = await self.create_or_update_on_disk_object(request)
         return web.json_response(objective.display)

--- a/app/api/v2/handlers/objective_api.py
+++ b/app/api/v2/handlers/objective_api.py
@@ -11,7 +11,7 @@ from app.objects.c_objective import ObjectiveSchema
 class ObjectiveApi(BaseApi):
     def __init__(self, services):
         super().__init__(auth_svc=services['auth_svc'])
-        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router

--- a/app/api/v2/handlers/objective_api.py
+++ b/app/api/v2/handlers/objective_api.py
@@ -1,0 +1,77 @@
+import aiohttp_apispec
+from aiohttp import web
+
+from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.api.v2.responses import JsonHttpNotFound
+from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
+from app.objects.c_objective import ObjectiveSchema
+
+
+class ObjectiveApi(BaseApi):
+    def __init__(self, services):
+        super().__init__(auth_svc=services['auth_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+
+    def add_routes(self, app: web.Application):
+        router = app.router
+        router.add_get('/objectives', self.get_objectives)
+        router.add_get('/objectives/{objective_id}', self.get_objective_by_id)
+        router.add_post('/objectives', self.create_objective)
+        router.add_patch('/objectives/{objective_id}', self.update_objective)
+
+    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
+    @aiohttp_apispec.response_schema(ObjectiveSchema(many=True, partial=True))
+    async def get_objectives(self, request: web.Request):
+        sort = request['querystring'].get('sort', 'name')
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+
+        objectives = self._api_manager.find_and_dump_objects('objectives', access, sort, include, exclude)
+        return web.json_response(objectives)
+
+    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
+    @aiohttp_apispec.response_schema(ObjectiveSchema(partial=True))
+    async def get_objective_by_id(self, request: web.Request):
+        objective_id = request.match_info['objective_id']
+        include = request['querystring'].get('include')
+        exclude = request['querystring'].get('exclude')
+
+        access = await self.get_request_permissions(request)
+        query = dict(id=objective_id)
+        search = {**query, **access}
+
+        objective = self._api_manager.find_and_dump_object('objectives', search, include, exclude)
+        if not objective:
+            raise JsonHttpNotFound(f'Objective not found: {objective_id}')
+
+        return web.json_response(objective)
+
+    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.request_schema(ObjectiveSchema)
+    @aiohttp_apispec.response_schema(ObjectiveSchema)
+    async def create_objective(self, request: web.Request):
+        objective_data = await request.json()
+        objective = self._api_manager.store_json_as_schema(ObjectiveSchema, objective_data)
+        return web.json_response(objective.display)
+
+    @aiohttp_apispec.docs(tags=['objectives'])
+    @aiohttp_apispec.request_schema(ObjectiveSchema(partial=True))
+    @aiohttp_apispec.response_schema(ObjectiveSchema)
+    async def update_objective(self, request: web.Request):
+        objective_id = request.match_info['objective_id']
+        objective_data = await request.json()
+
+        access = await self.get_request_permissions(request)
+        query = dict(id=objective_id)
+        search = {**query, **access}
+
+        objective = self._api_manager.update_object('objectives', 'id', objective_data, search)
+        if not objective:
+            raise JsonHttpNotFound(f'Objective not found: {objective_id}')
+
+        return web.json_response(objective.display)

--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -11,7 +11,7 @@ from app.objects.c_planner import PlannerSchema
 class PlannerApi(BaseApi):
     def __init__(self, services):
         super().__init__(auth_svc=services['auth_svc'])
-        self._api_manager = BaseApiManager(data_svc=services['data_svc'])
+        self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
         router = app.router

--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -20,18 +20,18 @@ class PlannerApi(BaseApi):
 
     @aiohttp_apispec.docs(tags=['planners'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
-    @aiohttp_apispec.response_schema(PlannerSchema(many=True))
+    @aiohttp_apispec.response_schema(PlannerSchema(many=True, partial=True))
     async def get_planners(self, request: web.Request):
         sort = request['querystring'].get('sort', 'name')
         include = request['querystring'].get('include')
         exclude = request['querystring'].get('exclude')
 
-        planners = self._api_manager.get_objects_with_filters('planners', sort=sort, include=include, exclude=exclude)
+        planners = self._api_manager.find_and_dump_objects('planners', sort=sort, include=include, exclude=exclude)
         return web.json_response(planners)
 
     @aiohttp_apispec.docs(tags=['planners'])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
-    @aiohttp_apispec.response_schema(PlannerSchema)
+    @aiohttp_apispec.response_schema(PlannerSchema(partial=True))
     async def get_planner_by_id(self, request: web.Request):
         planner_id = request.match_info['planner_id']
         include = request['querystring'].get('include')
@@ -39,7 +39,7 @@ class PlannerApi(BaseApi):
 
         search = dict(planner_id=planner_id)
 
-        planner = self._api_manager.get_object_with_filters('planners', search=search, include=include, exclude=exclude)
+        planner = self._api_manager.find_and_dump_object('planners', search=search, include=include, exclude=exclude)
         if not planner:
             raise JsonHttpNotFound(f'Planner not found: {planner_id}')
 

--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -1,16 +1,16 @@
 import aiohttp_apispec
 from aiohttp import web
 
-from app.api.v2.handlers.base_api import BaseApi
+from app.api.v2.handlers.base_object_api import BaseObjectApi
 from app.api.v2.managers.base_api_manager import BaseApiManager
-from app.api.v2.responses import JsonHttpNotFound
 from app.api.v2.schemas.base_schemas import BaseGetAllQuerySchema, BaseGetOneQuerySchema
-from app.objects.c_planner import PlannerSchema
+from app.objects.c_planner import Planner, PlannerSchema
 
 
-class PlannerApi(BaseApi):
+class PlannerApi(BaseObjectApi):
     def __init__(self, services):
-        super().__init__(auth_svc=services['auth_svc'])
+        super().__init__(description='planner', obj_class=Planner, schema=PlannerSchema, ram_key='planners', id_property='planner_id',
+                         auth_svc=services['auth_svc'])
         self._api_manager = BaseApiManager(data_svc=services['data_svc'], file_svc=services['file_svc'])
 
     def add_routes(self, app: web.Application):
@@ -22,25 +22,12 @@ class PlannerApi(BaseApi):
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
     @aiohttp_apispec.response_schema(PlannerSchema(many=True, partial=True))
     async def get_planners(self, request: web.Request):
-        sort = request['querystring'].get('sort', 'name')
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        planners = self._api_manager.find_and_dump_objects('planners', sort=sort, include=include, exclude=exclude)
+        planners = await self.get_all_objects(request)
         return web.json_response(planners)
 
     @aiohttp_apispec.docs(tags=['planners'])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
     @aiohttp_apispec.response_schema(PlannerSchema(partial=True))
     async def get_planner_by_id(self, request: web.Request):
-        planner_id = request.match_info['planner_id']
-        include = request['querystring'].get('include')
-        exclude = request['querystring'].get('exclude')
-
-        search = dict(planner_id=planner_id)
-
-        planner = self._api_manager.find_and_dump_object('planners', search=search, include=include, exclude=exclude)
-        if not planner:
-            raise JsonHttpNotFound(f'Planner not found: {planner_id}')
-
+        planner = await self.get_object(request)
         return web.json_response(planner)

--- a/app/api/v2/managers/adversary_api_manager.py
+++ b/app/api/v2/managers/adversary_api_manager.py
@@ -1,5 +1,3 @@
-import uuid
-
 from app.api.v2.managers.base_api_manager import BaseApiManager
 from app.objects.c_adversary import Adversary
 
@@ -8,38 +6,7 @@ class AdversaryApiManager(BaseApiManager):
     def __init__(self, data_svc, file_svc):
         super().__init__(data_svc=data_svc, file_svc=file_svc)
 
-    async def create_adversary(self, data: dict, access: dict):
-        data['adversary_id'] = data.get('adversary_id') or str(uuid.uuid4())
-
-        file_path = await self._get_new_object_file_path('adversaries', data['adversary_id'])
-        allowed = self._get_allowed_from_access(access)
-
-        await self._save_and_reload_object(file_path, data, Adversary, allowed)
-        return await self._find_and_verify_adversary(data['adversary_id'])
-
-    async def update_adversary(self, data: dict, search: dict):
-        adversary = next(self.find_objects('adversaries', search), None)
-        if not adversary:
-            return None
-
-        file_path = await self._get_existing_object_file_path(adversary.adversary_id)
-        allowed = adversary.access
-
-        existing_adversary_data = dict(self.strip_yml(file_path)[0])
-        existing_adversary_data.update(data)
-
-        await self._save_and_reload_object(file_path, existing_adversary_data, Adversary, allowed)
-        return await self._find_and_verify_adversary(data['adversary_id'])
-
-    async def replace_adversary(self, adversary: Adversary, data: dict):
-        file_path = await self._get_existing_object_file_path(adversary.adversary_id)
-        allowed = adversary.access
-
-        await self._save_and_reload_object(file_path, data, Adversary, allowed)
-        return await self._find_and_verify_adversary(data['adversary_id'])
-
-    async def _find_and_verify_adversary(self, adversary_id: str):
-        adversary = next(self.find_objects('adversaries', dict(adversary_id=adversary_id)))
+    async def verify_adversary(self, adversary: Adversary):
         adversary.verify(log=self.log, abilities=self._data_svc.ram['abilities'],
                          objectives=self._data_svc.ram['objectives'])
         return adversary

--- a/app/api/v2/managers/adversary_api_manager.py
+++ b/app/api/v2/managers/adversary_api_manager.py
@@ -1,0 +1,45 @@
+import uuid
+
+from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.objects.c_adversary import Adversary
+
+
+class AdversaryApiManager(BaseApiManager):
+    def __init__(self, data_svc, file_svc):
+        super().__init__(data_svc=data_svc, file_svc=file_svc)
+
+    async def create_adversary(self, data: dict, access: dict):
+        data['adversary_id'] = data.get('adversary_id') or str(uuid.uuid4())
+
+        file_path = await self._get_new_object_file_path('adversaries', data['adversary_id'])
+        allowed = self._get_allowed_from_access(access)
+
+        await self._save_and_reload_object(file_path, data, Adversary, allowed)
+        return await self._find_and_verify_adversary(data['adversary_id'])
+
+    async def update_adversary(self, data: dict, search: dict):
+        adversary = next(self.find_objects('adversaries', search), None)
+        if not adversary:
+            return None
+
+        file_path = await self._get_existing_object_file_path(adversary.adversary_id)
+        allowed = adversary.access
+
+        existing_adversary_data = dict(self.strip_yml(file_path)[0])
+        existing_adversary_data.update(data)
+
+        await self._save_and_reload_object(file_path, existing_adversary_data, Adversary, allowed)
+        return await self._find_and_verify_adversary(data['adversary_id'])
+
+    async def replace_adversary(self, adversary: Adversary, data: dict):
+        file_path = await self._get_existing_object_file_path(adversary.adversary_id)
+        allowed = adversary.access
+
+        await self._save_and_reload_object(file_path, data, Adversary, allowed)
+        return await self._find_and_verify_adversary(data['adversary_id'])
+
+    async def _find_and_verify_adversary(self, adversary_id: str):
+        adversary = next(self.find_objects('adversaries', dict(adversary_id=adversary_id)))
+        adversary.verify(log=self.log, abilities=self._data_svc.ram['abilities'],
+                         objectives=self._data_svc.ram['objectives'])
+        return adversary

--- a/app/api/v2/managers/agent_api_manager.py
+++ b/app/api/v2/managers/agent_api_manager.py
@@ -1,0 +1,22 @@
+from app.api.v2.managers.base_api_manager import BaseApiManager
+
+
+class AgentApiManager(BaseApiManager):
+    def __init__(self, data_svc, file_svc):
+        super().__init__(data_svc=data_svc, file_svc=file_svc)
+
+    async def get_deploy_commands(self, ability_id: str):
+        abilities = await self._data_svc.locate('abilities', {'ability_id': ability_id})
+
+        raw_abilities = []
+        for ability in abilities:
+            for executor in ability.executors:
+                variations = [{'description': v.description, 'command': v.raw_command} for v in executor.variations]
+                raw_abilities.append({'platform': executor.platform, 'executor': executor.name,
+                                      'description': ability.description, 'command': executor.command,
+                                      'variations': variations})
+
+        app_config = {k: v for k, v in self.get_config().items() if k.startswith('app.')}
+        app_config.update({f'agents.{k}': v for k, v in self.get_config(name='agents').items()})
+
+        return dict(abilities=raw_abilities, app_config=app_config)

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import uuid
 import yaml
 
 from marshmallow.schema import SchemaMeta
@@ -21,29 +22,38 @@ class BaseApiManager(BaseWorld):
     def log(self):
         return self._log
 
-    def find_objects(self, object_name: str, search: dict = None):
+    """Object Retrieval"""
+
+    def find_objects(self, ram_key: str, search: dict = None):
         """Find objects matching the given criteria"""
-        for obj in self._data_svc.ram[object_name]:
+        for obj in self._data_svc.ram[ram_key]:
             if not search or obj.match(search):
                 yield obj
 
-    def find_and_dump_objects(self, object_name: str, search: dict = None, sort: str = None, include: List[str] = None,
+    def find_object(self, ram_key: str, search: dict = None):
+        for obj in self.find_objects(ram_key, search):
+            return obj
+
+    def find_and_dump_objects(self, ram_key: str, search: dict = None, sort: str = None, include: List[str] = None,
                               exclude: List[str] = None):
         matched_objs = []
-        for obj in self.find_objects(object_name, search):
+        for obj in self.find_objects(ram_key, search):
             dumped_obj = self.dump_object_with_filters(obj, include, exclude)
             matched_objs.append(dumped_obj)
         return sorted(matched_objs, key=lambda p: p.get(sort, 0))
 
-    def find_and_dump_object(self, object_name: str, search: dict = None, include: List[str] = None,
-                             exclude: List[str] = None):
-        for obj in self.find_objects(object_name, search):
-            return self.dump_object_with_filters(obj, include, exclude)
+    @staticmethod
+    def dump_object_with_filters(obj: Any, include: List[str] = None, exclude: List[str] = None) -> dict:
+        dumped = obj.display
+        if include:
+            exclude_attributes = list(set(dumped.keys()) - set(include))
+            exclude = set(exclude + exclude_attributes) if exclude else exclude_attributes
+        if exclude:
+            for exclude_attribute in exclude:
+                dumped.pop(exclude_attribute, None)
+        return dumped
 
-    def find_and_update_object(self, object_name: str, data: dict, search: dict = None):
-        for obj in self.find_objects(object_name, search):
-            new_obj = self.update_object(obj, data)
-            return new_obj
+    """Object Creation"""
 
     def create_object_from_schema(self, schema: SchemaMeta, data: dict, access: BaseWorld.Access):
         obj_schema = schema()
@@ -51,6 +61,30 @@ class BaseApiManager(BaseWorld):
         obj.access = self._get_allowed_from_access(access)
         obj.store(self._data_svc.ram)
         return obj
+
+    async def create_on_disk_object(self, data: dict, access: dict, ram_key: str, id_property: str, obj_class: type):
+        obj_id = data.get(id_property) or str(uuid.uuid4())
+        data[id_property] = obj_id
+
+        file_path = await self._get_new_object_file_path(data[id_property], ram_key)
+        allowed = self._get_allowed_from_access(access)
+        await self._save_and_reload_object(file_path, data, obj_class, allowed)
+        return next(self.find_objects(ram_key, {id_property: obj_id}))
+
+    def _get_allowed_from_access(self, access) -> BaseWorld.Access:
+        if self._data_svc.Access.HIDDEN in access['access']:
+            return self._data_svc.Access.HIDDEN
+        elif self._data_svc.Access.BLUE in access['access']:
+            return self._data_svc.Access.BLUE
+        else:
+            return self._data_svc.Access.RED
+
+    """Object Updates"""
+
+    def find_and_update_object(self, ram_key: str, data: dict, search: dict = None):
+        for obj in self.find_objects(ram_key, search):
+            new_obj = self.update_object(obj, data)
+            return new_obj
 
     def update_object(self, obj: Any, data: dict):
         dumped_obj = obj.schema.dump(obj)
@@ -64,43 +98,53 @@ class BaseApiManager(BaseWorld):
         new_obj.store(self._data_svc.ram)
         return new_obj
 
-    async def remove_object_from_memory_by_id(self, ram_key: str, id_value: str, id_attribute: str):
-        await self._data_svc.remove(ram_key, {id_attribute: id_value})
+    async def find_and_update_on_disk_object(self, data: dict, search: dict, ram_key: str, id_property: str, obj_class: type):
+        for obj in self.find_objects(ram_key, search):
+            new_obj = await self.update_on_disk_object(obj, data, ram_key, id_property, obj_class)
+            return new_obj
 
-    async def remove_object_from_disk_by_id(self, ram_key: str, id_value: str):
-        _, file_path = await self._file_svc.find_file_path(f'{id_value}.yml', location='data')
-        if not file_path:
-            file_path = f'data/{ram_key}/{id_value}.yml'
+    async def update_on_disk_object(self, obj: Any, data: dict, ram_key: str, id_property: str, obj_class: type):
+        obj_id = getattr(obj, id_property)
+        file_path = await self._get_existing_object_file_path(obj_id, ram_key)
+
+        existing_obj_data = dict(self.strip_yml(file_path)[0])
+        existing_obj_data.update(data)
+
+        await self._save_and_reload_object(file_path, existing_obj_data, obj_class, obj.access)
+        return next(self.find_objects(ram_key, {id_property: obj_id}))
+
+    """"Object Replacement"""
+
+    async def replace_on_disk_object(self, obj: Any, data: dict, ram_key: str, id_property: str):
+        obj_id = getattr(obj, id_property)
+        file_path = await self._get_existing_object_file_path(obj_id, ram_key)
+
+        await self._save_and_reload_object(file_path, data, type(obj), obj.access)
+        return next(self.find_objects(ram_key, {id_property: obj_id}))
+
+    """"Object Removal"""
+
+    async def remove_object_from_memory_by_id(self, identifier: str, ram_key: str, id_property: str):
+        await self._data_svc.remove(ram_key, {id_property: identifier})
+
+    async def remove_object_from_disk_by_id(self, identifier: str, ram_key: str):
+        file_path = await self._get_existing_object_file_path(identifier, ram_key)
 
         if os.path.exists(file_path):
             os.remove(file_path)
 
+    """Helpers"""
+
     @staticmethod
-    def dump_object_with_filters(obj: Any, include: List[str] = None, exclude: List[str] = None) -> dict:
-        dumped = obj.display
-        if include:
-            exclude_attributes = list(set(dumped.keys()) - set(include))
-            exclude = set(exclude + exclude_attributes) if exclude else exclude_attributes
-        if exclude:
-            for exclude_attribute in exclude:
-                dumped.pop(exclude_attribute, None)
-        return dumped
-
-    def _get_allowed_from_access(self, access) -> BaseWorld.Access:
-        if self._data_svc.Access.HIDDEN in access['access']:
-            return self._data_svc.Access.HIDDEN
-        elif self._data_svc.Access.BLUE in access['access']:
-            return self._data_svc.Access.BLUE
-        else:
-            return self._data_svc.Access.RED
-
-    async def _get_new_object_file_path(self, ram_key: str, identifier: str) -> str:
+    async def _get_new_object_file_path(identifier: str, ram_key: str) -> str:
         """Create file path for new object"""
-        return f'data/{ram_key}/{identifier}.yml'
+        return os.path.join('data', ram_key, f'{identifier}.yml')
 
-    async def _get_existing_object_file_path(self, identifier: str) -> str:
+    async def _get_existing_object_file_path(self, identifier: str, ram_key: str) -> str:
         """Find file path for existing object (by id)"""
-        _, file_path = await self._file_svc.find_file_path(f'{identifier}.yml', location='data')
+        _, file_path = await self._file_svc.find_file_path(f'{identifier}.yml', location=ram_key)
+        if not file_path:
+            file_path = await self._get_new_object_file_path(identifier, ram_key)
         return file_path
 
     async def _save_and_reload_object(self, file_path: str, data: dict, obj_type: type, access: BaseWorld.Access):

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -45,9 +45,10 @@ class BaseApiManager(BaseWorld):
             new_obj = self.update_object(obj, data)
             return new_obj
 
-    def create_object_from_schema(self, schema: SchemaMeta, data: dict):
+    def create_object_from_schema(self, schema: SchemaMeta, data: dict, access: BaseWorld.Access):
         obj_schema = schema()
         obj = obj_schema.load(data)
+        obj.access = self._get_allowed_from_access(access)
         obj.store(self._data_svc.ram)
         return obj
 

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -40,11 +40,16 @@ class BaseApiManager:
         obj.store(self._data_svc.ram)
         return obj
 
-    def update_object(self, object_name: str, data: dict, search: dict = None):
+    def update_object(self, object_name: str, id_key: str, data: dict, search: dict = None):
+        data.pop(id_key, None)
         for obj in self.find_objects(object_name, search):
-            for key, value in data.items():
-                obj.update(key, value)
-            return obj
+            dumped_obj = obj.schema.dump(obj)
+            for key, value in dumped_obj.items():
+                if key not in data:
+                    data[key] = value
+            new_obj = obj.schema.load(data)
+            new_obj.store(self._data_svc.ram)
+            return new_obj
 
     @staticmethod
     def dump_object_with_filters(obj, include: List[str] = None, exclude: List[str] = None):

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -28,7 +28,6 @@ class BaseApiManager:
 
     @staticmethod
     def dump_with_include_exclude(obj, include: List[str] = None, exclude: List[str] = None):
-        obj.schema.dump(obj)
         dumped = obj.display
         if include:
             exclude_attributes = list(set(dumped.keys()) - set(include))

--- a/app/api/v2/managers/base_api_manager.py
+++ b/app/api/v2/managers/base_api_manager.py
@@ -1,4 +1,5 @@
 import logging
+from marshmallow.schema import SchemaMeta
 from typing import List
 
 
@@ -25,6 +26,12 @@ class BaseApiManager:
         for obj in self._data_svc.ram[object_name]:
             if not search or obj.match(search):
                 return self.dump_with_include_exclude(obj, include, exclude)
+
+    def store_json_as_schema(self, schema: SchemaMeta, data: dict):
+        obj_schema = schema()
+        obj = obj_schema.load(data)
+        obj.store(self._data_svc.ram)
+        return obj
 
     @staticmethod
     def dump_with_include_exclude(obj, include: List[str] = None, exclude: List[str] = None):

--- a/app/api/v2/managers/config_api_manager.py
+++ b/app/api/v2/managers/config_api_manager.py
@@ -51,8 +51,8 @@ class ConfigNotFound(Exception):
 
 
 class ConfigApiManager(BaseApiManager):
-    def __init__(self, data_svc, config_interface=None):
-        super().__init__(data_svc=data_svc)
+    def __init__(self, data_svc, file_svc, config_interface=None):
+        super().__init__(data_svc=data_svc, file_svc=file_svc)
         self._config_interface = config_interface or BaseWorld
 
     def get_filtered_config(self, name):

--- a/app/api/v2/responses.py
+++ b/app/api/v2/responses.py
@@ -44,8 +44,9 @@ async def apispec_request_validation_middleware(request, handler):
         )
     except AttributeError as ex:
         # ex: JSON contains attribute that does not exist in Schema
+        # Or any other AttributeError...
         raise JsonHttpBadRequest(
-            error='Error parsing JSON: Invalid attribute',
+            error='AttributeError',
             details=str(ex)
         )
     except ValidationError as ex:

--- a/app/api/v2/responses.py
+++ b/app/api/v2/responses.py
@@ -1,4 +1,5 @@
 from aiohttp import web
+from json import JSONDecodeError
 
 from app.api.v2 import errors
 from app.api.v2.schemas.error_schemas import JsonHttpErrorSchema
@@ -41,6 +42,11 @@ async def apispec_request_validation_middleware(request, handler):
     except AttributeError as ex:
         raise JsonHttpBadRequest(
             error='Error parsing JSON: Invalid attribute',
+            details=str(ex)
+        )
+    except JSONDecodeError as ex:
+        raise JsonHttpBadRequest(
+            error='Unexpected error occurred while parsing json',
             details=str(ex)
         )
 

--- a/app/api/v2/responses.py
+++ b/app/api/v2/responses.py
@@ -27,6 +27,25 @@ class JsonHttpNotFound(JsonHttpErrorResponse, web.HTTPNotFound):
 
 
 @web.middleware
+async def apispec_request_validation_middleware(request, handler):
+    """Middleware to handle errors thrown by schema validation
+
+    Must be added before `validation_middleware`"""
+    try:
+        return await handler(request)
+    except TypeError as ex:
+        raise JsonHttpBadRequest(
+            error='Error parsing JSON',
+            details=str(ex)
+        )
+    except AttributeError as ex:
+        raise JsonHttpBadRequest(
+            error='Error parsing JSON: Invalid attribute',
+            details=str(ex)
+        )
+
+
+@web.middleware
 async def json_request_validation_middleware(request, handler):
     """Middleware that converts json decoding and marshmallow validation
     errors into 400 responses w/ json bodies.

--- a/app/api/v2/schemas/deploy_command_schemas.py
+++ b/app/api/v2/schemas/deploy_command_schemas.py
@@ -1,0 +1,7 @@
+import marshmallow as ma
+from marshmallow import fields
+
+
+class DeployCommandsSchema(ma.Schema):
+    abilities = fields.List(fields.Dict)
+    app_config = fields.Dict()

--- a/app/objects/c_adversary.py
+++ b/app/objects/c_adversary.py
@@ -39,9 +39,14 @@ class AdversarySchema(ma.Schema):
             del adversary['phases']
         return adversary
 
+    @ma.pre_load
+    def remove_properties(self, data, **_):
+        data.pop('has_repeatable_abilities', None)
+        return data
+
     @ma.post_load
     def build_adversary(self, data, **kwargs):
-        return None if kwargs.get('partial') else Adversary(**data)
+        return None if kwargs.get('partial') is True else Adversary(**data)
 
 
 class Adversary(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_adversary.py
+++ b/app/objects/c_adversary.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 import marshmallow as ma
 
@@ -7,15 +8,18 @@ from app.utility.base_object import BaseObject
 from app.utility.base_service import BaseService
 
 
+DEFAULT_OBJECTIVE_ID = '495a9828-cab1-44dd-a0ca-66e58177d8cc'
+
+
 class AdversarySchema(ma.Schema):
 
-    adversary_id = ma.fields.String()
+    adversary_id = ma.fields.String(required=False)
     name = ma.fields.String()
-    description = ma.fields.String()
-    atomic_ordering = ma.fields.List(ma.fields.String())
-    objective = ma.fields.String()
-    tags = ma.fields.List(ma.fields.String())
-    has_repeatable_abilities = ma.fields.Boolean()
+    description = ma.fields.String(required=False)
+    atomic_ordering = ma.fields.List(ma.fields.String(), required=False)
+    objective = ma.fields.String(required=False)
+    tags = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
+    has_repeatable_abilities = ma.fields.Boolean(dump_only=True)
 
     @ma.pre_load
     def fix_id(self, adversary, **_):
@@ -36,8 +40,8 @@ class AdversarySchema(ma.Schema):
         return adversary
 
     @ma.post_load
-    def build_adversary(self, data, **_):
-        return Adversary(**data)
+    def build_adversary(self, data, **kwargs):
+        return None if kwargs.get('partial') else Adversary(**data)
 
 
 class Adversary(FirstClassObjectInterface, BaseObject):
@@ -48,13 +52,13 @@ class Adversary(FirstClassObjectInterface, BaseObject):
     def unique(self):
         return self.hash('%s' % self.adversary_id)
 
-    def __init__(self, adversary_id, name, description, atomic_ordering, objective=None, tags=None):
+    def __init__(self, name, adversary_id='', description='', atomic_ordering=(), objective='', tags=None):
         super().__init__()
-        self.adversary_id = adversary_id
+        self.adversary_id = adversary_id if adversary_id else str(uuid.uuid4())
         self.name = name
         self.description = description
         self.atomic_ordering = atomic_ordering
-        self.objective = objective
+        self.objective = objective or DEFAULT_OBJECTIVE_ID
         self.tags = set(tags) if tags else set()
         self.has_repeatable_abilities = False
 
@@ -70,6 +74,20 @@ class Adversary(FirstClassObjectInterface, BaseObject):
         existing.update('tags', self.tags)
         existing.update('has_repeatable_abilities', self.check_repeatable_abilities(ram['abilities']))
         return existing
+
+    def verify(self, log, abilities, objectives):
+        for ability_id in self.atomic_ordering:
+            if not next((ability for ability in abilities if ability.ability_id == ability_id), None):
+                log.warning('Ability referenced in adversary %s but not found: %s', self.adversary_id, ability_id)
+
+        if not self.objective:
+            self.objective = DEFAULT_OBJECTIVE_ID
+        elif not next((objective for objective in objectives if objective.id == self.objective), None):
+            log.warning('Objective referenced in adversary %s but not found: %s. Setting default objective.',
+                        self.adversary_id, self.objective)
+            self.objective = DEFAULT_OBJECTIVE_ID
+
+        self.has_repeatable_abilities = self.check_repeatable_abilities(abilities)
 
     def has_ability(self, ability):
         for a in self.atomic_ordering:

--- a/app/objects/c_adversary.py
+++ b/app/objects/c_adversary.py
@@ -13,12 +13,12 @@ DEFAULT_OBJECTIVE_ID = '495a9828-cab1-44dd-a0ca-66e58177d8cc'
 
 class AdversarySchema(ma.Schema):
 
-    adversary_id = ma.fields.String(required=False)
-    name = ma.fields.String()
-    description = ma.fields.String(required=False)
-    atomic_ordering = ma.fields.List(ma.fields.String(), required=False)
-    objective = ma.fields.String(required=False)
-    tags = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
+    adversary_id = ma.fields.String()
+    name = ma.fields.String(required=True)
+    description = ma.fields.String()
+    atomic_ordering = ma.fields.List(ma.fields.String())
+    objective = ma.fields.String()
+    tags = ma.fields.List(ma.fields.String(), allow_none=True)
     has_repeatable_abilities = ma.fields.Boolean(dump_only=True)
 
     @ma.pre_load

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -13,47 +13,58 @@ from app.utility.base_planning_svc import BasePlanningService
 
 class AgentFieldsSchema(ma.Schema):
 
-    paw = ma.fields.String()
-    group = ma.fields.String()
-    architecture = ma.fields.String()
-    platform = ma.fields.String()
-    server = ma.fields.String()
-    upstream_dest = ma.fields.String()
-    username = ma.fields.String()
-    location = ma.fields.String()
-    pid = ma.fields.Integer()
-    ppid = ma.fields.Integer()
-    trusted = ma.fields.Boolean()
-    last_seen = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
+    paw = ma.fields.String(required=False, allow_none=True)
     sleep_min = ma.fields.Integer()
     sleep_max = ma.fields.Integer()
-    executors = ma.fields.List(ma.fields.String())
-    privilege = ma.fields.String()
-    display_name = ma.fields.String()
-    exe_name = ma.fields.String()
-    host = ma.fields.String()
     watchdog = ma.fields.Integer()
-    contact = ma.fields.String()
-    pending_contact = ma.fields.String()
-    links = ma.fields.List(ma.fields.Nested(LinkSchema()))
-    proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()))
-    proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()))
-    origin_link_id = ma.fields.Integer()
-    deadman_enabled = ma.fields.Boolean()
-    available_contacts = ma.fields.List(ma.fields.String())
-    created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
-    host_ip_addrs = ma.fields.List(ma.fields.String())
+    group = ma.fields.String(required=False)
+    architecture = ma.fields.String(required=False)
+    platform = ma.fields.String(required=False)
+    server = ma.fields.String(required=False)
+    upstream_dest = ma.fields.String(required=False, allow_none=True)
+    username = ma.fields.String(required=False)
+    location = ma.fields.String(required=False)
+    pid = ma.fields.Integer(required=False)
+    ppid = ma.fields.Integer(required=False)
+    trusted = ma.fields.Boolean(required=False)
+    executors = ma.fields.List(ma.fields.String(), required=False)
+    privilege = ma.fields.String(required=False)
+    exe_name = ma.fields.String(required=False)
+    host = ma.fields.String(required=False)
+    contact = ma.fields.String(required=False)
+    proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()),
+                                     required=False, allow_none=True)
+    proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()), required=False, allow_none=True)
+    origin_link_id = ma.fields.Integer(required=False)
+    deadman_enabled = ma.fields.Boolean(required=False, allow_none=True)
+    available_contacts = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
+    host_ip_addrs = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
+
+    display_name = ma.fields.String(dump_only=True)
+    created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', dump_only=True)
+    last_seen = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', dump_only=True)
+    links = ma.fields.List(ma.fields.Nested(LinkSchema), dump_only=True)
+    pending_contact = ma.fields.String(dump_only=True)
 
     @ma.pre_load
     def remove_nulls(self, in_data, **_):
         return {k: v for k, v in in_data.items() if v is not None}
 
+    @ma.pre_load
+    def remove_properties(self, data, **_):
+        data.pop('display_name', None)
+        data.pop('created', None)
+        data.pop('last_seen', None)
+        data.pop('links', None)
+        data.pop('pending_contact', None)
+        return data
+
 
 class AgentSchema(AgentFieldsSchema):
 
     @ma.post_load
-    def build_agent(self, data, **_):
-        return Agent(**data)
+    def build_agent(self, data, **kwargs):
+        return None if kwargs.get('partial') is True else Agent(**data)
 
 
 class Agent(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -13,32 +13,32 @@ from app.utility.base_planning_svc import BasePlanningService
 
 class AgentFieldsSchema(ma.Schema):
 
-    paw = ma.fields.String(required=False, allow_none=True)
-    sleep_min = ma.fields.Integer()
-    sleep_max = ma.fields.Integer()
+    paw = ma.fields.String(allow_none=True)
+    sleep_min = ma.fields.Integer(required=True)
+    sleep_max = ma.fields.Integer(required=True)
     watchdog = ma.fields.Integer()
-    group = ma.fields.String(required=False)
-    architecture = ma.fields.String(required=False)
-    platform = ma.fields.String(required=False)
-    server = ma.fields.String(required=False)
-    upstream_dest = ma.fields.String(required=False, allow_none=True)
-    username = ma.fields.String(required=False)
-    location = ma.fields.String(required=False)
-    pid = ma.fields.Integer(required=False)
-    ppid = ma.fields.Integer(required=False)
-    trusted = ma.fields.Boolean(required=False)
-    executors = ma.fields.List(ma.fields.String(), required=False)
-    privilege = ma.fields.String(required=False)
-    exe_name = ma.fields.String(required=False)
-    host = ma.fields.String(required=False)
-    contact = ma.fields.String(required=False)
+    group = ma.fields.String()
+    architecture = ma.fields.String()
+    platform = ma.fields.String()
+    server = ma.fields.String()
+    upstream_dest = ma.fields.String(allow_none=True)
+    username = ma.fields.String()
+    location = ma.fields.String()
+    pid = ma.fields.Integer()
+    ppid = ma.fields.Integer()
+    trusted = ma.fields.Boolean()
+    executors = ma.fields.List(ma.fields.String())
+    privilege = ma.fields.String()
+    exe_name = ma.fields.String()
+    host = ma.fields.String()
+    contact = ma.fields.String()
     proxy_receivers = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List(ma.fields.String()),
-                                     required=False, allow_none=True)
-    proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()), required=False, allow_none=True)
-    origin_link_id = ma.fields.Integer(required=False)
-    deadman_enabled = ma.fields.Boolean(required=False, allow_none=True)
-    available_contacts = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
-    host_ip_addrs = ma.fields.List(ma.fields.String(), required=False, allow_none=True)
+                                     allow_none=True)
+    proxy_chain = ma.fields.List(ma.fields.List(ma.fields.String()), allow_none=True)
+    origin_link_id = ma.fields.Integer()
+    deadman_enabled = ma.fields.Boolean(allow_none=True)
+    available_contacts = ma.fields.List(ma.fields.String(), allow_none=True)
+    host_ip_addrs = ma.fields.List(ma.fields.String(), allow_none=True)
 
     display_name = ma.fields.String(dump_only=True)
     created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', dump_only=True)
@@ -94,7 +94,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
             return True
         return False
 
-    def __init__(self, sleep_min, sleep_max, watchdog, platform='unknown', server='unknown', host='unknown',
+    def __init__(self, sleep_min, sleep_max, watchdog=0, platform='unknown', server='unknown', host='unknown',
                  username='unknown', architecture='unknown', group='red', location='unknown', pid=0, ppid=0,
                  trusted=True, executors=(), privilege='User', exe_name='unknown', contact='unknown', paw=None,
                  proxy_receivers=None, proxy_chain=None, origin_link_id=0, deadman_enabled=False,

--- a/app/objects/c_objective.py
+++ b/app/objects/c_objective.py
@@ -9,10 +9,10 @@ from app.utility.base_object import BaseObject
 
 class ObjectiveSchema(ma.Schema):
 
-    id = ma.fields.String(required=False)
-    name = ma.fields.String(required=False)
-    description = ma.fields.String(required=False)
-    goals = ma.fields.List(ma.fields.Nested(GoalSchema), required=False)
+    id = ma.fields.String()
+    name = ma.fields.String()
+    description = ma.fields.String()
+    goals = ma.fields.List(ma.fields.Nested(GoalSchema))
     percentage = ma.fields.Float(dump_only=True)
 
     @ma.pre_load

--- a/app/objects/c_objective.py
+++ b/app/objects/c_objective.py
@@ -22,7 +22,7 @@ class ObjectiveSchema(ma.Schema):
 
     @ma.post_load
     def build_objective(self, data, **kwargs):
-        return None if kwargs.get('partial') else Objective(**data)
+        return None if kwargs.get('partial') is True else Objective(**data)
 
 
 class Objective(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_objective.py
+++ b/app/objects/c_objective.py
@@ -1,3 +1,5 @@
+import uuid
+
 import marshmallow as ma
 
 from app.objects.interfaces.i_object import FirstClassObjectInterface
@@ -7,15 +9,20 @@ from app.utility.base_object import BaseObject
 
 class ObjectiveSchema(ma.Schema):
 
-    id = ma.fields.String()
-    name = ma.fields.String()
-    description = ma.fields.String()
-    goals = ma.fields.List(ma.fields.Nested(GoalSchema()))
-    percentage = ma.fields.Float()
+    id = ma.fields.String(required=False)
+    name = ma.fields.String(required=False)
+    description = ma.fields.String(required=False)
+    goals = ma.fields.List(ma.fields.Nested(GoalSchema), required=False)
+    percentage = ma.fields.Float(dump_only=True)
+
+    @ma.pre_load
+    def remove_properties(self, data, **_):
+        data.pop('percentage', None)
+        return data
 
     @ma.post_load
-    def build_objective(self, data, **_):
-        return Objective(**data)
+    def build_objective(self, data, **kwargs):
+        return None if kwargs.get('partial') else Objective(**data)
 
 
 class Objective(FirstClassObjectInterface, BaseObject):
@@ -37,7 +44,7 @@ class Objective(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, id='', name='', description='', goals=None):
         super().__init__()
-        self.id = id
+        self.id = id if id else str(uuid.uuid4())
         self.name = name
         self.description = description
         self.goals = goals if goals else []

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -29,10 +29,10 @@ class SourceSchema(ma.Schema):
 
     id = ma.fields.String(required=False)
     name = ma.fields.String()
-    facts = ma.fields.List(ma.fields.Nested(FactSchema()), required=False)
-    rules = ma.fields.List(ma.fields.Nested(RuleSchema()), required=False)
-    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema()), required=False, load_only=True)
-    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema()), required=False)
+    facts = ma.fields.List(ma.fields.Nested(FactSchema), required=False)
+    rules = ma.fields.List(ma.fields.Nested(RuleSchema), required=False)
+    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema), required=False)
+    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema), required=False)
 
     @ma.pre_load
     def fix_adjustments(self, in_data, **_):

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -49,7 +49,7 @@ class SourceSchema(ma.Schema):
 
     @ma.post_load()
     def build_source(self, data, **kwargs):
-        return None if kwargs['partial'] else Source(**data)
+        return None if kwargs.get('partial') else Source(**data)
 
 
 class Source(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import uuid
 
 import marshmallow as ma
 
@@ -26,12 +27,12 @@ Adjustment = namedtuple('Adjustment', 'ability_id trait value offset')
 
 class SourceSchema(ma.Schema):
 
-    id = ma.fields.String()
+    id = ma.fields.String(required=False)
     name = ma.fields.String()
-    facts = ma.fields.List(ma.fields.Nested(FactSchema()))
-    rules = ma.fields.List(ma.fields.Nested(RuleSchema()))
-    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema(), required=False))
-    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema()))
+    facts = ma.fields.List(ma.fields.Nested(FactSchema()), required=False)
+    rules = ma.fields.List(ma.fields.Nested(RuleSchema()), required=False)
+    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema()), required=False, load_only=True)
+    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema()), required=False)
 
     @ma.pre_load
     def fix_adjustments(self, in_data, **_):
@@ -48,7 +49,6 @@ class SourceSchema(ma.Schema):
 
     @ma.post_load()
     def build_source(self, data, **_):
-        data['id'] = data.pop('id')
         return Source(**data)
 
 
@@ -61,9 +61,9 @@ class Source(FirstClassObjectInterface, BaseObject):
     def unique(self):
         return self.hash('%s' % self.id)
 
-    def __init__(self, id, name, facts, relationships=(), rules=(), adjustments=()):
+    def __init__(self, name, id='', facts=(), relationships=(), rules=(), adjustments=()):
         super().__init__()
-        self.id = id
+        self.id = id if id else str(uuid.uuid4())
         self.name = name
         self.facts = facts
         self.rules = rules

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -49,7 +49,7 @@ class SourceSchema(ma.Schema):
 
     @ma.post_load()
     def build_source(self, data, **kwargs):
-        return None if kwargs.get('partial') else Source(**data)
+        return None if kwargs.get('partial') is True else Source(**data)
 
 
 class Source(FirstClassObjectInterface, BaseObject):

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -27,12 +27,12 @@ Adjustment = namedtuple('Adjustment', 'ability_id trait value offset')
 
 class SourceSchema(ma.Schema):
 
-    id = ma.fields.String(required=False)
-    name = ma.fields.String()
-    facts = ma.fields.List(ma.fields.Nested(FactSchema), required=False)
-    rules = ma.fields.List(ma.fields.Nested(RuleSchema), required=False)
-    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema), required=False)
-    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema), required=False)
+    id = ma.fields.String()
+    name = ma.fields.String(required=True)
+    facts = ma.fields.List(ma.fields.Nested(FactSchema))
+    rules = ma.fields.List(ma.fields.Nested(RuleSchema))
+    adjustments = ma.fields.List(ma.fields.Nested(AdjustmentSchema))
+    relationships = ma.fields.List(ma.fields.Nested(RelationshipSchema))
 
     @ma.pre_load
     def fix_adjustments(self, in_data, **_):

--- a/app/objects/c_source.py
+++ b/app/objects/c_source.py
@@ -48,8 +48,8 @@ class SourceSchema(ma.Schema):
         return in_data
 
     @ma.post_load()
-    def build_source(self, data, **_):
-        return Source(**data)
+    def build_source(self, data, **kwargs):
+        return None if kwargs['partial'] else Source(**data)
 
 
 class Source(FirstClassObjectInterface, BaseObject):

--- a/app/objects/secondclass/c_fact.py
+++ b/app/objects/secondclass/c_fact.py
@@ -36,19 +36,19 @@ class FactSchema(ma.Schema):
     class Meta:
         unknown = ma.EXCLUDE
 
-    unique = ma.fields.String()
+    unique = ma.fields.String(dump_only=True)
     trait = ma.fields.String()
-    name = ma.fields.String()
+    name = ma.fields.String(dump_only=True)
     value = ma.fields.Function(lambda x: x.value, deserialize=lambda x: str(x), allow_none=True)
-    created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S')
-    score = ma.fields.Integer()
-    source = ma.fields.String()
-    origin_type = ma_enum.EnumField(OriginType)
-    links = ma.fields.List(ma.fields.String())
-    relationships = ma.fields.List(ma.fields.String())
-    limit_count = ma.fields.Integer()
-    collected_by = ma.fields.String(allow_none=True)
-    technique_id = ma.fields.String(allow_none=True)
+    created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', dump_only=True)
+    score = ma.fields.Integer(required=False)
+    source = ma.fields.String(required=False, allow_none=True)
+    origin_type = ma_enum.EnumField(OriginType, required=False, allow_none=True)
+    links = ma.fields.List(ma.fields.String(), required=False)
+    relationships = ma.fields.List(ma.fields.String(), required=False)
+    limit_count = ma.fields.Integer(required=False)
+    collected_by = ma.fields.String(required=False, allow_none=True)
+    technique_id = ma.fields.String(required=False, allow_none=True)
 
     @ma.post_load()
     def build_fact(self, data, **_):

--- a/app/objects/secondclass/c_fact.py
+++ b/app/objects/secondclass/c_fact.py
@@ -37,18 +37,18 @@ class FactSchema(ma.Schema):
         unknown = ma.EXCLUDE
 
     unique = ma.fields.String(dump_only=True)
-    trait = ma.fields.String()
+    trait = ma.fields.String(required=True)
     name = ma.fields.String(dump_only=True)
     value = ma.fields.Function(lambda x: x.value, deserialize=lambda x: str(x), allow_none=True)
     created = ma.fields.DateTime(format='%Y-%m-%d %H:%M:%S', dump_only=True)
-    score = ma.fields.Integer(required=False)
-    source = ma.fields.String(required=False, allow_none=True)
-    origin_type = ma_enum.EnumField(OriginType, required=False, allow_none=True)
-    links = ma.fields.List(ma.fields.String(), required=False)
-    relationships = ma.fields.List(ma.fields.String(), required=False)
-    limit_count = ma.fields.Integer(required=False)
-    collected_by = ma.fields.String(required=False, allow_none=True)
-    technique_id = ma.fields.String(required=False, allow_none=True)
+    score = ma.fields.Integer()
+    source = ma.fields.String(allow_none=True)
+    origin_type = ma_enum.EnumField(OriginType, allow_none=True)
+    links = ma.fields.List(ma.fields.String())
+    relationships = ma.fields.List(ma.fields.String())
+    limit_count = ma.fields.Integer()
+    collected_by = ma.fields.String(allow_none=True)
+    technique_id = ma.fields.String(allow_none=True)
 
     @ma.post_load()
     def build_fact(self, data, **_):

--- a/app/objects/secondclass/c_goal.py
+++ b/app/objects/secondclass/c_goal.py
@@ -5,11 +5,16 @@ from app.utility.base_object import BaseObject
 
 class GoalSchema(ma.Schema):
 
-    target = ma.fields.String()
-    value = ma.fields.String()
-    count = ma.fields.Integer()
-    achieved = ma.fields.Boolean()
-    operator = ma.fields.String()
+    target = ma.fields.String(required=False)
+    value = ma.fields.String(required=False)
+    count = ma.fields.Integer(required=False)
+    operator = ma.fields.String(required=False)
+    achieved = ma.fields.Boolean(dump_only=True)
+
+    @ma.pre_load
+    def remove_properties(self, data, **_):
+        data.pop('achieved', None)
+        return data
 
     @ma.post_load
     def build_goal(self, data, **_):

--- a/app/objects/secondclass/c_goal.py
+++ b/app/objects/secondclass/c_goal.py
@@ -5,10 +5,10 @@ from app.utility.base_object import BaseObject
 
 class GoalSchema(ma.Schema):
 
-    target = ma.fields.String(required=False)
-    value = ma.fields.String(required=False)
-    count = ma.fields.Integer(required=False)
-    operator = ma.fields.String(required=False)
+    target = ma.fields.String()
+    value = ma.fields.String()
+    count = ma.fields.Integer()
+    operator = ma.fields.String()
     achieved = ma.fields.Boolean(dump_only=True)
 
     @ma.pre_load

--- a/app/objects/secondclass/c_relationship.py
+++ b/app/objects/secondclass/c_relationship.py
@@ -7,10 +7,10 @@ from app.objects.secondclass.c_fact import FactSchema
 class RelationshipSchema(ma.Schema):
 
     unique = ma.fields.String(dump_only=True)
-    source = ma.fields.Nested(FactSchema)
-    edge = ma.fields.String(required=False, allow_none=True)
-    target = ma.fields.Nested(FactSchema, required=False, allow_none=True)
-    score = ma.fields.Integer(required=False)
+    source = ma.fields.Nested(FactSchema, required=True)
+    edge = ma.fields.String(allow_none=True)
+    target = ma.fields.Nested(FactSchema, allow_none=True)
+    score = ma.fields.Integer()
 
     @ma.post_load
     def build_relationship(self, data, **_):

--- a/app/objects/secondclass/c_relationship.py
+++ b/app/objects/secondclass/c_relationship.py
@@ -6,11 +6,11 @@ from app.objects.secondclass.c_fact import FactSchema
 
 class RelationshipSchema(ma.Schema):
 
-    unique = ma.fields.String()
-    source = ma.fields.Nested(FactSchema())
-    edge = ma.fields.String()
-    target = ma.fields.Nested(FactSchema())
-    score = ma.fields.Integer()
+    unique = ma.fields.String(dump_only=True)
+    source = ma.fields.Nested(FactSchema)
+    edge = ma.fields.String(required=False, allow_none=True)
+    target = ma.fields.Nested(FactSchema, required=False, allow_none=True)
+    score = ma.fields.Integer(required=False)
 
     @ma.post_load
     def build_relationship(self, data, **_):

--- a/app/objects/secondclass/c_rule.py
+++ b/app/objects/secondclass/c_rule.py
@@ -8,7 +8,7 @@ from app.utility.rule_set import RuleAction
 class RuleSchema(ma.Schema):
 
     trait = ma.fields.String()
-    match = ma.fields.String()
+    match = ma.fields.String(required=False)
     action = ma_enum.EnumField(RuleAction)
 
     @ma.post_load

--- a/app/objects/secondclass/c_rule.py
+++ b/app/objects/secondclass/c_rule.py
@@ -7,9 +7,9 @@ from app.utility.rule_set import RuleAction
 
 class RuleSchema(ma.Schema):
 
-    trait = ma.fields.String()
-    match = ma.fields.String(required=False)
-    action = ma_enum.EnumField(RuleAction)
+    action = ma_enum.EnumField(RuleAction, required=True)
+    trait = ma.fields.String(required=True)
+    match = ma.fields.String()
 
     @ma.post_load
     def build_rule(self, data, **_):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -391,11 +391,4 @@ class DataService(DataServiceInterface, BaseService):
 
     async def _verify_adversary_profiles(self):
         for adv in await self.locate('adversaries'):
-            if not adv.objective:
-                adv.objective = '495a9828-cab1-44dd-a0ca-66e58177d8cc'
-            if not next((objective for objective in self.ram['objectives'] if objective.id == adv.objective), None):
-                self.log.warning('Objective referenced in %s but not found: %s' % (adv.adversary_id, adv.objective))
-            for ability_id in adv.atomic_ordering:
-                if not next((ability for ability in self.ram['abilities'] if ability.ability_id == ability_id), None):
-                    self.log.warning('Ability referenced in %s but not found: %s' % (adv.adversary_id, ability_id))
-            adv.has_repeatable_abilities = adv.check_repeatable_abilities(self.ram['abilities'])
+            adv.verify(log=self.log, abilities=self.ram['abilities'], objectives=self.ram['objectives'])

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -92,7 +92,7 @@ class FileSvc(FileServiceInterface, BaseService):
                 file_path = await self.walk_file_path(os.path.join('plugins', plugin.name, subd, location), name)
                 if file_path:
                     return plugin.name, file_path
-        file_path = await self.walk_file_path(os.path.join('data'), name)
+        file_path = await self.walk_file_path(os.path.join('data', location), name)
         if file_path:
             return None, file_path
         return None, await self.walk_file_path('%s' % location, name)

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ from aiohttp import web
 import app.api.v2
 from app import version
 from app.api.rest_api import RestApi
+from app.api.v2.responses import apispec_request_validation_middleware
 from app.objects.c_ability import Ability
 from app.objects.c_agent import Agent
 from app.objects.secondclass.c_link import Link
@@ -76,12 +77,13 @@ def init_swagger_documentation(app):
     """
     aiohttp_apispec.setup_aiohttp_apispec(
         app=app,
-        title="CALDERA",
+        title='CALDERA',
         version=version.get_version(),
-        swagger_path="/api/docs",
-        url="/api/docs/swagger.json",
-        static_path="/static/swagger"
+        swagger_path='/api/docs',
+        url='/api/docs/swagger.json',
+        static_path='/static/swagger'
     )
+    app.middlewares.append(apispec_request_validation_middleware)
     app.middlewares.append(validation_middleware)
 
 

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -1,0 +1,123 @@
+from app.api.v2.managers.base_api_manager import BaseApiManager
+
+
+class StubDataService:
+    def __init__(self):
+        self.ram = {}
+
+
+def test_dump(data_svc, agent):
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent)
+
+    for key in manager_dumped_agent:
+        assert manager_dumped_agent[key] == dumped_agent[key]
+
+
+def test_dump_with_exclude(data_svc, agent):
+    exclude_key = 'paw'
+
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, exclude=[exclude_key])
+
+    assert exclude_key in dumped_agent
+    assert exclude_key not in manager_dumped_agent
+    for key in manager_dumped_agent:
+        assert manager_dumped_agent[key] == dumped_agent[key]
+
+
+def test_dump_with_include(data_svc, agent):
+    include_key = 'paw'
+
+    test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
+    dumped_agent = test_agent.schema.dump(test_agent)
+
+    manager = BaseApiManager(data_svc=data_svc)
+    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, include=[include_key])
+
+    assert include_key in dumped_agent
+    assert include_key in manager_dumped_agent
+    assert len(manager_dumped_agent.keys()) == 1
+    assert manager_dumped_agent[include_key] == dumped_agent[include_key]
+
+
+def test_get_objects(agent):
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0)
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    dumped_agents = manager.get_objects_with_filters('agents')
+
+    assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
+
+
+def test_get_objects_with_search(agent):
+    search_property = 'sleep_min'
+    search_value = 2
+
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent3', sleep_min=3, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    dumped_agents = manager.get_objects_with_filters('agents', search=search)
+
+    assert len(dumped_agents) == 2
+    for dumped_agent in dumped_agents:
+        assert dumped_agent[search_property] == search_value
+
+
+def test_get_objects_with_sort(agent):
+    sort_property = 'paw'
+
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent5', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent3', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent4', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    dumped_agents = manager.get_objects_with_filters('agents', sort=sort_property)
+
+    assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
+    prev_paw = None
+    for dumped_agent in dumped_agents:
+        assert not prev_paw or dumped_agent[sort_property] > prev_paw
+        prev_paw = dumped_agent[sort_property]
+
+
+def test_get_object(agent):
+    search_property = 'paw'
+    search_value = 'agent0'
+
+    test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        test_agent,
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    dumped_agent = manager.get_object_with_filters('agents', search=search)
+
+    assert dumped_agent == test_agent.display

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -53,7 +53,7 @@ def test_find_objects(agent):
         agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
         agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0)
     ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     agents = list(manager.find_objects('agents'))
 
@@ -71,7 +71,7 @@ def test_find_objects_with_search(agent):
         agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
         agent(paw='agent3', sleep_min=3, sleep_max=5, watchdog=0),
     ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     search = {search_property: search_value}
     agents = list(manager.find_objects('agents', search=search))
@@ -92,7 +92,7 @@ def test_find_object(agent):
         agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
         test_agent,
     ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     search = {search_property: search_value}
     agents = list(manager.find_objects('agents', search=search))
@@ -105,7 +105,7 @@ def test_dump(data_svc, agent):
     test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
     dumped_agent = test_agent.schema.dump(test_agent)
 
-    manager = BaseApiManager(data_svc=data_svc)
+    manager = BaseApiManager(data_svc=data_svc, file_svc=None)
     manager_dumped_agent = manager.dump_object_with_filters(test_agent)
 
     for key in manager_dumped_agent:
@@ -118,7 +118,7 @@ def test_dump_with_exclude(data_svc, agent):
     test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
     dumped_agent = test_agent.schema.dump(test_agent)
 
-    manager = BaseApiManager(data_svc=data_svc)
+    manager = BaseApiManager(data_svc=data_svc, file_svc=None)
     manager_dumped_agent = manager.dump_object_with_filters(test_agent, exclude=[exclude_key])
 
     assert exclude_key in dumped_agent
@@ -133,7 +133,7 @@ def test_dump_with_include(data_svc, agent):
     test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
     dumped_agent = test_agent.schema.dump(test_agent)
 
-    manager = BaseApiManager(data_svc=data_svc)
+    manager = BaseApiManager(data_svc=data_svc, file_svc=None)
     manager_dumped_agent = manager.dump_object_with_filters(test_agent, include=[include_key])
 
     assert include_key in dumped_agent
@@ -154,7 +154,7 @@ def test_find_and_dump_objects_with_sort(agent):
         agent(paw='agent4', sleep_min=2, sleep_max=5, watchdog=0),
         agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
     ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     dumped_agents = manager.find_and_dump_objects('agents', sort=sort_property)
 
@@ -169,7 +169,7 @@ def test_find_and_dump_object(agent):
     test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
     stub_data_svc = StubDataService()
     stub_data_svc.ram['agents'] = [test_agent]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     dumped_agent = manager.find_and_dump_object('agents')
 
@@ -179,7 +179,7 @@ def test_find_and_dump_object(agent):
 def test_create_object_from_schema():
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = []
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
     obj = manager.create_object_from_schema(TestSchema, data)
@@ -190,7 +190,7 @@ def test_create_object_from_schema():
 def test_create_object_from_schema_duplicate():
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = []
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
     manager.create_object_from_schema(TestSchema, data)
@@ -205,7 +205,7 @@ def test_find_and_update_object(agent):
         TestObject(name='name0', value='value0'),
         TestObject(name='name1', value='value1'),
     ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'value': 'value1'}
     search = {'name': 'name0'}
@@ -220,7 +220,7 @@ def test_replace_object(agent):
     stub_data_svc = StubDataService()
     test_obj = TestObject(name='name0', value='value0')
     stub_data_svc.ram['tests'] = [test_obj]
-    manager = BaseApiManager(data_svc=stub_data_svc)
+    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'name0'}
     manager.replace_object(test_obj, data)

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -9,6 +9,7 @@ from app.utility.base_world import BaseWorld
 class StubDataService:
     def __init__(self):
         self.ram = {}
+        self.Access = BaseWorld.Access
 
 
 class TestSchema(ma.Schema):
@@ -96,10 +97,9 @@ def test_find_object(agent):
     manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     search = {search_property: search_value}
-    agents = list(manager.find_objects('agents', search=search))
+    agent = manager.find_object('agents', search=search)
 
-    assert len(agents) == 1
-    assert agents[0] == test_agent
+    assert agent == test_agent
 
 
 def test_dump(data_svc, agent):
@@ -166,24 +166,14 @@ def test_find_and_dump_objects_with_sort(agent):
         prev_paw = dumped_agent[sort_property]
 
 
-def test_find_and_dump_object(agent):
-    test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
-    stub_data_svc = StubDataService()
-    stub_data_svc.ram['agents'] = [test_agent]
-    manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
-
-    dumped_agent = manager.find_and_dump_object('agents')
-
-    assert dumped_agent == test_agent.display
-
-
 def test_create_object_from_schema():
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = []
     manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    obj = manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
+    access = {'access': (BaseWorld.Access.RED, BaseWorld.Access.APP)}
+    obj = manager.create_object_from_schema(TestSchema, data, access)
 
     assert obj.name == 'test_name' and obj.value == 'test_value'
 
@@ -194,8 +184,9 @@ def test_create_object_from_schema_duplicate():
     manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
-    manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
+    access = {'access': (BaseWorld.Access.RED, BaseWorld.Access.APP)}
+    manager.create_object_from_schema(TestSchema, data, access)
+    manager.create_object_from_schema(TestSchema, data, access)
 
     assert len(stub_data_svc.ram) == 1
 

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -31,7 +31,7 @@ class TestObject(FirstClassObjectInterface, BaseObject):
     def unique(self):
         return self.hash('%s' % self.name)
 
-    def __init__(self, name, value):
+    def __init__(self, name, value=''):
         super().__init__()
         self.name = name
         self.value = value
@@ -176,30 +176,30 @@ def test_find_and_dump_object(agent):
     assert dumped_agent == test_agent.display
 
 
-def test_store_json_as_schema():
+def test_create_object_from_schema():
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = []
     manager = BaseApiManager(data_svc=stub_data_svc)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    obj = manager.store_json_as_schema(TestSchema, data)
+    obj = manager.create_object_from_schema(TestSchema, data)
 
     assert obj.name == 'test_name' and obj.value == 'test_value'
 
 
-def test_store_json_as_schema_duplicate():
+def test_create_object_from_schema_duplicate():
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = []
     manager = BaseApiManager(data_svc=stub_data_svc)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    manager.store_json_as_schema(TestSchema, data)
-    manager.store_json_as_schema(TestSchema, data)
+    manager.create_object_from_schema(TestSchema, data)
+    manager.create_object_from_schema(TestSchema, data)
 
     assert len(stub_data_svc.ram) == 1
 
 
-def test_update_object(agent):
+def test_find_and_update_object(agent):
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = [
         TestObject(name='name0', value='value0'),
@@ -209,23 +209,21 @@ def test_update_object(agent):
 
     data = {'value': 'value1'}
     search = {'name': 'name0'}
-    manager.update_object('tests', 'name', data, search)
+    manager.find_and_update_object('tests', data, search)
 
     assert len(stub_data_svc.ram['tests']) == 2
     for test_obj in stub_data_svc.ram['tests']:
         assert test_obj.value == 'value1'
 
 
-def test_update_object_try_to_overwrite_id(agent):
+def test_replace_object(agent):
     stub_data_svc = StubDataService()
-    stub_data_svc.ram['tests'] = [
-        TestObject(name='name_original', value='value0')
-    ]
+    test_obj = TestObject(name='name0', value='value0')
+    stub_data_svc.ram['tests'] = [test_obj]
     manager = BaseApiManager(data_svc=stub_data_svc)
 
-    data = {'name': 'name_updated'}
-    search = {'name': 'name_original'}
-    manager.update_object('tests', 'name', data, search)
+    data = {'name': 'name0'}
+    manager.replace_object(test_obj, data)
 
     assert len(stub_data_svc.ram['tests']) == 1
-    assert stub_data_svc.ram['tests'][0].name == 'name_original'
+    assert not stub_data_svc.ram['tests'][0].value

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -3,6 +3,7 @@ import marshmallow as ma
 from app.api.v2.managers.base_api_manager import BaseApiManager
 from app.objects.interfaces.i_object import FirstClassObjectInterface
 from app.utility.base_object import BaseObject
+from app.utility.base_world import BaseWorld
 
 
 class StubDataService:
@@ -182,7 +183,7 @@ def test_create_object_from_schema():
     manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    obj = manager.create_object_from_schema(TestSchema, data)
+    obj = manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
 
     assert obj.name == 'test_name' and obj.value == 'test_value'
 
@@ -193,8 +194,8 @@ def test_create_object_from_schema_duplicate():
     manager = BaseApiManager(data_svc=stub_data_svc, file_svc=None)
 
     data = {'name': 'test_name', 'value': 'test_value'}
-    manager.create_object_from_schema(TestSchema, data)
-    manager.create_object_from_schema(TestSchema, data)
+    manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
+    manager.create_object_from_schema(TestSchema, data, BaseWorld.Access.RED)
 
     assert len(stub_data_svc.ram) == 1
 

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -11,6 +11,8 @@ class StubDataService:
 
 
 class TestSchema(ma.Schema):
+    __test__ = False
+
     name = ma.fields.String()
     value = ma.fields.String()
 
@@ -20,6 +22,8 @@ class TestSchema(ma.Schema):
 
 
 class TestObject(FirstClassObjectInterface, BaseObject):
+    __test__ = False
+
     schema = TestSchema()
     display_schema = TestSchema()
 

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -1,4 +1,8 @@
+import marshmallow as ma
+
 from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.objects.interfaces.i_object import FirstClassObjectInterface
+from app.utility.base_object import BaseObject
 
 
 class StubDataService:
@@ -6,12 +10,99 @@ class StubDataService:
         self.ram = {}
 
 
+class TestSchema(ma.Schema):
+    name = ma.fields.String()
+    value = ma.fields.String()
+
+    @ma.post_load()
+    def build_test_object(self, data, **_):
+        return TestObject(**data)
+
+
+class TestObject(FirstClassObjectInterface, BaseObject):
+    schema = TestSchema()
+    display_schema = TestSchema()
+
+    @property
+    def unique(self):
+        return self.hash('%s' % self.name)
+
+    def __init__(self, name, value):
+        super().__init__()
+        self.name = name
+        self.value = value
+
+    def store(self, ram):
+        ram_key = 'tests'
+        existing = self.retrieve(ram[ram_key], self.unique)
+        if not existing:
+            ram[ram_key].append(self)
+            return self.retrieve(ram[ram_key], self.unique)
+        existing.update('name', self.name)
+        existing.update('value', self.value)
+        return existing
+
+
+def test_find_objects(agent):
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0)
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    agents = list(manager.find_objects('agents'))
+
+    assert len(agents) == len(stub_data_svc.ram['agents'])
+
+
+def test_find_objects_with_search(agent):
+    search_property = 'sleep_min'
+    search_value = 2
+
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0),
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent3', sleep_min=3, sleep_max=5, watchdog=0),
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    agents = list(manager.find_objects('agents', search=search))
+
+    assert len(agents) == 2
+    for agent in agents:
+        assert getattr(agent, search_property) == search_value
+
+
+def test_find_object(agent):
+    search_property = 'paw'
+    search_value = 'agent0'
+
+    test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['agents'] = [
+        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
+        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
+        test_agent,
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    search = {search_property: search_value}
+    agents = list(manager.find_objects('agents', search=search))
+
+    assert len(agents) == 1
+    assert agents[0] == test_agent
+
+
 def test_dump(data_svc, agent):
     test_agent = agent(sleep_min=2, sleep_max=5, watchdog=0)
     dumped_agent = test_agent.schema.dump(test_agent)
 
     manager = BaseApiManager(data_svc=data_svc)
-    manager_dumped_agent = manager.dump_with_include_exclude(test_agent)
+    manager_dumped_agent = manager.dump_object_with_filters(test_agent)
 
     for key in manager_dumped_agent:
         assert manager_dumped_agent[key] == dumped_agent[key]
@@ -24,7 +115,7 @@ def test_dump_with_exclude(data_svc, agent):
     dumped_agent = test_agent.schema.dump(test_agent)
 
     manager = BaseApiManager(data_svc=data_svc)
-    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, exclude=[exclude_key])
+    manager_dumped_agent = manager.dump_object_with_filters(test_agent, exclude=[exclude_key])
 
     assert exclude_key in dumped_agent
     assert exclude_key not in manager_dumped_agent
@@ -39,7 +130,7 @@ def test_dump_with_include(data_svc, agent):
     dumped_agent = test_agent.schema.dump(test_agent)
 
     manager = BaseApiManager(data_svc=data_svc)
-    manager_dumped_agent = manager.dump_with_include_exclude(test_agent, include=[include_key])
+    manager_dumped_agent = manager.dump_object_with_filters(test_agent, include=[include_key])
 
     assert include_key in dumped_agent
     assert include_key in manager_dumped_agent
@@ -47,41 +138,7 @@ def test_dump_with_include(data_svc, agent):
     assert manager_dumped_agent[include_key] == dumped_agent[include_key]
 
 
-def test_get_objects(agent):
-    stub_data_svc = StubDataService()
-    stub_data_svc.ram['agents'] = [
-        agent(paw='agent0', sleep_min=2, sleep_max=5, watchdog=0),
-        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0)
-    ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
-
-    dumped_agents = manager.get_objects_with_filters('agents')
-
-    assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
-
-
-def test_get_objects_with_search(agent):
-    search_property = 'sleep_min'
-    search_value = 2
-
-    stub_data_svc = StubDataService()
-    stub_data_svc.ram['agents'] = [
-        agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0),
-        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
-        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
-        agent(paw='agent3', sleep_min=3, sleep_max=5, watchdog=0),
-    ]
-    manager = BaseApiManager(data_svc=stub_data_svc)
-
-    search = {search_property: search_value}
-    dumped_agents = manager.get_objects_with_filters('agents', search=search)
-
-    assert len(dumped_agents) == 2
-    for dumped_agent in dumped_agents:
-        assert dumped_agent[search_property] == search_value
-
-
-def test_get_objects_with_sort(agent):
+def test_find_and_dump_objects_with_sort(agent):
     sort_property = 'paw'
 
     stub_data_svc = StubDataService()
@@ -95,7 +152,7 @@ def test_get_objects_with_sort(agent):
     ]
     manager = BaseApiManager(data_svc=stub_data_svc)
 
-    dumped_agents = manager.get_objects_with_filters('agents', sort=sort_property)
+    dumped_agents = manager.find_and_dump_objects('agents', sort=sort_property)
 
     assert len(dumped_agents) == len(stub_data_svc.ram['agents'])
     prev_paw = None
@@ -104,20 +161,23 @@ def test_get_objects_with_sort(agent):
         prev_paw = dumped_agent[sort_property]
 
 
-def test_get_object(agent):
-    search_property = 'paw'
-    search_value = 'agent0'
-
+def test_find_and_dump_object(agent):
     test_agent = agent(paw='agent0', sleep_min=1, sleep_max=5, watchdog=0)
     stub_data_svc = StubDataService()
-    stub_data_svc.ram['agents'] = [
-        test_agent,
-        agent(paw='agent1', sleep_min=2, sleep_max=5, watchdog=0),
-        agent(paw='agent2', sleep_min=2, sleep_max=5, watchdog=0),
-    ]
+    stub_data_svc.ram['agents'] = [test_agent]
     manager = BaseApiManager(data_svc=stub_data_svc)
 
-    search = {search_property: search_value}
-    dumped_agent = manager.get_object_with_filters('agents', search=search)
+    dumped_agent = manager.find_and_dump_object('agents')
 
     assert dumped_agent == test_agent.display
+
+
+def test_store_json_as_schema():
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['tests'] = []
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    data = {'name': 'test_name', 'value': 'test_value'}
+    obj = manager.store_json_as_schema(TestSchema, data)
+
+    assert obj.name == 'test_name' and obj.value == 'test_value'

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -20,7 +20,7 @@ class TestSchema(ma.Schema):
 
     @ma.post_load()
     def build_test_object(self, data, **kwargs):
-        return None if kwargs.get('partial') else TestObject(**data)
+        return None if kwargs.get('partial') is True else TestObject(**data)
 
 
 class TestObject(FirstClassObjectInterface, BaseObject):

--- a/tests/api/v2/managers/test_base_api_manager.py
+++ b/tests/api/v2/managers/test_base_api_manager.py
@@ -187,6 +187,18 @@ def test_store_json_as_schema():
     assert obj.name == 'test_name' and obj.value == 'test_value'
 
 
+def test_store_json_as_schema_duplicate():
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['tests'] = []
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    data = {'name': 'test_name', 'value': 'test_value'}
+    manager.store_json_as_schema(TestSchema, data)
+    manager.store_json_as_schema(TestSchema, data)
+
+    assert len(stub_data_svc.ram) == 1
+
+
 def test_update_object(agent):
     stub_data_svc = StubDataService()
     stub_data_svc.ram['tests'] = [
@@ -197,8 +209,23 @@ def test_update_object(agent):
 
     data = {'value': 'value1'}
     search = {'name': 'name0'}
-    manager.update_object('tests', data, search)
+    manager.update_object('tests', 'name', data, search)
 
     assert len(stub_data_svc.ram['tests']) == 2
     for test_obj in stub_data_svc.ram['tests']:
         assert test_obj.value == 'value1'
+
+
+def test_update_object_try_to_overwrite_id(agent):
+    stub_data_svc = StubDataService()
+    stub_data_svc.ram['tests'] = [
+        TestObject(name='name_original', value='value0')
+    ]
+    manager = BaseApiManager(data_svc=stub_data_svc)
+
+    data = {'name': 'name_updated'}
+    search = {'name': 'name_original'}
+    manager.update_object('tests', 'name', data, search)
+
+    assert len(stub_data_svc.ram['tests']) == 1
+    assert stub_data_svc.ram['tests'][0].name == 'name_original'

--- a/tests/api/v2/managers/test_config_api_manager.py
+++ b/tests/api/v2/managers/test_config_api_manager.py
@@ -92,7 +92,7 @@ def test_get_filtered_config_remove_sensitive_keys(base_world, data_svc):
     }
     base_world.apply_config('test', test_conf)
 
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
     filtered = manager.get_filtered_config('test')
     expected = {
         'foo': '1',
@@ -108,33 +108,33 @@ def test_get_filtered_config_all_sensitive_keys_filtered(base_world, data_svc):
     base_world.apply_config('test', sensitive_conf)
     assert base_world.get_config(name='test') == sensitive_conf
 
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
     filtered = manager.get_filtered_config('test')
     assert filtered == {}
 
 
 def test_get_filtered_config_throws_exception_on_not_found(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(ConfigNotFound):
         manager.get_filtered_config('THIS DOES NOT EXIST')
 
 
 def test_update_main_config(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
     manager.update_main_config(prop='foo.bar', value=100)
     assert manager.get_filtered_config('main')['foo.bar'] == 100
 
 
 def test_update_main_config_throws_exception_on_sensitive_field(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(ConfigUpdateNotAllowed):
         manager.update_main_config(prop='host', value='this is not allowed')
 
 
 async def test_update_global_agent_config(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
     await manager.update_global_agent_config(sleep_min=5, sleep_max=10)
 
     agent_config = manager.get_filtered_config('agents')
@@ -143,7 +143,7 @@ async def test_update_global_agent_config(base_world, data_svc):
 
 
 async def test_update_global_agent_config_allows_partial_updates(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
     agent_config = manager.get_filtered_config('agents')
 
     await manager.update_global_agent_config()  # no arguments passed in--should no-op
@@ -158,7 +158,7 @@ async def test_update_global_agent_config_updates_list_properties(base_world, ab
         ability('ability-3')
     ]
 
-    manager = ConfigApiManager(data_svc=stub_data_svc)
+    manager = ConfigApiManager(data_svc=stub_data_svc, file_svc=None)
     await manager.update_global_agent_config(
         deadman_abilities=['ability-1', 'ability-2'],
         bootstrap_abilities=['ability-3']
@@ -170,42 +170,42 @@ async def test_update_global_agent_config_updates_list_properties(base_world, ab
 
 
 async def test_update_global_agent_config_throws_validation_error_bad_sleep_min(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_global_agent_config(sleep_min=-1)
 
 
 async def test_update_global_agent_config_throws_validation_error_bad_sleep_max(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_global_agent_config(sleep_max=-1)
 
 
 async def test_update_global_agent_config_throws_validation_error_bad_watchdog(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_global_agent_config(watchdog=-1)
 
 
 async def test_update_global_agent_config_throws_validation_error_bad_untrusted_timer(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_global_agent_config(untrusted_timer=-1)
 
 
 async def test_update_global_agent_config_throws_validation_error_bad_implant_name(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_global_agent_config(implant_name='')
 
 
 async def test_update_main_config_throws_validation_error_empty_prop(base_world, data_svc):
-    manager = ConfigApiManager(data_svc)
+    manager = ConfigApiManager(data_svc, None)
 
     with pytest.raises(errors.DataValidationError):
         await manager.update_main_config(prop='', value=1234)

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -73,7 +73,8 @@ class TestRestSvc:
         # PART A: Create an operation
         expected_operation = {'name': 'My Test Operation',
                               'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc',
-                                            'adversary_id': 'ad-hoc', 'atomic_ordering': [], 'objective': None,
+                                            'adversary_id': 'ad-hoc', 'atomic_ordering': [],
+                                            'objective': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
                                             'tags': [], 'has_repeatable_abilities': False}, 'state': 'finished',
                               'planner': {'name': 'test', 'description': None, 'module': 'test',
                                           'stopping_conditions': [], 'params': {}, 'allow_repeatable_abilities': False,
@@ -143,7 +144,8 @@ class TestRestSvc:
     def test_create_operation(self, loop, rest_svc, data_svc):
         want = {'name': 'Test',
                 'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc', 'adversary_id': 'ad-hoc',
-                              'atomic_ordering': [], 'objective': None, 'tags': [], 'has_repeatable_abilities': False},
+                              'atomic_ordering': [], 'objective': '495a9828-cab1-44dd-a0ca-66e58177d8cc', 'tags': [],
+                              'has_repeatable_abilities': False},
                 'state': 'finished',
                 'planner': {'name': 'test', 'description': None, 'module': 'test', 'stopping_conditions': [],
                             'params': {},


### PR DESCRIPTION
## Description

Fact Sources API:

- `GET /api/v2/sources/`
- `GET /api/v2/sources/:id`
- `POST /api/v2/sources`
- `PUT /api/v2/sources/:id`
- `PATCH /api/v2/sources/:id`

Objectives API:

- `GET /api/v2/objectives/`
- `GET /api/v2/objectives/:id`
- `POST /api/v2/objectives`
- `PUT /api/v2/objectives/:id`
- `PATCH /api/v2/objectives/:id`

Adversaries API:

- `GET /api/v2/adversaries`
- `GET /api/v2/adversaries/{{id}}`
- `POST /api/v2/adversaries`
- `PUT /api/v2/adversaries/{{id}}`
- `PATCH /api/v2/adversaries/{{id}}`
- `DELETE /api/v2/adversaries/{{id}}`

Agents API:

- `GET /api/v2/agents`
- `GET /api/v2/agents/:paw`
- `POST /api/v2/agents`
- `PUT /api/v2/agents/:paw`
- `PATCH /api/v2/agents/:paw`
- `DELETE /api/v2/agents/:paw`
- `DELETE /api/v2/deploy_commands/{{ability_id}}` (though this may want to get moved)


Additionally:

- This will break the Planners API, but it will hopefully make Abilities API easier
- Fixed bug for file service finding the wrong object when searching by duplicate ID
- Added schema validation error handling
  - Attribute errors for unknown fields
  - Note: `ma.post_load()` on object schemas *must* skip object instantiation if `kwargs['partial']` is `True`. This allows for documentation and validation, without validating that all fields are present. Important for `PATCH` calls.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Postman, and automated tests.

Including tests for:

- Duplicate object IDs
- Authz between red/blue users

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
