### PR TITLE
Add paw to existing Fact only if Fact wasn't used in Link command

### DIFF
--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -285,7 +285,7 @@ class Link(BaseObject):
                     existing_fact.links.append(self.id)
                 if relationship not in existing_fact.relationships:
                     existing_fact.relationships.append(relationship)
-                if self.paw not in existing_fact.collected_by:
+                if self.paw not in existing_fact.collected_by and existing_fact not in self.used:
                     existing_fact.collected_by.append(self.paw)
                 await knowledge_svc_handle.update_fact(criteria=dict(trait=fact.trait, value=fact.value,
                                                                      source=fact.source),


### PR DESCRIPTION
## Description

Follow up bug fix to https://github.com/mitre/caldera/pull/2397. This change proposes that paws are only added to a Fact's `collected_by` if they were not used in the command, which resolves the issue when relationships are created for seeded facts and seeded facts go through the `save_fact` process. Seeded facts should not be updated to show they have been collected by an agent if they were only used in the command.

The proposed change also resolves the scenario where an operation started with a seeded fact (say `domain.user.name`) and further discovery actions by an agent led to the re-discovery of the same fact. The paw will be added to a Fact's `collected_by` in this case.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran an operation against two agents that used seeded facts and learned facts. Ensured that the agent paws were not added to the seeded facts' `collected_by`.
- Added a test for the scenario mentioned above

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
