### PR TITLE
Operations select dead agent bug in add potential link menu

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1247,7 +1247,6 @@
                         if ((new Date() - new Date(res.last_seen)) > 3600000) {
                             toast(`Command might not run. Is Agent #${res.paw} still alive?`);
                         } else {
-                            this.selectedAgentIndex = 0;
                             this.potentialLink.agent = res;
                         }
                     })

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -284,7 +284,6 @@
                                             <template x-if="!isLinkEditable">
                                                 <div class="is-flex is-justify-content-center is-flex-direction-column">
                                                     <button class="button is-primary is-small"
-                                                            x-bind:class="{'hover-opacity':selectedLink !== link}"
                                                             x-on:click="getLink(link); openModal='showCommand'"
                                                             title="view output">View Command
                                                     </button>
@@ -1244,11 +1243,12 @@
             getAgent(agentPaw) {
                 apiV2('GET', `api/v2/agents/${agentPaw}`)
                     .then((res) => {
-                        this.selectedAgentIndex = 0;
-                        this.potentialLink.agent = res;
                         // Check if agent has been seen in the last hour
                         if ((new Date() - new Date(res.last_seen)) > 3600000) {
                             toast(`Command might not run. Is Agent #${res.paw} still alive?`);
+                        } else {
+                            this.selectedAgentIndex = 0;
+                            this.potentialLink.agent = res;
                         }
                     })
                     .catch(() => {
@@ -1702,14 +1702,6 @@
         justify-content: space-between;
         overflow-y: scroll;
         margin-bottom: 1em;
-    }
-
-    #operationsPage .hover-opacity {
-        opacity: 0.5;
-    }
-
-    #operationsPage .hover-opacity:hover {
-        opacity: 1;
     }
 
     #operationsPage .controls-container button {


### PR DESCRIPTION
## Description

Fixed bug where if first agent is dead, does not let user select a different agent when creating a command
Removed opacity styling on view command buttons in operation links

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
