### PR TITLE
[VIRTS-2780] Change PATCH operation link to expect unencoded command

### DIFF
--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -62,15 +62,16 @@ class OperationApiManager(BaseApiManager):
             raise JsonHttpForbidden(f'Cannot update link {link_id} due to insufficient permissions.')
         if link.is_finished() or link.can_ignore():
             raise JsonHttpForbidden(f'Cannot update a finished link: {link_id}')
+        if link_data.get('command'):
+            command_str = link_data.get('command')
+            link.executor.command = command_str
+            link.ability = self.build_ability({}, link.executor)
+            link.command = self._encode_string(command_str)
         if link_data.get('status'):
             link_status = link_data['status']
             if not link.is_valid_status(link_status):
                 raise JsonHttpBadRequest(f'Cannot update link {link_id} due to invalid link status.')
             link.status = link_status
-        if link_data.get('command'):
-            link.command = link_data.get('command')
-            command_str = self._decode_string(link_data.get('command'))
-            link.executor.command = command_str
         return link.display
 
     async def create_potential_link(self, operation_id: str, data: dict, access: BaseWorld.Access):


### PR DESCRIPTION
## Description
There was a small bug that caused a discrepancy between the old rest API behavior and the new v2 behavior. In the old ui, manual commands were expected to be provided as unencoded commands that were then base64 encoded; with these changes, v2 `PATCH /api/v2/operations/{operation_id}/links/{link_id}` now expects the same.

On `POST /api/v2/operations/{operation_id}/potential-links` and `PATCH /api/v2/operations/{operation_id}/links/{link_id}`  requests, link commands are expected to be unencoded, as they will be base64 encoded and applied to the link object. For nested fields such as executor and ability, the command will be unencoded.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with Postman to verify that correct fields were being updated, and that expected output was the same as modifying the link with the UI.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
