### PR TITLE
Add API docs for Planners

### DIFF
--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -18,16 +18,34 @@ class PlannerApi(BaseObjectApi):
         router.add_get('/planners', self.get_planners)
         router.add_get('/planners/{planner_id}', self.get_planner_by_id)
 
-    @aiohttp_apispec.docs(tags=['planners'])
+    @aiohttp_apispec.docs(tags=['planners'],
+                          summary='Retrieve planners',
+                          description='Retrieve CALDERA planners by criteria. Supply fields from the `PlannerSchema` '
+                                      'to the `include` and `exclude` fields of the `BaseGetAllQuerySchema` in the '
+                                      'request body to filter retrieved planners.')
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
-    @aiohttp_apispec.response_schema(PlannerSchema(many=True, partial=True))
+    @aiohttp_apispec.response_schema(PlannerSchema(many=True, partial=True),
+                                     description='Returns a list of matching planners in `PlannerSchema` format.')
     async def get_planners(self, request: web.Request):
         planners = await self.get_all_objects(request)
         return web.json_response(planners)
 
-    @aiohttp_apispec.docs(tags=['planners'])
+    @aiohttp_apispec.docs(tags=['planners'],
+                          summary='Retrieve a planner by planner id',
+                          description='Retrieve one CALDERA planner based on the planner id (String `UUID`). '
+                                      'Supply fields from the `PlannerSchema` to the `include` and `exclude` fields '
+                                      'of the `BaseGetOneQuerySchema` in the request body to filter retrieved '
+                                      'planners.',
+                          parameters=[{
+                              'in': 'path',
+                              'name': 'planner_id',
+                              'schema': {'type': 'string'},
+                              'required': 'true',
+                              'description': 'UUID of the Planner object to be retrieved.'
+                          }])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
-    @aiohttp_apispec.response_schema(PlannerSchema(partial=True))
+    @aiohttp_apispec.response_schema(PlannerSchema(partial=True),
+                                     description='Returns a planner with the specified id in `PlannerSchema` format.')
     async def get_planner_by_id(self, request: web.Request):
         planner = await self.get_object(request)
         return web.json_response(planner)


### PR DESCRIPTION
## Description

Added to the Planner apispec docs for the HEAD/GET requests to the `/api/v2/planners` and `/api/v2/planners/{planner_id}` API endpoints.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All descriptions and summaries appear in Swagger documentation.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
