### PR TITLE
Knowledge Service Documentation Patch

### DIFF
--- a/app/service/interfaces/i_data_svc.py
+++ b/app/service/interfaces/i_data_svc.py
@@ -8,6 +8,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def apply(self, collection):
         """
         Add a new collection to RAM
+
         :param collection:
         :return:
         """
@@ -17,6 +18,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def load_data(self, plugins):
         """
         Non-blocking read all the data sources to populate the object store
+
         :return: None
         """
         pass
@@ -25,6 +27,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def reload_data(self, plugins):
         """
         Blocking read all the data sources to populate the object store
+
         :return: None
         """
         pass
@@ -33,6 +36,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def store(self, c_object):
         """
         Accept any c_object type and store it (create/update) in RAM
+
         :param c_object:
         :return: a single c_object
         """
@@ -42,6 +46,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def locate(self, object_name, match):
         """
         Find all c_objects which match a search. Return all c_objects if no match.
+
         :param object_name:
         :param match: dict()
         :return: a list of c_object types
@@ -52,6 +57,7 @@ class DataServiceInterface(ObjectServiceInterface):
     def remove(self, object_name, match):
         """
         Remove any c_objects which match a search
+
         :param object_name:
         :param match: dict()
         :return:

--- a/app/service/interfaces/i_knowledge_svc.py
+++ b/app/service/interfaces/i_knowledge_svc.py
@@ -8,6 +8,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def add_fact(self, fact, constraints=None):
         """
         Add a fact to the internal store
+
         :param fact: Fact to add
         :param constraints: any potential constraints
         """
@@ -17,6 +18,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def update_fact(self, criteria, updates):
         """
         Update a fact in the internal store
+
         :param criteria: dictionary containing fields to match on
         :param updates: dictionary containing fields to replace
         """
@@ -26,6 +28,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def get_facts(self, criteria, restrictions=None):
         """
         Retrieve a fact from the internal store
+
         :param criteria: dictionary containing fields to match on
         :return: list of facts matching the criteria
         """
@@ -35,24 +38,34 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def delete_fact(self, criteria):
         """
         Delete a fact from the internal store
+
         :param criteria: dictionary containing fields to match on
         """
         pass
 
     @abc.abstractmethod
     async def get_meta_facts(self, meta_fact=None, agent=None, group=None):
-        """Returns the complete set of facts associated with a meta-fact construct"""
+        """Returns the complete set of facts associated with a meta-fact construct [In Development]"""
         pass
 
     @abc.abstractmethod
     async def get_fact_origin(self, fact):
-        """Retrieve the specific origin of a fact. If it was learned in the current operation, parse through
-        links to identify the host it was discovered on."""
+        """
+        Identify the place where a fact originated, either the source that loaded it or its original link
+
+        :param fact: Fact to get origin for (can be either a trait string or a full blown fact)
+        :return: tuple - (String of either origin source id or origin link id, fact origin type)"""
         pass
 
     @abc.abstractmethod
     async def check_fact_exists(self, fact, listing=None):
-        """Check to see if a fact already exists in the knowledge store, or if a listing is provided, in said listing"""
+        """
+        Check to see if a fact already exists in the knowledge store, or if a listing is provided, in said listing
+
+        :param fact: The fact to check for
+        :param listing: Optional specific listing to examine
+        :return: Bool indicating whether or not the fact is already present
+        """
         pass
 
     # -- Relationships API --
@@ -60,6 +73,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def get_relationships(self, criteria, restrictions=None):
         """
         Retrieve relationships from the internal store
+
         :param criteria: dictionary containing fields to match on
         :return: list of matching relationships
         """
@@ -69,6 +83,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def add_relationship(self, relationship, constraints=None):
         """
         Add a relationship to the internal store
+
         :param relationship: Relationship object to add
         :param constraints: optional constraints on the use of the relationship
         """
@@ -78,6 +93,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def update_relationship(self, criteria, updates):
         """
         Update a relationship in the internal store
+
         :param criteria: dictionary containing fields to match on
         :param updates: dictionary containing fields to modify
         """
@@ -87,6 +103,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def delete_relationship(self, criteria):
         """
         Remove a relationship from the internal store
+
         :param criteria: dictionary containing fields to match on
         """
         pass
@@ -96,6 +113,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def add_rule(self, rule, constraints=None):
         """
         Add a rule to the internal store
+
         :param rule: Rule object to add
         :param constraints: dictionary containing fields to match on
         """
@@ -105,6 +123,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def get_rules(self, criteria, restrictions=None):
         """
         Retrieve rules from the internal store
+
         :param criteria: dictionary containing fields to match on
         :return: list of matching rules
         """
@@ -114,6 +133,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
     async def delete_rule(self, criteria):
         """
         Remove a rule from the internal store
+
         :param criteria: dictionary containing fields to match on
         """
         pass

--- a/app/service/knowledge_svc.py
+++ b/app/service/knowledge_svc.py
@@ -27,10 +27,6 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
         return await self.__loaded_knowledge_module._update_fact(criteria, updates)
 
     async def get_facts(self, criteria, restrictions=None):
-        """
-        # Becomes a powerful function, because it sorts and filters out facts based on
-        # input (values, groupings) as well as underlying mechanisms such as fact mutexs
-        """
         return await self.__loaded_knowledge_module._get_facts(criteria, restrictions)
 
     async def delete_fact(self, criteria):
@@ -40,19 +36,9 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
         return await self.__loaded_knowledge_module._get_meta_facts(meta_fact, agent, group)
 
     async def get_fact_origin(self, fact):
-        """
-        # Retrieve the specific origin of a fact. If it was learned in the current operation, parse through
-        # links to identify the host it was discovered on.
-        """
         return await self.__loaded_knowledge_module._get_fact_origin(fact)
 
     async def check_fact_exists(self, fact, listing=None):
-        """
-        Check to see if a fact already exists in the knowledge store, or if a listing is provided, in said listing
-        :param fact: The fact to check for
-        :param listing: Optional specific listing to examine
-        :return: Bool indicating whether or not the fact is already present
-        """
         searchable = fact.display
         if not listing:
             results = await self.get_facts(criteria=searchable)
@@ -79,14 +65,6 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
 
     # --- Rules ---
     async def add_rule(self, rule, constraints=None):
-        """
-        # Add a rule to the knowledge service
-        # Args:
-        #    rule.action: [DENY, ALLOW, EXCLUSIVE, EXCLUSIVE_TRAIT, EXCLUSIVE_VALUE], 'EXCLUSIVE_*' actions denote that
-        #        the trait/value will be made mutually exclusive in its use to the agent/group/operation that is
-        #        specified for. Essentially a fact is binded to mutex, and only one action can be using the fact
-        #        at any one time.
-        """
         if isinstance(rule, Rule):
             return await self.__loaded_knowledge_module._add_rule(rule, constraints)
 
@@ -97,13 +75,23 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
         return await self.__loaded_knowledge_module._delete_rule(criteria)
 
     async def save_state(self):
+        """
+        Save Internal Datastore state to disk
+        """
         return await self.__loaded_knowledge_module._save_state()
 
     async def restore_state(self):
+        """
+        Restore Internal Datastore state from disk
+        """
         return await self.__loaded_knowledge_module._restore_state()
 
     async def destroy(self):
         """
-        Delete data stores
+        Reset the caldera data directory and server state.
+
+        This creates a gzipped tarball backup of the data files tracked by caldera.
+        Paths are preserved within the tarball, with all files having "data/" as the
+        root.
         """
         return self.__loaded_knowledge_module._destroy()


### PR DESCRIPTION
## Description

Updated documentation for knowledge service so it should render properly in readthedocs. Basically, without some necessary newlines, the autogenerated documentation was off. I also took a moment to clean/organize things up now that the service is more fleshed out.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

This has been tested via local documentation generation. The underlying code has been in use for a while now.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
