### PR TITLE
Change cursor on navbar items, fix agent commands bugs

### DIFF
--- a/static/css/core.css
+++ b/static/css/core.css
@@ -100,7 +100,7 @@ main.main {
   justify-content: center;
 }
 
-.nav-logo img{
+.nav-logo img {
   max-height: 150px;
   cursor: pointer;
 }
@@ -109,12 +109,18 @@ main.main {
   background-color: #060606;
 }
 
+.nav-header {
+  cursor: default;
+}
+
 .nav-item.disabled {
   color: #a0a0a0;
 }
 .nav-item:hover.disabled {
   background-color: transparent;
   color: #a0a0a0;
+  cursor: default;
+  margin: 0;
 }
 
 #no-open-tabs {
@@ -161,4 +167,8 @@ main.main {
 .toast {
   padding: 10px 10px !important;
   border-radius: 4px !important;
+}
+
+.user-badge {
+  cursor: default !important;
 }

--- a/templates/BLUE.html
+++ b/templates/BLUE.html
@@ -19,7 +19,7 @@
                     <img src="/gui/img/caldera-logo.png" alt="CALDERA logo" @click="window.open('https://caldera.mitre.org?ref=caldera', '_blank')"/>
                 </div>
                 <div class="is-flex is-justify-content-center">
-                    <span class="button is-primary is-small is-rounded mb-2"><i class="fas fa-user pr-3"></i>blue</span>
+                    <span class="tag is-primary is-small is-rounded mb-2 p-4 user-badge"><i class="fas fa-user pr-3"></i>blue</span>
                 </div>
                 <template x-if="errors.length > 0">
                     <div class="is-flex is-justify-content-center">
@@ -30,14 +30,14 @@
                     </div>
                 </template>
                 <aside id="nav-menu" class="menu">
-                    <p class="menu-label"><i class="fas fa-flag pr-2"></i>Campaigns</p>
+                    <p class="menu-label nav-header"><i class="fas fa-flag pr-2"></i>Campaigns</p>
                     <ul class="menu-list">
-                        <li><a href="#home" x-on:click="addTab('agents', '/campaign/agents')">agents</a></li>
-                        <li><a href="#home" x-on:click="addTab('abilities', '/campaign/abilities')">abilities</a></li>
-                        <li><a href="#home" x-on:click="addTab('adversaries', '/campaign/profiles')">defenders</a></li>
-                        <li><a href="#home" x-on:click="addTab('operations', '/campaign/operations')">operations</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('agents', '/campaign/agents')">agents</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('abilities', '/campaign/abilities')">abilities</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('adversaries', '/campaign/profiles')">defenders</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('operations', '/campaign/operations')">operations</a></li>
                     </ul>
-                    <p class="menu-label"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
+                    <p class="menu-label nav-header"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
                     <ul class="menu-list">
                         {% for plugin in plugins | sort(attribute='name') %}
                         <li>
@@ -50,15 +50,15 @@
                             </li>
                         {% endfor %}
                     </ul>
-                    <p class="menu-label"><i class="fas fa-cog pr-2"></i></i>Configuration</p>
+                    <p class="menu-label nav-header"><i class="fas fa-cog pr-2"></i></i>Configuration</p>
                     <ul class="menu-list">
-                        <li><a href="#home" x-on:click="addTab('fact sources', '/advanced/sources')">fact sources</a></li>
-                        <li><a href="#home" x-on:click="addTab('objectives', '/advanced/objectives')">objectives</a></li>
-                        <li><a href="#home" x-on:click="addTab('planners', '/advanced/planners')">planners</a></li>
-                        <li><a href="#home" x-on:click="addTab('contacts', '/advanced/contacts')">contacts</a></li>
-                        <li><a href="#home" x-on:click="addTab('obfuscators', '/advanced/obfuscators')">obfuscators</a></li>
-                        <li><a href="#home" x-on:click="addTab('configuration', '/advanced/configurations')">configuration</a></li>
-                        <li><a href="#home" x-on:click="addTab('exfilled files', '/advanced/exfills')">exfilled files</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('fact sources', '/advanced/sources')">fact sources</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('objectives', '/advanced/objectives')">objectives</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('planners', '/advanced/planners')">planners</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('contacts', '/advanced/contacts')">contacts</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('obfuscators', '/advanced/obfuscators')">obfuscators</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('configuration', '/advanced/configurations')">configuration</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('exfilled files', '/advanced/exfills')">exfilled files</a></li>
                         <li><a href="./api/docs" target="_blank">
                             api docs
                             <sup><i class="fas fa-external-link-alt pl-1 is-size-7"></i></sup></a>

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -19,7 +19,7 @@
                     <img src="/gui/img/caldera-logo.png" alt="CALDERA logo" @click="window.open('https://caldera.mitre.org?ref=caldera', '_blank')"/>
                 </div>
                 <div class="is-flex is-justify-content-center">
-                    <span class="button is-primary is-small is-rounded mb-2"><i class="fas fa-user pr-3"></i>red</span>
+                    <span class="tag is-primary is-small is-rounded mb-2 p-4 user-badge"><i class="fas fa-user pr-3"></i>red</span>
                 </div>
                 <template x-if="errors.length > 0">
                     <div class="is-flex is-justify-content-center">
@@ -30,14 +30,14 @@
                     </div>
                 </template>
                 <aside id="nav-menu" class="menu">
-                    <p class="menu-label"><i class="fas fa-flag pr-2"></i>Campaigns</p>
+                    <p class="menu-label nav-header"><i class="fas fa-flag pr-2"></i>Campaigns</p>
                     <ul class="menu-list">
-                        <li><a href="#home" x-on:click="addTab('agents', '/campaign/agents')">agents</a></li>
-                        <li><a href="#home" x-on:click="addTab('abilities', '/campaign/abilities')">abilities</a></li>
-                        <li><a href="#home" x-on:click="addTab('adversaries', '/campaign/profiles')">adversaries</a></li>
-                        <li><a href="#home" x-on:click="addTab('operations', '/campaign/operations')">operations</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('agents', '/campaign/agents')">agents</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('abilities', '/campaign/abilities')">abilities</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('adversaries', '/campaign/profiles')">adversaries</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('operations', '/campaign/operations')">operations</a></li>
                     </ul>
-                    <p class="menu-label"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
+                    <p class="menu-label nav-header"><i class="fas fa-puzzle-piece pr-2"></i>Plugins</p>
                     <ul class="menu-list">
                         {% for plugin in plugins | sort(attribute='name') %}
                             <li>
@@ -50,15 +50,15 @@
                             </li>
                         {% endfor %}
                     </ul>
-                    <p class="menu-label"><i class="fas fa-cog pr-2"></i></i>Configuration</p>
+                    <p class="menu-label nav-header"><i class="fas fa-cog pr-2"></i></i>Configuration</p>
                     <ul class="menu-list">
-                        <li><a href="#home" x-on:click="addTab('fact sources', '/advanced/sources')">fact sources</a></li>
-                        <li><a href="#home" x-on:click="addTab('objectives', '/advanced/objectives')">objectives</a></li>
-                        <li><a href="#home" x-on:click="addTab('planners', '/advanced/planners')">planners</a></li>
-                        <li><a href="#home" x-on:click="addTab('contacts', '/advanced/contacts')">contacts</a></li>
-                        <li><a href="#home" x-on:click="addTab('obfuscators', '/advanced/obfuscators')">obfuscators</a></li>
-                        <li><a href="#home" x-on:click="addTab('configuration', '/advanced/configurations')">configuration</a></li>
-                        <li><a href="#home" x-on:click="addTab('exfilled files', '/advanced/exfills')">exfilled files</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('fact sources', '/advanced/sources')">fact sources</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('objectives', '/advanced/objectives')">objectives</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('planners', '/advanced/planners')">planners</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('contacts', '/advanced/contacts')">contacts</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('obfuscators', '/advanced/obfuscators')">obfuscators</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('configuration', '/advanced/configurations')">configuration</a></li>
+                        <li><a href="#home" class="nav-item" x-on:click="addTab('exfilled files', '/advanced/exfills')">exfilled files</a></li>
                         <li><a href="./api/docs" target="_blank">
                             api docs
                             <sup><i class="fas fa-external-link-alt pl-1 is-size-7"></i></sup></a>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -551,6 +551,9 @@
                 this.agentFields = [];
                 this.filteredCommands.forEach((command) => {
                     fields = fields.concat([...command.command.matchAll(/#{(.*?)}/gm)].map((field) => field[1]));
+                    command.variations.forEach((variation) => {
+                        fields = fields.concat([...variation.command.matchAll(/#{(.*?)}/gm)].map((field) => field[1]));
+                    })
                 });
                 fields = [...new Set(fields)];
                 fields.forEach((field) => {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -530,7 +530,7 @@
 
                                         <div>
                                             <label for="autonomous-source"><span
-                                                    class="has-tooltip-multiline has-tooltip-bottom"
+                                                    class="has-tooltip-multiline has-tooltip-top"
                                                     x-bind:data-tooltip="usage['Fact source']">Fact source</span></label>
                                             <div class="modal-form-fields" id="autonomous-source">
                                                 <div class="select is-small my-2 ml-3">
@@ -675,7 +675,7 @@
 
                                         <div>
                                             <label for="stealth-jitter"><span
-                                                    class="has-tooltip-multiline has-tooltip-bottom"
+                                                    class="has-tooltip-multiline has-tooltip-top"
                                                     x-bind:data-tooltip="usage['Jitter']">Jitter (sec/sec)</span></label>
                                             <div class="modal-form-fields" id="stealth-jitter">
                                                 <input class="input"
@@ -706,7 +706,7 @@
                                         </div>
                                         <div>
                                             <label for="stealth-queue"><span
-                                                    class="has-tooltip-multiline has-tooltip-bottom"
+                                                    class="has-tooltip-multiline has-tooltip-top"
                                                     x-bind:data-tooltip="usage['Visibility']">Visibility</span></label>
                                             <div class="modal-form-fields">
                                                 <input x-model="startOperation.visibility"


### PR DESCRIPTION
## Description

This commit fixes a UI bug on the agent deploy modal, where some fields were not automatically populated into the commands. The nav bar also had some styles changed for hover events, so that the cursor matches what the user is able to do (i.e. no more pointer cursor when hovering over plugin with no UI)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All agent deploys on any platform show all fields, no console errors.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
