### PR TITLE
Bug fix for source-originated facts in relationships

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -268,6 +268,10 @@ class Link(BaseObject):
         source = operation.id if operation else self.id
         rl = [relationship] if relationship else []
         if all([fact.trait, fact.value]):
+            if operation and operation.source:
+                if any([(fact.trait, fact.value) == (x.trait, x.value) for x in
+                        await knowledge_svc_handle.get_facts(criteria=dict(source=operation.source.id))]):
+                    source = operation.source.id
             fact.source = source  # Manual addition to ensure the check works correctly
             if not await knowledge_svc_handle.check_fact_exists(fact, all_facts):
                 f_gen = Fact(trait=fact.trait, value=fact.value, source=source, score=score, collected_by=self.paw,


### PR DESCRIPTION
## Description

@mchan143 discovered a bug where facts that originate from sources can be incorrectly duplicated when used in relationships. This patch fixes this potential loophole.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested using the Thief Adversary, and via the standard test battery.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
