### PR TITLE
[VIRTS-2869] Relationship Schema Error when creating Operation via v2 API

### DIFF
--- a/app/objects/secondclass/c_relationship.py
+++ b/app/objects/secondclass/c_relationship.py
@@ -13,6 +13,11 @@ class RelationshipSchema(ma.Schema):
     score = ma.fields.Integer()
     origin = ma.fields.String(allow_none=True)
 
+    @ma.pre_load
+    def remove_unique(self, data, **_):
+        data.pop('unique', None)
+        return data
+
     @ma.post_load
     def build_relationship(self, data, **_):
         return Relationship(**data)

--- a/tests/api/v2/handlers/test_operations_api.py
+++ b/tests/api/v2/handlers/test_operations_api.py
@@ -251,6 +251,7 @@ class TestOperationsApi:
         assert op_data['start']
         assert op_data['planner']['id'] == payload['planner']['id']
         assert op_data['source']['id'] == payload['source']['id']
+        assert len(op_data['source']['relationships']) == len(payload['source']['relationships'])
 
     async def test_create_finished_operation(self, api_v2_client, api_cookies, test_operation):
         payload = dict(name='post_test', id='111', planner={'id': '123'},


### PR DESCRIPTION
## Description
When creating an operation using the v2 API, if a Source with an existing relationship is provided, an invalid key would be provided to the `Relationship()` constructor. This PR removes the `unique` key (which is dump only) when the Relationship object is being loaded.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Verified manually with postman, and added an operations api unit test for this specific case.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
