### PR TITLE
Update agent executor removal/update functions

### DIFF
--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -78,6 +78,8 @@ class Agent(FirstClassObjectInterface, BaseObject):
                     exe_name='#{exe_name}', upstream_dest='#{upstream_dest}',
                     payload=re.compile('#{payload:(.*?)}', flags=re.DOTALL))
 
+    log = BaseObject.create_logger('agent')
+
     @property
     def unique(self):
         return self.hash(self.paw)
@@ -301,6 +303,9 @@ class Agent(FirstClassObjectInterface, BaseObject):
                 # Remove the executor server-side so planners can generate appropriate links immediately.
                 self.executors.remove(executor_name)
                 self._executor_change_to_assign = dict(action='remove', executor=executor_name)
+        else:
+            self.log.error('Invalid executor name format. Please provide non-empty string. Provided value: {0}',
+                           executor_name)
 
     def set_pending_executor_path_update(self, executor_name, new_binary_path):
         """Mark specified executor to update its binary path to the new path.
@@ -314,6 +319,10 @@ class Agent(FirstClassObjectInterface, BaseObject):
             if executor_name in self.executors:
                 self._executor_change_to_assign = dict(action='update_path', executor=executor_name,
                                                        value=new_binary_path)
+        else:
+            self.log.error('Invalid format for executor name or new binary path. Please provide non-empty strings. '
+                           'Provided values: {0}, {1}',
+                           executor_name, new_binary_path)
 
     def assign_pending_executor_change(self):
         """Return the executor change dict and remove pending change to assign.

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -11,6 +11,7 @@ from app.objects.secondclass.c_fact import OriginType
 from app.utility.base_object import BaseObject
 from app.utility.base_planning_svc import BasePlanningService
 from app.utility.base_service import BaseService
+from app.utility.base_world import BaseWorld
 
 
 class AgentFieldsSchema(ma.Schema):
@@ -78,8 +79,6 @@ class Agent(FirstClassObjectInterface, BaseObject):
                     exe_name='#{exe_name}', upstream_dest='#{upstream_dest}',
                     payload=re.compile('#{payload:(.*?)}', flags=re.DOTALL))
 
-    log = BaseObject.create_logger('agent')
-
     @property
     def unique(self):
         return self.hash(self.paw)
@@ -141,6 +140,7 @@ class Agent(FirstClassObjectInterface, BaseObject):
         else:
             self.upstream_dest = self.server
         self._executor_change_to_assign = None
+        self.log = self.create_logger('agent')
 
     def store(self, ram):
         existing = self.retrieve(ram['agents'], self.unique)
@@ -304,8 +304,8 @@ class Agent(FirstClassObjectInterface, BaseObject):
                 self.executors.remove(executor_name)
                 self._executor_change_to_assign = dict(action='remove', executor=executor_name)
         else:
-            self.log.error('Invalid executor name format. Please provide non-empty string. Provided value: {0}',
-                           executor_name)
+            self.log.error('Paw %s: Invalid executor name. Please provide non-empty string. Provided value: %s',
+                           self.paw, executor_name)
 
     def set_pending_executor_path_update(self, executor_name, new_binary_path):
         """Mark specified executor to update its binary path to the new path.
@@ -320,9 +320,9 @@ class Agent(FirstClassObjectInterface, BaseObject):
                 self._executor_change_to_assign = dict(action='update_path', executor=executor_name,
                                                        value=new_binary_path)
         else:
-            self.log.error('Invalid format for executor name or new binary path. Please provide non-empty strings. '
-                           'Provided values: {0}, {1}',
-                           executor_name, new_binary_path)
+            self.log.error('Paw %s: Invalid format for executor name or new binary path. '
+                           'Please provide non-empty strings. Provided values: %s, %s',
+                           self.paw, executor_name, new_binary_path)
 
     def assign_pending_executor_change(self):
         """Return the executor change dict and remove pending change to assign.

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -290,29 +290,42 @@ class Agent(FirstClassObjectInterface, BaseObject):
     def executor_change_to_assign(self):
         return self._executor_change_to_assign
 
-    @executor_change_to_assign.setter
-    def executor_change_to_assign(self, executor_change_dict):
-        """Set pending executor change dict for the agent."""
-        if executor_change_dict:
-            self._executor_change_to_assign = executor_change_dict
-            if executor_change_dict.get('action') == 'remove':
+    def set_pending_executor_removal(self, executor_name):
+        """Mark specified executor to remove.
+
+        :param executor_name: name of executor for agent to remove
+        :type executor_name: str
+        """
+        if executor_name and isinstance(executor_name, str):
+            if executor_name in self.executors:
                 # Remove the executor server-side so planners can generate appropriate links immediately.
-                self._remove_executor(executor_change_dict.get('executor'))
+                self.executors.remove(executor_name)
+                self._executor_change_to_assign = dict(action='remove', executor=executor_name)
+
+    def set_pending_executor_path_update(self, executor_name, new_binary_path):
+        """Mark specified executor to update its binary path to the new path.
+
+        :param executor_name: name of executor for agent to update binary path
+        :type executor_name: str
+        :param new_binary_path: new binary path for executor to reference
+        :type new_binary_path: str
+        """
+        if executor_name and new_binary_path and isinstance(executor_name, str) and isinstance(new_binary_path, str):
+            if executor_name in self.executors:
+                self._executor_change_to_assign = dict(action='update_path', executor=executor_name,
+                                                       value=new_binary_path)
 
     def assign_pending_executor_change(self):
         """Return the executor change dict and remove pending change to assign.
 
-        :return: Dict (string, string) representing the executor change that is assigned.
+        :return: Dict representing the executor change that is assigned.
+        :rtype: dict(str, str)
         """
         executor_change = self.executor_change_to_assign
         self._executor_change_to_assign = None
         return executor_change
 
     """ PRIVATE """
-
-    def _remove_executor(self, executor_name):
-        if executor_name in self.executors:
-            self.executors.remove(executor_name)
 
     def _replace_payload_data(self, decoded_cmd, file_svc):
         for uuid in re.findall(self.RESERVED['payload'], decoded_cmd):

--- a/app/objects/c_agent.py
+++ b/app/objects/c_agent.py
@@ -11,7 +11,6 @@ from app.objects.secondclass.c_fact import OriginType
 from app.utility.base_object import BaseObject
 from app.utility.base_planning_svc import BasePlanningService
 from app.utility.base_service import BaseService
-from app.utility.base_world import BaseWorld
 
 
 class AgentFieldsSchema(ma.Schema):


### PR DESCRIPTION
## Description
Agent object will create the executor change dict objects rather than having users pass them in. Planners will now reference the `set_pending_executor_removal` and `set_pending_executor_path_update` agent functions to mark executors for removal/update.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested with custom planner that uses the new agent methods to update executors. Also updated tests to reflect the new methods.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
