### PR TITLE
virts-2891 - Planner parsing error checking

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -190,8 +190,13 @@ class Link(BaseObject):
             source_facts = operation.source.facts if operation else []
             try:
                 relationships = await self._parse_link_result(result, parser, source_facts)
-                await update_scores(operation, increment=len(relationships), used=self.used, facts=self.facts)
-                await self._create_relationships(relationships, operation)
+                if relationships == 418:
+                    logging.getLogger('link').debug(f'link {self.id} (ability id={self.ability.ability_id}) during '
+                                                    f'execution, which was caught during parsing.')
+                    self.status = self.states['ERROR']
+                else:
+                    await update_scores(operation, increment=len(relationships), used=self.used, facts=self.facts)
+                    await self._create_relationships(relationships, operation)
             except Exception as e:
                 logging.getLogger('link').debug('error in %s while parsing ability %s: %s'
                                                 % (parser.module, self.ability.ability_id, e))

--- a/app/utility/base_parser.py
+++ b/app/utility/base_parser.py
@@ -1,6 +1,8 @@
 import json
 import re
 
+PARSER_SIGNALS_FAILURE = 418  # Universal Teapot error code
+
 
 class BaseParser:
 


### PR DESCRIPTION
## Description

This change makes it possible for parsers to return an error code that signals the failure of a link based on the return, regardless of the return code of the link. This functionality is not automatic, and needs to be manually triggered from parsers to occur. For an example, see the [atomic example](https://github.com/mitre/atomic/pull/27).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been tested in a AWS environment with Alice 2.0, as well as with the full battery of tests.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
