### PR TITLE
VIRTS-3397: Compatibility issue in base_knowledge_svc.py

### DIFF
--- a/app/utility/base_knowledge_svc.py
+++ b/app/utility/base_knowledge_svc.py
@@ -13,7 +13,7 @@ from app.objects.secondclass.c_fact import Fact, WILDCARD_STRING
 from app.objects.secondclass.c_relationship import Relationship
 
 DATA_BACKUP_DIR = app.service.data_svc.DATA_BACKUP_DIR
-FACT_STORE_PATH = "data/fact_store"
+FACT_STORE_PATH = f"data{os.path.sep}fact_store"
 
 
 class BaseKnowledgeService(BaseService):
@@ -282,8 +282,8 @@ class BaseKnowledgeService(BaseService):
 
         :return: None
         """
-        await self.get_service('file_svc').save_file(FACT_STORE_PATH.split('/')[1], pickle.dumps(self.fact_ram),
-                                                     FACT_STORE_PATH.split('/')[0])
+        await self.get_service('file_svc').save_file(FACT_STORE_PATH.split(os.path.sep)[1], pickle.dumps(self.fact_ram),
+                                                     FACT_STORE_PATH.split(os.path.sep)[0])
 
     async def _restore_state(self):
         """


### PR DESCRIPTION
## Description

Using an OS with different line separators will cause an error that did not occur in the past. This PR applies more consistent approach to paths. Using an OS with different line separators it will cause the following error to occur:

```
Traceback (most recent call last):
  File "C:/Users/user1/caldera/server.py", line 72, in run_tasks
    loop.run_forever()
  File "c:\program files\python38\lib\asyncio\windows_events.py", line 316, in run_forever
    super().run_forever()
  File "c:\program files\python38\lib\asyncio\base_events.py", line 570, in run_forever
    self._run_once()
  File "c:\program files\python38\lib\asyncio\base_events.py", line 1823, in _run_once
    event_list = self._selector.select(timeout)
  File "c:\program files\python38\lib\asyncio\windows_events.py", line 434, in select
    self._poll(timeout)
  File "c:\program files\python38\lib\asyncio\windows_events.py", line 783, in _poll
    status = _overlapped.GetQueuedCompletionStatus(self._iocp, ms)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:/Users/user1/caldera/server.py", line 153, in <module>
    run_tasks(services=app_svc.get_services())
  File "C:/Users/user1/caldera/server.py", line 74, in run_tasks
    loop.run_until_complete(services.get('app_svc').teardown(main_config_file=args.environment))
  File "c:\program files\python38\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "C:\Users\user1\caldera\app\service\app_svc.py", line 132, in teardown
    await self._services.get('knowledge_svc').save_state()
  File "C:\Users\user1\caldera\app\service\knowledge_svc.py", line 78, in save_state
    return await self.__loaded_knowledge_module._save_state()
  File "C:\Users\user1\caldera\app\utility\base_knowledge_svc.py", line 285, in _save_state
    await self.get_service('file_svc').save_file(FACT_STORE_PATH.split('/')[1], pickle.dumps(self.fact_ram),
IndexError: list index out of range
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Start the server in a system with a different OS. After stopping and restarting the server the behavior described above will not occur.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
