### PR TITLE
[VIRTS-2708] Update get_deploy_commands endpoint

### DIFF
--- a/app/api/v2/handlers/agent_api.py
+++ b/app/api/v2/handlers/agent_api.py
@@ -23,7 +23,7 @@ class AgentApi(BaseObjectApi):
         router.add_put('/agents/{paw}', self.create_or_update_agent)
         router.add_delete('/agents/{paw}', self.delete_agent)
 
-        router.add_get('/deploy_commands/{ability_id}', self.get_deploy_commands)
+        router.add_get('/deploy_commands', self.get_deploy_commands)
 
     @aiohttp_apispec.docs(tags=['agents'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
@@ -69,6 +69,5 @@ class AgentApi(BaseObjectApi):
     @aiohttp_apispec.docs(tags=['agents'])
     @aiohttp_apispec.response_schema(DeployCommandsSchema)
     async def get_deploy_commands(self, request: web.Request):
-        ability_id = request.match_info.get('ability_id')
-        deploy_commands = await self._api_manager.get_deploy_commands(ability_id)
+        deploy_commands = await self._api_manager.get_deploy_commands()
         return web.json_response(deploy_commands)

--- a/app/api/v2/managers/agent_api_manager.py
+++ b/app/api/v2/managers/agent_api_manager.py
@@ -5,14 +5,17 @@ class AgentApiManager(BaseApiManager):
     def __init__(self, data_svc, file_svc):
         super().__init__(data_svc=data_svc, file_svc=file_svc)
 
-    async def get_deploy_commands(self, ability_id: str):
-        abilities = await self._data_svc.locate('abilities', {'ability_id': ability_id})
+    async def get_deploy_commands(self):
+        deployment_ability_ids = tuple(self.get_config(name='agents', prop='deployments'))
+        deployment_abilities = []
+        for id in deployment_ability_ids:
+            deployment_abilities.append((await self._data_svc.locate('abilities', {'ability_id': id}))[0])
 
         raw_abilities = []
-        for ability in abilities:
+        for ability in deployment_abilities:
             for executor in ability.executors:
                 variations = [{'description': v.description, 'command': v.raw_command} for v in executor.variations]
-                raw_abilities.append({'platform': executor.platform, 'executor': executor.name,
+                raw_abilities.append({'name': ability.name, 'platform': executor.platform, 'executor': executor.name,
                                       'description': ability.description, 'command': executor.command,
                                       'variations': variations})
 


### PR DESCRIPTION
## Description

To simplify the number of requests the UI team needs to make for the agent creation page, `get_deploy_commands()` was updated to return data for all of the current deployment abilities. Originally this method would only fetch deployment data for a specified ability. 

This data contains ability names, descriptions, commands, platforms, and variations, as well as necessary app/agent config information. This only requires one GET request, whereas the original design required 3 separate requests. The API design doc has been updated to reflect this.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Submitted GET requests with Postman to verify that the necessary data was returned for each deployment ability.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
