### PR TITLE
Change addPotentialLink to have ability: link in response.

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1314,7 +1314,7 @@
                 }
                 const executor = link.executors.find((e) => this.potentialLink.executor === e.name);
                 apiV2('POST', `${this.ENDPOINT}/${this.selectedOperationID}/potential-links`, {
-                    ...link,
+                    ability: link,
                     paw: this.potentialLink.agent.paw,
                     executor: executor
                 })


### PR DESCRIPTION
## Description

Currently `link` is unpacked into the response, but in the `operation_api_manager.py` `create_potential_link`, which handles this request, it is expected that the data has an ability key. Since there is none, when it goes to build an ability it builds a default 'manual' one instead.

This can be tested by making an operation, and then adding a potential link.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

1. Set breakpoint in `create_potential_link` in `operation_api_manager.py`
2. Start server with debugger attached
3. Start agent  
4. Start operation
5. Add potential link manually
6. At breakpoint trigger step until `ability = self.build_ability(data=data.pop('ability', {}), executor=executor)`
7. Check that ability is correctly made (and is not labeled "manual ability" from default values in build_ability)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
