### PR TITLE
Fix ability executor errors in Chrome

### DIFF
--- a/templates/abilities.html
+++ b/templates/abilities.html
@@ -194,7 +194,7 @@
                             <button class="button is-small is-primary" @click="addExecutorToAbility('before')">+ Add Executor</button>
                         </div>
                         <br>
-                        <template x-for="(executor, index) of selectedAbility.executors" :key="`${executor.platform}-${executor.name}`">
+                        <template x-for="(executor, index) of selectedAbility.executors" :key="index">
                             <div class="box">
                                 <div class="has-text-right">
                                     <button class="delete" @click="selectedAbility.executors.splice(index, 1)"></button>

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -92,7 +92,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <template x-for="(ability, index) in selectedProfileAbilities">
+                    <template x-for="(ability, index) of selectedProfileAbilities">
                         <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1, 'row-hover': ability.ability_id === abilityTableDragHoverId }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id">
                             <td class="has-text-centered drag" @click.stop draggable="true" x-on:dragstart="startAbilitySwap"  x-on:dragover.prevent="swapAbilitiesHover" x-on:dragend="swapAbilities">&#9776;</td>
                             <td x-text="index + 1"></td>
@@ -464,7 +464,7 @@
                             <button class="button is-small is-primary" @click="addExecutorToAbility('before')">+ Add Executor</button>
                         </div>
                         <br>
-                        <template x-for="(executor, index) of getAbilityExecutors()" :key="`${executor.platform}-${executor.name}`">
+                        <template x-for="(executor, index) of getAbilityExecutors()" :key="index">
                             <div class="box">
                                 <div class="has-text-right">
                                     <button class="delete" @click="selectedAbility.executors.splice(index, 1)"></button>
@@ -958,6 +958,9 @@
             addExecutorToAbility(bOrA) {
                 const template = {
                     payloads: [],
+                    parsers: [],
+                    cleanup: [],
+                    requirements: [],
                     platform: 'linux'
                 };
 


### PR DESCRIPTION
## Description

Fixes a bug in Chrome where users are unable to add executors to an ability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested adding executors in Chrome and no errors appeared.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
