### PR TITLE
[VIRTS-3044] Silence Schema Warnings

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import sys
+import warnings
 
 import aiohttp_apispec
 from aiohttp_apispec import validation_middleware
@@ -77,6 +78,10 @@ def init_swagger_documentation(app):
     """Makes swagger documentation available at /api/docs for any endpoints
     marked for aiohttp_apispec documentation.
     """
+    warnings.filterwarnings(
+        "ignore",
+        message="Multiple schemas resolved to the name"
+    )
     aiohttp_apispec.setup_aiohttp_apispec(
         app=app,
         title='CALDERA',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import string
 import uuid
 import yaml
 import aiohttp_apispec
+import warnings
 
 from unittest import mock
 from aiohttp_apispec import validation_middleware
@@ -315,6 +316,11 @@ def agent_config():
 @pytest.fixture
 def api_v2_client(loop, aiohttp_client, contact_svc):
     def make_app(svcs):
+        warnings.filterwarnings(
+            "ignore",
+            message="Multiple schemas resolved to the name"
+        )
+
         app = web.Application(
             middlewares=[
                 authentication_required_middleware_factory(svcs['auth_svc']),


### PR DESCRIPTION
## Description
Note: associated with #2324 
When the request schema is modified in the `aiohttp_apispec.request` decorator, a "multiple schema" warning will be logged. There are no errors associated with this message; marshmallow simply logs this message to make sure users know that schema fields have been included/excluded. This PR silences those warnings.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Verified manually that "Duplicate Schema" warnings are silenced in the server output.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
