### PR TITLE
VIRTS3277: Minor scalability updates

### DIFF
--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -175,7 +175,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
             agent_links = []
             for agent in operation.agents:
                 agent_links.append(await self.generate_and_trim_links(agent, operation, abilities, trim))
-            links = self._remove_links_of_duplicate_singletons(agent_links)
+            links = await self._remove_links_of_duplicate_singletons(agent_links)
         self.log.debug('Generated %s usable links' % (len(links)))
         return await self.sort_links(links)
 

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -1,6 +1,7 @@
 import copy
 import itertools
 import logging
+import pickle
 import re
 from base64 import b64decode
 
@@ -103,7 +104,7 @@ class BasePlanningService(BaseService):
                     for combo in list(itertools.product(*valid_facts)):
                         try:
                             copy_test = copy.copy(decoded_test)
-                            copy_link = copy.deepcopy(link)
+                            copy_link = pickle.loads(pickle.dumps(link))
                             variant, score, used = await self._build_single_test_variant(copy_test, combo,
                                                                                          link.executor.name)
                             copy_link.command = self.encode_string(variant)
@@ -132,7 +133,7 @@ class BasePlanningService(BaseService):
         """
         completed_links = [lnk for lnk in operation.chain if lnk.paw == agent.paw and (lnk.finish or lnk.can_ignore())]
 
-        singleton_links = BasePlanningService._list_historic_duplicate_singletons(operation)
+        singleton_links = await BasePlanningService._list_historic_duplicate_singletons(operation)
 
         return [lnk for lnk in links if lnk.ability.repeatable or
                 (lnk not in completed_links and
@@ -167,7 +168,7 @@ class BasePlanningService(BaseService):
         return links
 
     @staticmethod
-    def _list_historic_duplicate_singletons(operation):
+    async def _list_historic_duplicate_singletons(operation):
         """
         Generate a list of successfully run singleton abilities for a given operation
         :param operation: Operation to scan
@@ -177,7 +178,7 @@ class BasePlanningService(BaseService):
         return [x for x in singleton if x]
 
     @staticmethod
-    def _remove_links_of_duplicate_singletons(agent_links):
+    async def _remove_links_of_duplicate_singletons(agent_links):
         """
         Filter links across agents
         :param agent_links: array of agent links

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -104,7 +104,7 @@ class BasePlanningService(BaseService):
                     for combo in list(itertools.product(*valid_facts)):
                         try:
                             copy_test = copy.copy(decoded_test)
-                            copy_link = pickle.loads(pickle.dumps(link))    #nosec
+                            copy_link = pickle.loads(pickle.dumps(link))    # nosec
                             variant, score, used = await self._build_single_test_variant(copy_test, combo,
                                                                                          link.executor.name)
                             copy_link.command = self.encode_string(variant)

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -104,7 +104,7 @@ class BasePlanningService(BaseService):
                     for combo in list(itertools.product(*valid_facts)):
                         try:
                             copy_test = copy.copy(decoded_test)
-                            copy_link = pickle.loads(pickle.dumps(link))
+                            copy_link = pickle.loads(pickle.dumps(link))    #nosec
                             variant, score, used = await self._build_single_test_variant(copy_test, combo,
                                                                                          link.executor.name)
                             copy_link.command = self.encode_string(variant)

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -362,9 +362,9 @@ class TestPlanningService:
         assert 1 == len(filt)
 
         # test parallel filtering
-        flat_fil = planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
-                                                                       [l0, l1, l2, l3],
-                                                                       [l0, l1, l2, l3]])
+        flat_fil = loop.run_until_complete(planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
+                                                                                               [l0, l1, l2, l3],
+                                                                                               [l0, l1, l2, l3]]))
         assert 7 == len(flat_fil)
 
     async def test_trait_with_one_part(self, setup_planning_test, planning_svc):


### PR DESCRIPTION
## Description

Minor fixes as part of the solution to scalability issues. Profiling indicated `deepcopy` was one of the biggest culprits slowing down the server and freezing the UI. The proposed fixes in this PR does not resolve the issue entirely but does at least allow operations to complete eventually.

The affixed `# nosec` comment to the line calling `pickle.loads` suppresses the blacklisted call issue raised by bandit:

> B301: pickle 
> Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.

Data being used with the pickle.loads in this specific case is only generated on the server side or loaded into the server.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran Thief profile against 1000 simulated agents in an operation using the Mock plugin.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
