### PR TITLE
virts-2979 - Learning Service Fact Creation bugfix

### DIFF
--- a/app/service/learning_svc.py
+++ b/app/service/learning_svc.py
@@ -73,8 +73,6 @@ class LearningService(LearningServiceInterface, BaseService):
                 if fact.trait in relationship:
                     matches.append(fact)
                     facts_covered.append(fact)
-                else:
-                    await link._save_fact(operation=operation, fact=fact, score=link.score, relationship=None)
             for pair in itertools.combinations(matches, r=2):
                 if pair[0].trait != pair[1].trait:
                     await link._create_relationships([Relationship(source=pair[0], edge='has', target=pair[1])],


### PR DESCRIPTION
## Description

In the current iteration of Caldera, it is possible for the learning service to generate facts that get added to a link's internal collection, but not to the overall operation's collection (duplicate protection differences due to scope, essentially). This patch addresses this by changing things so that fact storage is handled manually by the learning service, rather than delegated to the link.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested by running Snag Broadcast IP (known as a trigger ability for this bug), and checking the results of the Debrief plugin (which revealed an [issue](https://github.com/mitre/debrief/pull/54) with the Debrief plugin). 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
