### PR TITLE
Adding primary color as CSS variable for training plugin to use RED/B…

### DIFF
--- a/templates/BLUE.html
+++ b/templates/BLUE.html
@@ -11,6 +11,11 @@
         <link rel="stylesheet" href="/gui/css/lib/custom-bulma-blue.css">
         <link rel="stylesheet" href="/gui/css/lib/bulma-tooltip.min.css">
         <link href="/gui/css/lib/fa-all.min.css" rel="stylesheet">
+        <style>
+            :root {
+                --primary-color: #191970;
+            }
+        </style>
     </head>
     <body>
         <main id="home" class="main" x-data="alpineCore()">

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -11,6 +11,11 @@
         <link rel="stylesheet" href="/gui/css/lib/custom-bulma-red.css">
         <link rel="stylesheet" href="/gui/css/lib/bulma-tooltip.min.css">
         <link href="/gui/css/lib/fa-all.min.css" rel="stylesheet">
+        <style>
+            :root {
+                --primary-color: #8B0000;
+            }
+        </style>
     </head>
     <body>
         <main id="home" class="main" x-data="alpineCore()">


### PR DESCRIPTION
…LUE colors

## Description

This needs to be pulled in alongside this [PR in the training plugin](https://github.com/mitre/training/pull/138) in order for the training plugin to take the correct RED/BLUE theme colors

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
