### PR TITLE
Add back stockpile and atomic to nav, just disable them

### DIFF
--- a/static/css/core.css
+++ b/static/css/core.css
@@ -93,6 +93,14 @@ main.main {
   background-color: #060606;
 }
 
+.nav-item.disabled {
+  color: #a0a0a0;
+}
+.nav-item:hover.disabled {
+  background-color: transparent;
+  color: #a0a0a0;
+}
+
 #no-open-tabs {
   width: 100%;
   height: 50%;

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -21,6 +21,8 @@ function alpineCore() {
             if (tabName === 'fieldmanual') {
                 restRequest('GET', null, (data) => { this.setTabContent({ name: tabName, contentID: `tab-${tabName}`, address: address }, data); }, address);
                 return;
+            } else if (tabName === 'stockpile' || tabName === 'atomic') {
+                return;
             }
 
             // If tab is already open, jump to it

--- a/templates/BLUE.html
+++ b/templates/BLUE.html
@@ -40,8 +40,9 @@
                     <p class="menu-label"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
                     <ul class="menu-list">
                         {% for plugin in plugins | sort(attribute='name') %}
-                            <li x-show="'{{ plugin.name }}' !== 'atomic' && '{{ plugin.name }}' !== 'stockpile'">
-                                <a x-on:click="addTab('{{ plugin.name }}', '{{ plugin.address }}')">{{ plugin.name }}
+                        <li>
+                            <a x-on:click="addTab('{{ plugin.name }}', '{{ plugin.address }}')" class="nav-item" x-bind:class="{ 'disabled': '{{ plugin.name }}' === 'atomic' || '{{ plugin.name }}' === 'stockpile' }">
+                                {{ plugin.name }}
                                     <template x-if="`{{plugin.name | e}}` === 'fieldmanual'">
                                         <sup><i class="fas fa-external-link-alt pl-1 is-size-7"></i></sup>
                                     </template>

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -40,8 +40,9 @@
                     <p class="menu-label"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
                     <ul class="menu-list">
                         {% for plugin in plugins | sort(attribute='name') %}
-                            <li x-show="'{{ plugin.name }}' !== 'atomic' && '{{ plugin.name }}' !== 'stockpile'">
-                                <a x-on:click="addTab('{{ plugin.name }}', '{{ plugin.address }}')">{{ plugin.name }}
+                            <li>
+                                <a x-on:click="addTab('{{ plugin.name }}', '{{ plugin.address }}')" class="nav-item" x-bind:class="{ 'disabled': '{{ plugin.name }}' === 'atomic' || '{{ plugin.name }}' === 'stockpile' }">
+                                    {{ plugin.name }}
                                     <template x-if="`{{plugin.name | e}}` === 'fieldmanual'">
                                         <sup><i class="fas fa-external-link-alt pl-1 is-size-7"></i></sup>
                                     </template>


### PR DESCRIPTION
## Description

Adds stockpile and atomic back to nav bar, but a user can no longer click on it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Atomic and stockpile don't show a UI


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
