### PR TITLE
[VIRTS-2857] Fact Sources Delete Endpoint

### DIFF
--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -20,6 +20,7 @@ class FactSourceApi(BaseObjectApi):
         router.add_post('/sources', self.create_fact_source)
         router.add_patch('/sources/{id}', self.update_fact_source)
         router.add_put('/sources/{id}', self.create_or_update_source)
+        router.add_delete('/sources/{id}', self.delete_source)
 
     @aiohttp_apispec.docs(tags=['sources'])
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
@@ -55,3 +56,9 @@ class FactSourceApi(BaseObjectApi):
     async def create_or_update_source(self, request: web.Request):
         source = await self.create_or_update_on_disk_object(request)
         return web.json_response(source.display)
+
+    @aiohttp_apispec.docs(tags=['sources'])
+    @aiohttp_apispec.response_schema(SourceSchema)
+    async def delete_source(self, request: web.Request):
+        await self.delete_object(request)
+        return web.HTTPNoContent()


### PR DESCRIPTION
## Description
Single endpoint for deleting fact sources from data service.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested using Postman to confirm that fact sources are deleted correctly. A Pytest unit test was not added, because an underlying aiohttp bug causes errors for DELETE requests in Pytest.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
