### PR TITLE
Remove unutilized knowledge service loading code

### DIFF
--- a/app/service/knowledge_svc.py
+++ b/app/service/knowledge_svc.py
@@ -12,13 +12,7 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
 
     def __init__(self):
         self.log = self.add_service('knowledge_svc', self)
-        target_module = self.get_config('app.knowledge_svc.module')
-        try:
-            self.__loaded_knowledge_module = self._load_module(target_module, {})
-        except Exception as e:
-            self.log.warning(f"Unable to properly load knowledge service module "
-                             f"{self.get_config('app.knowledge_svc.module')} ({e}). Reverting to default.")
-            self.__loaded_knowledge_module = BaseKnowledgeService()
+        self.__loaded_knowledge_module = BaseKnowledgeService()
 
     @staticmethod
     def _load_module(module_type, module_info):

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -14,7 +14,6 @@ app.contact.tunnel.ssh.user_password: s4ndc4t!
 app.contact.tcp: 0.0.0.0:7010
 app.contact.udp: 0.0.0.0:7011
 app.contact.websocket: 0.0.0.0:7012
-app.knowledge_svc.module: app.utility.base_knowledge_svc
 crypt_salt: REPLACE_WITH_RANDOM_VALUE
 encryption_key: ADMIN123
 exfil_dir: /tmp/caldera


### PR DESCRIPTION
## Description

Quick change to remove the loading code in Knowledge Service that would make it possible to load a non-default base module. We don't have any other modules, so it's kind of a waste for the moment.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran through the test battery. There is no actual functional change here, since the code always defaulted to the default anyway.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
