### PR TITLE
Add Python 3.9 testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,8 @@ jobs:
             toxenv: py37,style,coverage-ci
           - python-version: 3.8
             toxenv: py38,style,coverage-ci
+          - python-version: 3.9
+            toxenv: py39,style,coverage-ci
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -38,9 +38,9 @@ class TestFileService:
         loop.run_until_complete(file_svc.save_file(filename, payload, tmp_path, encrypt=False))
         file_location = tmp_path / filename
         # Read file contents from saved file
-        file_contents = open(file_location, "r")
         assert os.path.isfile(file_location)
-        assert payload.decode("utf-8") == file_contents.read()
+        with open(file_location, "r") as file_contents:
+            assert payload.decode("utf-8") == file_contents.read()
 
     def test_create_exfil_sub_directory(self, loop, file_svc):
         exfil_dir_name = 'unit-testing-Rocks'

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{37,38,3}
+    py{37,38,39}
     style
     coverage
     safety
@@ -25,21 +25,8 @@ deps =
     coverage
     codecov
 commands =
-    coverage run -p -m pytest --tb=short -Werror tests
-
-[testenv:py38]
-description = run tests
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
-deps =
-    -rrequirements.txt
-    virtualenv!=20.0.22
-    pre-commit
-    pytest
-    pytest-aiohttp
-    coverage
-    codecov
-commands =
-    coverage run -p -m pytest --tb=short tests
+    py37: coverage run -p -m pytest --tb=short -Werror tests
+    py{38,39}: coverage run -p -m pytest --tb=short tests
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
## Description

- Adds automated testing with Python 3.9
- Simplifies the tox config
- Fixes 1 warning in file service tests

We were already only treating warnings as errors in 3.7, not 3.8. There are a bunch of asyncio warnings in 3.8 and 3.9. A fix for some has been merged into CPython (https://github.com/python/cpython/pull/23521) but doesn't seem to be included in any released version yet, that I can find.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran tox locally.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
