### PR TITLE
Suppress websockets debug logging

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -15,6 +15,9 @@ class Contact(BaseWorld):
         web_socket = self.get_config('app.contact.websocket')
         try:
             await websockets.serve(self.handler.handle, *web_socket.split(':'))
+            # as soon as we start serving from websockets, we need to suppress their excessive debug messages
+            self.log.manager.loggerDict['websockets.protocol'].level = 100
+            self.log.manager.loggerDict['websockets.server'].level = 100
         except OSError as e:
             self.log.error("WebSocket error: {}".format(e))
 


### PR DESCRIPTION
## Description

Removed debug logging of websockets traffic (caused by version 9.1 update).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested by connecting an agent to the server both by myself and by @aapplebaum, and verifying that the debug messages no longer print out.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
