### PR TITLE
Add API documentation for /contacts/{name}

### DIFF
--- a/app/api/v2/handlers/contact_api.py
+++ b/app/api/v2/handlers/contact_api.py
@@ -15,7 +15,20 @@ class ContactApi(BaseApi):
         router = app.router
         router.add_get('/contacts/{name}', self.get_contact_report)
 
-    @aiohttp_apispec.docs(tags=['contacts'])
+    @aiohttp_apispec.docs(tags=['contacts'],
+                          summary='Retrieve a List of Beacons made by Agents to the specified Contact',
+                          description='Returns a list of beacons made by agents to the specified contact. The response'
+                                      ' is formatted as a list of dictionaries. The dictionaries have the keys "paw",'
+                                      ' "instructions", and "date". "paw" being the paw of the agent that made the'
+                                      ' beacon. "instructions" being a list of strings (commands) executed by the'
+                                      ' agent since its last beacon. "date" being a UTC date/time string.',
+                          parameters=[{
+                              'in': 'path',
+                              'name': 'name',
+                              'schema': {'type': 'string'},
+                              'required': 'true',
+                              'description': 'Name of the contact to get beacons for, e.g. HTTP, TCP, et cetera.'
+                          }])
     async def get_contact_report(self, request: web.Request):
         contact_name = request.match_info['name']
         report = self._api_manager.get_contact_report(contact_name)

--- a/app/api/v2/handlers/contact_api.py
+++ b/app/api/v2/handlers/contact_api.py
@@ -18,10 +18,10 @@ class ContactApi(BaseApi):
     @aiohttp_apispec.docs(tags=['contacts'],
                           summary='Retrieve a List of Beacons made by Agents to the specified Contact',
                           description='Returns a list of beacons made by agents to the specified contact. The response'
-                                      ' is formatted as a list of dictionaries. The dictionaries have the keys "paw",'
-                                      ' "instructions", and "date". "paw" being the paw of the agent that made the'
-                                      ' beacon. "instructions" being a list of strings (commands) executed by the'
-                                      ' agent since its last beacon. "date" being a UTC date/time string.',
+                                      ' is formatted as a list of dictionaries. The dictionaries have the keys `paw`,'
+                                      ' `instructions`, and `date`. `paw` being the paw of the agent that made the'
+                                      ' beacon. `instructions` being a list of strings (commands) executed by the'
+                                      ' agent since its last beacon. `date` being a UTC date/time string.',
                           parameters=[{
                               'in': 'path',
                               'name': 'name',


### PR DESCRIPTION
## Description

Added API documentation for:
- `HEAD /api/v2/contacts/{name}`
- `GET /api/v2/contacts/{name}`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

I built and observed the changes to the API documentation page.

## Checklist:

- [x] My code follows the style guidelines of this project
  - I believe it does
    - I matched the style of other multiline doc decorators
    - I kept under the flake8 line length of 180 _(I folded at 119 chars, not sure if changing that would be more preferable)_
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
