### PR TITLE
Fix scrollbar color in chrome, minor UI tweaks with ability modals

### DIFF
--- a/static/css/core.css
+++ b/static/css/core.css
@@ -4,6 +4,21 @@ body {
   scroll-behavior: smooth;
 }
 
+*::-webkit-scrollbar {
+  background-color: #0000;
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-thumb {
+  background: #3f3f3f;
+  border-radius: 10px;
+  height: 50px;
+}
+*::-webkit-scrollbar-corner {
+  background-color: #0000;
+  color: white;
+}
+
 .level {
   width: 100%;
 }

--- a/templates/abilities.html
+++ b/templates/abilities.html
@@ -69,7 +69,7 @@
                         <tr @click="selectAbility(ability)">
                             <td>
                                 <p x-text="ability.name"></p>
-                                <p class="help" x-text="ability.description"></p>
+                                <p class="help ability-description" x-text="ability.description"></p>
                             </td>
                             <td x-text="ability.tactic"></td>
                             <td x-text="`${ability.technique_id} | ${ability.technique_name}`"></td>
@@ -263,7 +263,7 @@
                                             <div class="field">
                                                 <div class="control">
                                                     <div class="select is-small is-multiple is-fullwidth">
-                                                        <select class="select" multiple size="6">
+                                                        <select class="select is-multiple" multiple size="6">
                                                             <template x-for="payload of payloads">
                                                                 <option x-show="executor.payloads.indexOf(payload) === -1" x-on:click="executor.payloads.push(payload)" x-text="payload"></option>
                                                             </template>      
@@ -535,13 +535,17 @@
 
     #abilities-table {
         height: calc(100vh - 480px);
-        overflow: scroll;
+        overflow-y: scroll;
     }
 
     #main-content {
         display: flex;
         flex-flow: column;
         height: 100%;
+    }
+
+    .ability-description {
+        word-break: break-word;
     }
 
     tr:hover {

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -533,7 +533,7 @@
                                             <div class="field">
                                                 <div class="control">
                                                     <div class="select is-small is-multiple is-fullwidth">
-                                                        <select class="select" multiple size="6">
+                                                        <select class="select is-multiple" multiple size="6">
                                                             <template x-for="payload of payloads">
                                                                 <option x-show="executor.payloads.indexOf(payload) === -1" x-on:click="executor.payloads.push(payload)" x-text="payload"></option>
                                                             </template>      


### PR DESCRIPTION
## Description

Removes the jarring white scrollbar on all pages in Chrome and fixes some small UI bugs on ability modals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Chrome and FF have consistent styles.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
