### PR TITLE
Drop Python 3.6 support, add 3.9 to tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,8 @@ jobs:
             toxenv: py37,style,coverage-ci
           - python-version: 3.8
             toxenv: py38,style,coverage-ci
+          - python-version: 3.9
+            toxenv: py39,style,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ python -m pytest
 ```
 This will run all unit tests in your current development environment. Depending on the level of the change, you might need to run the test suite on various versions of Python. The unit testing pipeline will run the entire suite across multiple Python versions that we support when you submit your PR.
 
-We utilize `tox` to test CALDERA in multiple versions of Python. This will only run the interpreter is present on your system. We currently test 3.6+. To run tox, execute:
+We utilize `tox` to test CALDERA in multiple versions of Python. This will only run if the interpreter is present on your system. To run tox, execute:
 ```
 tox
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These plugins are ready to use but are not included by default:
 These requirements are for the computer running the core framework:
 
 * Any Linux or MacOS
-* Python 3.6.1+ (with Pip3)
+* Python 3.7+ (with Pip3)
 * Recommended hardware to run on is 8GB+ RAM and 2+ CPUs
 
 ## Installation

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -50,7 +50,7 @@ requirements:
     attr: version
     module: sys
     type: python_module
-    version: 3.6.1
+    version: 3.7.0
 users:
   blue:
     blue: admin

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -137,7 +137,7 @@ async def test_command_overwrite_failure(aiohttp_client, authorized_cookies):
                                                           python=dict(attr='version',
                                                                       module='sys',
                                                                       type='python_module',
-                                                                      version='3.6.1'))))
+                                                                      version='3.7.0'))))
 
     assert resp.status == HTTPStatus.OK
     config_dict = await resp.json()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{35,36,37,38,3}
+    py{37,38,39,3}
     style
     coverage
     safety


### PR DESCRIPTION
## Description

Drop Python 3.6 support. Start testing 3.9.
Corresponding documentation PR: https://github.com/mitre/fieldmanual/pull/81

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Ran tox locally. Searched project for all references of `3.6`.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
