### PR TITLE
Fix fact source creation and editting 

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -41,8 +41,8 @@
 .toggleSwitch {
   position: relative;
   display: inline-block;
-  width: 65px;
-  height: 34px;
+  width: 50px;
+  height: 12px;
 }
 
 .toggleSwitch input {
@@ -50,7 +50,7 @@
 }
 
 .toggleSlider {
-  border: 2px solid white;
+  border: 2px solid #7e7e7e;
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -63,12 +63,12 @@
 .toggleSlider::before {
   position: absolute;
   content: "";
-  height: 24px;
-  width: 24px;
+  height: 17px;
+  width: 17px;
   bottom: 4px;
   transition: all 0.3s ease;
   left: 3px;
-  top: 3px;
+  top: 6px;
 }
 
 .toggle-off {
@@ -76,7 +76,7 @@
 }
 
 .toggle-on {
-  background-color: #339c3f;
+  background-color: #87FA5F;
 }
 
 .toggle-slider-on,
@@ -92,12 +92,12 @@
 
 .toggle-on.toggleSlider.toggleSlider::before {
   background-color: white;
-  transform: translateX(30px);
+  transform: translate(30px, -11px);
 }
 
 .toggle-off.toggleSlider.toggleSlider::before {
   background-color: white;
-  transform: translateX(0);
+  transform: translate(-5px, -11px);
 }
 
 .toggleSlider.toggleSliderRound::before {

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -8,85 +8,75 @@
     </div>
     <hr>
     <div>
-        <!-- TOP PANEL -->
-        <div>
-            <div class="is-flex is-flex-direction-row" x-data="{filterKeyword: ''}">
-                <!-- SEARCH BAR -->
-                <div class="mb-4 is-flex is-justify-content-space-between is-flex-direction-column">
-                    <div class="is-flex is-align-items-center filter-search-box">
-                        <i class="fas fa-search"></i>
-                        <input class="input is-small"
-                               id="source-search"
-                               placeholder="Fact source"
-                               x-model="filterKeyword"
-                               x-on:keyup="filterSources($el.value)">
-                        <i class="fas fa-times"
-                           x-on:click="filterSources(''); filterKeyword=''"></i>
-                    </div>
-                    <label class="is-size-7" for="source-search">
-                        <em x-text="filterKeyword !== '' ? ('searching: ' + filterKeyword) : 'type fact source name'"></em>
-                    </label>
-                </div>
-                <div class="pl-0 is-flex is-align-content-flex-start">
-                    <button
-                            type="button"
-                            class="ml-2 button is-primary is-small"
-                            x-on:click="addSource(filterKeyword)"
-                            title="Create a new source">
-                        <i class="pr-1 fas fa-plus"></i>
-                        <span>Add Source</span>
-                    </button>
-                    <button type="button"
-                            x-bind:disabled="!selectedSource"
-                            class="ml-2 button is-primary is-small"
-                            x-on:click="duplicateSource(selectedSource)"
-                            title="Duplicate selected source">
-                        <i class="pr-1 fas fa-plus"></i>
-                        <span>Duplicate</span>
-                    </button>
-                    <button type="button"
-                            x-bind:disabled="!selectedSource"
-                            class="ml-2 button is-primary is-small"
-                            x-on:click="openModalData.name = 'deleteSource'; openModalData.item = selectedSource"
-                            title="Delete selected source">
-                        <i class="pr-1 fas fa-trash"></i>
-                    </button>
-                </div>
-            </div>
 
-            <!-- SOURCES MENU -->
-            <div class="is-flex is-flex-direction-row is-justify-content-flex-start sources-menu-container">
-                <template x-if="filteredSources.length < 1">
-                    <em class="is-flex is-justify-content-center">No sources available; click on the 'Add Source'
-                        button to get started.</em>
-                </template>
-                <template x-for="source of filteredSources" :key="source.id" x-data="{ editSourceName: false}">
-                    <button class="pt-2 no-style source-menu-links"
-                            x-bind:class="selectedSource === source ? 'active' : ''"
-                            x-on:click="handleSelectSource(source)">
-                        <i class="fas fa-project-diagram"></i>
-                        <span x-on:click="editSourceName = (selectedSource === source)"
-                              x-show="!editSourceName || selectedSource !== source" x-text="source.name"></span>
-                        <label for="edit-source-name" x-show="false">Edit source name</label>
-                        <textarea id="edit-source-name"
-                                  @click.outside="handleEditSource(editSourceName)"
-                                  class="is-small edit-field"
-                                  x-model="source.name"
-                                  x-show="editSourceName && selectedSource === source"
-                                  contenteditable
-                                  spellcheck="false"></textarea>
-                    </button>
-                </template>
+        <!-- FACT SELECTION -->
+
+        <form>
+            <div id="select-source" class="field has-addons">
+                <label class="label">Select a source &nbsp;&nbsp;&nbsp;</label>
+                <div class="control is-expanded">
+                    <div class="select is-small is-fullwidth">
+                        <select x-on:change="handleSelectSource()" x-model="selectedSourceId">
+                            <option value="" default disabled selected>Select a source...</option>
+                            <template x-for="source of sources" :key="source.id">
+                                <option x-bind:value="source.id" x-text="source.name"></option>
+                            </template>
+                        </select>
+                    </div>
+                </div>
+                <div class="control">
+                    <button type="button" class="button is-primary is-small" @click="createSource()">+ New</button>
+                </div>
             </div>
-        </div>
+        </form>
 
         <!-- CONTENT -->
+        
         <template x-if="!selectedSource">
             <em class="is-flex is-justify-content-center">Click on a fact source to get started.</em>
         </template>
 
         <template x-if="selectedSource">
             <div>
+                <nav class="level">
+                    <div class="level-left">
+                        <div class="level-item" x-show="!isEditingSourceName">
+                            <h2 x-text="selectedSource.name" class="mb-2"></h2>
+                        </div>
+                        <div class="level-item">
+                            <a class="mb-2 has-text-white" @click="isEditingSourceName = true" x-show="!isEditingSourceName">
+                                <span class="icon"><em class="fas fa-pencil-alt"></em></span>
+                            </a>
+                        </div>
+                        <div class="level-item" x-show="isEditingSourceName">
+                            <input id="sourceName" class="input is-small" placeholder="Enter a source name" x-model="selectedSource.name">
+                        </div>
+                        <div class="level-item" x-show="isEditingSourceName">
+                            <button class="button is-small is-primary" @click="saveSourceName()">
+                                <span class="icon"><em class="fas fa-save"></em></span>
+                                <span>Save</span>
+                            </button>
+                        </div>
+                        <div class="level-item" x-show="isEditingSourceName">
+                            <button class="button is-small" @click="isEditingSourceName = false">Cancel</button>
+                        </div>
+                    </div>
+                    <div class="level-right">  
+                        <div class="level-item">
+                            <button class="button is-small is-primary" @click="duplicateSource(selectedSource)">
+                                <span class="icon"><em class="fas fa-copy"></em></span>
+                                <span>Duplicate</span>
+                            </button>
+                        </div>
+                        <div class="level-item">
+                            <button class="button is-small is-primary" @click="isConfirmDeleteModalOpen = true">
+                                <span class="icon"><em class="fas fa-trash"></em></span>
+                                <span>Delete</span>
+                            </button>
+                        </div>
+                    </div>
+                </nav>
+
                 <!-- FACTS CONTENT -->
                 <div class="my-5" x-data="{collapseFacts: false}">
                     <div class="collapsible-header">
@@ -104,15 +94,12 @@
                                     <i class="fas fa-search"></i>
                                     <input class="input is-small"
                                            id="fact-search"
-                                           placeholder="Fact keyword"
+                                           placeholder="Find a trait or value..."
                                            x-model="factsFilterKeyword"
                                            x-on:keyup="filterFacts($el.value)">
                                     <i class="fas fa-times"
                                        x-on:click="filterFacts(''); factsFilterKeyword=''"></i>
                                 </div>
-                                <label class="is-size-7" for="fact-search">
-                                    <em x-text="factsFilterKeyword !== '' ? ('searching: ' + factsFilterKeyword) : 'type fact trait or value'"></em>
-                                </label>
                             </div>
                             <div class="pl-0 is-flex is-align-content-flex-start">
                                 <button type="button"
@@ -227,15 +214,12 @@
                                     <i class="fas fa-search"></i>
                                     <input class="input is-small"
                                            id="rule-search"
-                                           placeholder="Rule keyword"
+                                           placeholder="Find a match rule or trait..."
                                            x-model="rulesFilterKeyword"
                                            x-on:keyup="filterRules($el.value)">
                                     <i class="fas fa-times"
                                        x-on:click="filterRules(''); rulesFilterKeyword=''"></i>
                                 </div>
-                                <label class="is-size-7" for="rule-search">
-                                    <em x-text="rulesFilterKeyword !== '' ? ('searching: ' + rulesFilterKeyword) : 'type match rule or fact trait'"></em>
-                                </label>
                             </div>
                             <div class="pl-0 is-flex is-align-content-flex-start">
                                 <button type="button"
@@ -455,62 +439,37 @@
         </template>
     </div>
 
-    <!-- MODAL -->
-    <template x-if="openModalData.item">
-        <div class="modal is-active">
-            <div class="modal-background"></div>
-            <form class="m-1">
-                <div class="modal-card">
-                    <template x-if="openModalData.name.includes('delete')">
-                        <div>
-                            <header class="modal-card-head">
-                                <p class="modal-card-title">Confirm Delete</p>
-                            </header>
-                            <section class="modal-card-body">
-                                <div>
-                                    <p>Are you sure you want to delete
-                                        <em x-show="openModalData.name === 'deleteSource'" x-text="openModalData.item?.name"></em>
-                                        <em x-show="openModalData.name === 'deleteFact'"
-                                            x-text="openModalData.item?.name"></em>
-                                        <em x-show="openModalData.name === 'deleteRule'"
-                                            x-text="openModalData.item?.trait"></em>
-                                        <em x-show="openModalData.name === 'deleteRelationship'"
-                                            x-text="openModalData.item?.trait"></em>
-                                        ?</p>
-                                </div>
-                            </section>
+    <div class="modal" x-bind:class="{ 'is-active': isConfirmDeleteModalOpen }">
+        <div class="modal-background" @click="isConfirmDeleteModalOpen = false"></div>
+        <div class="modal-card" style="z-index: 20">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Delete Fact Source?</p>
+            </header>
+            <section class="modal-card-body">
+                <p>
+                    Are you sure you want to delete this fact source? This cannot be undone.
+                </p>
+            </section>
+            <footer class="modal-card-foot">
+                <nav class="level">
+                    <div class="level-left">
+                        <div class="level-item">
+                            <button class="button is-small" @click="isConfirmDeleteModalOpen = false">Cancel</button>
                         </div>
-                    </template>
-                    <footer class="modal-card-foot is-flex is-justify-content-space-between">
-                        <button type="button" class="button ml-2 is-small"
-                                x-on:click="resetModal()">
-                            Cancel
-                        </button>
-                        <button x-show="openModalData.name === 'deleteSource'" type="button"
-                                class="button is-primary is-small"
-                                x-on:click="deleteSource(openModalData.item)">
-                            Yes
-                        </button>
-                        <button x-show="openModalData.name === 'deleteFact'" type="button"
-                                class="button is-primary is-small"
-                                x-on:click="deleteFact(openModalData.item)">
-                            Yes
-                        </button>
-                        <button x-show="openModalData.name === 'deleteRule'" type="button"
-                                class="button is-primary is-small"
-                                x-on:click="deleteRule(openModalData.item)">
-                            Yes
-                        </button>
-                        <button x-show="openModalData.name === 'deleteRelationship'" type="button"
-                                class="button is-primary is-small"
-                                x-on:click="deleteRelationship(openModalData.item)">
-                            Yes
-                        </button>
-                    </footer>
-                </div>
-            </form>
+                    </div>
+                    <div class="level-right">
+                        <div class="level-item">
+                            <button class="button is-danger is-small" @click="deleteSource(); isConfirmDeleteModalOpen = false;">
+                                <span class="icon"><em class="fas fa-trash"></em></span>
+                                <span>Delete Source</span>
+                            </button>
+                        <div>
+                    </div>
+                </nav>
+            </footer>
         </div>
-    </template>
+    </div>
+
 </div>
 
 <script>
@@ -524,14 +483,21 @@
             filteredSources: [],
             filteredFacts: [],
             filteredRules: [],
+
             selectedSource: null,
+            selectedSourceId: '',
             selectedRelationship: null,
             selectedFact: null,
             selectedRule: null,
+
+            isEditingSourceName: false,
+
+            isConfirmDeleteModalOpen: false,
+
             showAddFactRow: false,
             showAddRuleRow: false,
             showAddRelationshipRow: false,
-            openModalData: { name: '', item: null },
+
             newRelationship: {
                 sourceTrait: '',
                 edge: '',
@@ -540,28 +506,17 @@
 
             getSources() {
                 apiV2('GET', '/api/v2/sources').then((sources) => {
-                    this.sources = sources;
-                    this.filteredSources = sources;
+                    this.sources = sources.sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase());
                 }).catch((error) => {
                     toast('Error loading page', false);
                     console.error(error);
                 });
             },
 
-            handleSelectSource(source) {
-                this.selectedSource = source;
-                this.filteredFacts = source.facts;
-                this.filteredRules = source.rules;
-            },
-
-            handleEditSource(editSourceName) {
-                editSourceName = false;
-                this.updateFactSource();
-            },
-
-            filterSources(input = '') {
-                input = input.toLowerCase();
-                this.filteredSources = this.sources.filter((s) => s.name.toLowerCase().includes(input));
+            handleSelectSource() {
+                this.selectedSource = this.sources.find((source) => source.id === this.selectedSourceId);
+                this.filteredFacts = this.selectedSource.facts;
+                this.filteredRules = this.selectedSource.rules;
             },
 
             filterFacts(input = '') {
@@ -574,16 +529,22 @@
                 this.filteredRules = this.selectedSource.rules.filter((r) => (r.match.toLowerCase().includes(input) || r.trait.toLowerCase().includes(input)));
             },
 
-            addSource(newSourceName) {
+            createSource(newSourceName) {
                 const newSource = {
-                    name: newSourceName === '' ? 'new source' : newSourceName,
+                    name: '',
                     facts: [],
                     rules: [],
                     relationships: []
                 };
-                apiV2('POST', '/api/v2/sources', newSource).then((res) => {
-                    toast('Added new fact source', res);
-                    this.getSources();
+                apiV2('POST', '/api/v2/sources', newSource).then((newSource) => {
+                    toast('Added new fact source', true);
+                    this.isEditingSourceName = true;
+                    this.sources.push(newSource);
+                    this.selectedSourceId = newSource.id;
+                    this.selectedSource = newSource;
+                    this.$nextTick(() => {
+                        document.getElementById('sourceName').focus();
+                    });
                 }).catch((error) => {
                     toast('Error adding source', false);
                     console.error(error);
@@ -652,11 +613,11 @@
                 });
             },
 
-            deleteSource(source) {
-                apiV2('DELETE', `/api/v2/sources/${source.id}`).then((res) => {
+            deleteSource() {
+                apiV2('DELETE', `/api/v2/sources/${this.selectedSourceId}`).then((res) => {
                     toast('Deleted fact source', true);
+                    this.selectedSourceId = '';
                     this.getSources();
-                    this.resetModal();
                 }).catch((error) => {
                     toast('Error deleting source', false);
                     console.error(error);
@@ -666,23 +627,26 @@
             deleteFact(fact) {
                 this.selectedSource.facts.splice(this.selectedSource.facts.findIndex((f) => f.unique === fact.unique), 1);
                 this.updateFactSource();
-                this.resetModal();
             },
 
             deleteRule(rule) {
                 this.selectedSource.rules.splice(this.selectedSource.rules.findIndex((r) => r === rule), 1);
                 this.updateFactSource();
-                this.resetModal();
             },
 
             deleteRelationship(rel) {
                 this.selectedSource.relationships.splice(this.selectedSource.relationships.find((r) => r === rel), 1);
                 this.updateFactSource();
-                this.resetModal();
             },
 
-            resetModal() {
-                this.openModalData = { name: '', item: null };
+            saveSourceName() {
+                apiV2('PATCH', `/api/v2/sources/${this.selectedSource.id}`, { name: this.selectedSource.name }).then((res) => {
+                    toast('Source name updated', true);
+                    this.isEditingSourceName = false;
+                }).catch((error) => {
+                    toast('Error loading page', false);
+                    console.error(error);
+                });
             },
 
             updateFactSource() {
@@ -848,6 +812,11 @@
     /*DOMAIN*/
     #sourcePage td.origin-DOMAIN {
         color: cornflowerblue;
+    }
+
+    #select-source {
+        max-width: 800px;
+        margin: 0 auto;
     }
 
 </style>

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -93,7 +93,7 @@
                                 <span class="icon"><i class="fas fa-plus"></i></span>
                                 <span>Add Fact</span>
                             </button>
-                            <div class="field mr-2" x-show="filteredFacts.length >= 1 || showAddFactRow">
+                            <div class="field mr-2" x-show="selectedSource.facts && selectedSource.facts.length >= 1 || showAddFactRow">
                                 <p class="control has-icons-left">
                                     <input class="input is-small"
                                            id="fact-search"
@@ -230,11 +230,11 @@
                                 <span class="icon"><i class="fas fa-plus"></i></span>
                                 <span>Add Rule</span>
                             </button>
-                            <div class="field mr-2" x-show="filteredFacts.length >= 1 || showAddFactRow">
+                            <div class="field mr-2" x-show="selectedSource.rules && selectedSource.rules.length >= 1 || showAddRuleRow">
                                 <p class="control has-icons-left">
                                     <input class="input is-small"
                                         id="rule-search"
-                                        placeholder="Find a match rule or trait..."
+                                        placeholder="Find a matching rule or trait..."
                                         x-model="rulesFilterKeyword"
                                         x-on:keyup="filterRules($el.value)">
                                     <span class="icon is-small is-left">
@@ -855,30 +855,6 @@
 
     #sourcePage td {
         word-wrap: anywhere;
-    }
-
-    #sourcePage .toggle-on.toggleSlider.toggleSlider::before {
-        transform: translatex(24px);
-    }
-
-    #sourcePage .toggleSwitch {
-        width: 55px;
-        height: 28px;
-    }
-
-    #sourcePage .toggle-off {
-        background-color: var(--primary-color);
-    }
-
-    #sourcePage .toggleSlider::before {
-        position: absolute;
-        content: "";
-        height: 20px;
-        width: 20px;
-        bottom: 4px;
-        transition: all 0.3s ease;
-        left: 3px;
-        top: 2px;
     }
 
     /*IMPORTED*/

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -25,18 +25,18 @@
                     </div>
                 </div>
                 <div class="control">
-                    <button type="button" class="button is-primary is-small" @click="createSource()">+ New</button>
+                    <button type="button" class="button is-primary is-small" @click="createSource()">+ Create Source</button>
                 </div>
             </div>
         </form>
 
         <!-- CONTENT -->
         
-        <template x-if="!selectedSource">
-            <em class="is-flex is-justify-content-center">Click on a fact source to get started.</em>
+        <template x-if="!selectedSourceId">
+            <p class="is-flex is-justify-content-center">Select a fact source to get started</p>
         </template>
 
-        <template x-if="selectedSource">
+        <template x-if="selectedSourceId">
             <div>
                 <nav class="level">
                     <div class="level-left">
@@ -49,6 +49,7 @@
                             </a>
                         </div>
                         <div class="level-item" x-show="isEditingSourceName">
+                            <label class="label">Source Name</label>
                             <input id="sourceName" class="input is-small" placeholder="Enter a source name" x-model="selectedSource.name">
                         </div>
                         <div class="level-item" x-show="isEditingSourceName">
@@ -69,9 +70,9 @@
                             </button>
                         </div>
                         <div class="level-item">
-                            <button class="button is-small is-primary" @click="isConfirmDeleteModalOpen = true">
+                            <button class="button is-small is-primary" @click="isConfirmSourceDeleteModalOpen = true">
                                 <span class="icon"><em class="fas fa-trash"></em></span>
-                                <span>Delete</span>
+                                <span>Delete Source</span>
                             </button>
                         </div>
                     </div>
@@ -80,272 +81,307 @@
                 <!-- FACTS CONTENT -->
                 <div class="my-5" x-data="{collapseFacts: false}">
                     <div class="collapsible-header">
-                        <button class="button px-0 no-style is-size-4" x-on:click="collapseFacts = !collapseFacts"
-                                x-bind:class="collapseFacts ? 'collapsed' : 'expanded'">
+                        <button class="button px-0 no-style is-size-4" x-on:click="collapseFacts = !collapseFacts" x-bind:class="collapseFacts ? 'collapsed' : 'expanded'">
                             Facts
+                            <span x-text="`&nbsp;(${filteredFacts.length})`"></span>
                         </button>
                     </div>
                     <span class="navbar-divider"></span>
-                    <div x-show="!collapseFacts" x-data="{selectedFact: null}">
-                        <!-- FACTS SEARCH BAR -->
+                    <div x-show="!collapseFacts">
                         <div class="is-flex is-flex-direction-row" x-data="{factsFilterKeyword: ''}">
-                            <div class="mb-4 is-flex is-justify-content-space-between is-flex-direction-column">
-                                <div class="is-flex is-align-items-center filter-search-box">
-                                    <i class="fas fa-search"></i>
+                            <button type="button" class="button is-primary is-small mr-2" x-on:click="showAddFactRow = true; selectedFactIndex = -1">
+                                <span class="icon"><i class="fas fa-plus"></i></span>
+                                <span>Add Fact</span>
+                            </button>
+                            <div class="field mr-2" x-show="filteredFacts.length >= 1 || showAddFactRow">
+                                <p class="control has-icons-left">
                                     <input class="input is-small"
                                            id="fact-search"
                                            placeholder="Find a trait or value..."
                                            x-model="factsFilterKeyword"
                                            x-on:keyup="filterFacts($el.value)">
-                                    <i class="fas fa-times"
-                                       x-on:click="filterFacts(''); factsFilterKeyword=''"></i>
-                                </div>
-                            </div>
-                            <div class="pl-0 is-flex is-align-content-flex-start">
-                                <button type="button"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="showAddFactRow = true; selectedFact = null">
-                                    <span class="icon"><i class="fas fa-plus"></i></span>
-                                    <span>Add Fact</span>
-                                </button>
-                                <button type="button"
-                                        x-bind:disabled="!selectedFact"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="openModalData.name = 'deleteFact'; openModalData.item = selectedFact"
-                                        title="Delete selected fact">
-                                    <i class="pr-1 fas fa-trash"></i>
-                                </button>
-
+                                    <span class="icon is-small is-left">
+                                        <i class="fas fa-search"></i>
+                                    </span>
+                                </p>
                             </div>
                         </div>
 
                         <!-- FACTS TABLE -->
-                        <table class="table is-striped">
+                        <table class="table is-striped" x-show="filteredFacts.length >= 1 || showAddFactRow">
+                            <colgroup>
+                                <col width="5%">
+                                <col width="10%">
+                                <col width="30%">
+                                <col width="30%">
+                                <col width="5%">
+                                <col width="20%">
+                            </colgroup>
                             <thead>
-                            <tr class="table-header">
-                                <th></th>
-                                <th>Origin</th>
-                                <th>Fact Trait</th>
-                                <th>Value</th>
-                                <th>Score</th>
-                                <th></th>
-                            </tr>
-                            </thead>
-                            <template x-if="filteredFacts.length < 1 && !showAddFactRow">
-                                <tbody>
-                                <tr>
-                                    <td colspan="6" class="text-align-center py-2">
-                                        <em>No facts; click 'Add Fact' to get started.</em>
-                                    </td>
+                                <tr class="table-header">
+                                    <th>Order</th>
+                                    <th>Origin</th>
+                                    <th>Fact Trait</th>
+                                    <th>Value</th>
+                                    <th>Score</th>
+                                    <th></th>
                                 </tr>
-                                </tbody>
-                            </template>
-                            <tbody>
-                            <template x-if="showAddFactRow">
-                                <tr x-data="{newFact: EMPTY_FACT_OBJECT}">
+                            </thead>
+                            <tbody @click.outside="selectedFactIndex = -1; factIndexToDelete = -1;">
+                                <tr x-data="{ newFact: EMPTY_FACT_OBJECT }" x-show="showAddFactRow">
                                     <td></td>
                                     <td></td>
-                                    <td @click.outside="selectedFact = {}">
-                                        <label x-show="false" for="new-fact-trait">Fact Trait</label>
+                                    <td>
                                         <input id="new-fact-trait" class="input is-small" x-model="newFact.trait" contenteditable>
                                     </td>
                                     <td>
-                                        <label x-show="false" for="new-fact-value">Fact Value</label>
                                         <input id="new-fact-value" class="input is-small" x-model="newFact.value" contenteditable>
                                     </td>
                                     <td>
-                                        <label x-show="false" for="new-fact-score">Fact Score</label>
                                         <input class="is-small input fact-score" id="new-fact-score" type="number" x-model="newFact.score" min="0"/>
                                     </td>
                                     <td>
                                         <button type="button"
                                                 class="button is-small is-primary"
                                                 x-on:click="addFact(newFact); newFact = EMPTY_FACT_OBJECT">
-                                            Add
+                                            + Add Fact
+                                        </button>
+                                        <button type="button"
+                                                class="button is-small"
+                                                x-on:click="showAddFactRow = false; newFact = EMPTY_FACT_OBJECT">
+                                            Cancel
                                         </button>
                                     </td>
                                 </tr>
-                            </template>
-                            <template x-for="(fact, index) in filteredFacts" :key="fact.unique">
-                                <tr x-on:click="selectedFact = fact; showAddFactRow = false;"
-                                    x-bind:class="selectedFact === fact ? 'selected' : ''">
-                                    <td class="index-column" x-text="index"></td>
-                                    <td x-bind:class="(fact.origin_type) ? 'is-size-6 origin-' + fact.origin_type : ''"
-                                        x-text="fact.origin_type"></td>
-                                    <td x-show="selectedFact !== fact" x-text="fact.trait"></td>
-                                    <td x-show="selectedFact === fact">
-                                        <label x-show="false" for="edit-fact-trait">Fact Trait</label>
-                                        <input id="edit-fact-trait" class="input is-small" x-model="fact.trait" contenteditable>
-                                    </td>
-                                    <td x-show="selectedFact !== fact" x-text="fact.value"></td>
-                                    <td x-show="selectedFact === fact">
-                                        <label x-show="false" for="edit-fact-value">Fact Value</label>
-                                        <input id="edit-fact-value" class="input is-small" x-model="fact.value" contenteditable>
-                                    </td>
-                                    <td x-text="fact.score"></td>
-                                    <td>
-                                        <button x-show="selectedFact === fact"
-                                                type="button"
-                                                class="button is-small is-primary"
-                                                x-on:click="updateFactSource()">
-                                            Save
-                                        </button>
-                                    </td>
-                                </tr>
-                            </template>
+                                <template x-for="(fact, index) in filteredFacts" :key="fact.unique">
+                                    <tr x-on:click="selectedFactIndex = index; showAddFactRow = false;" x-bind:class="selectedFactIndex === index ? 'selected' : ''">
+                                        <td class="index-column" x-text="index"></td>
+
+                                        <td x-bind:class="(fact.origin_type) ? 'is-size-6 origin-' + fact.origin_type : ''" x-text="fact.origin_type"></td>
+                                        
+                                        <td x-show="selectedFactIndex !== index" x-text="fact.trait"></td>
+                                        <td x-show="selectedFactIndex === index">
+                                            <input id="edit-fact-trait" class="input is-small" x-model="fact.trait" contenteditable>
+                                        </td>
+                                        
+                                        <td x-show="selectedFactIndex !== index" x-text="fact.value"></td>
+                                        <td x-show="selectedFactIndex === index">
+                                            <input id="edit-fact-value" class="input is-small" x-model="fact.value" contenteditable>
+                                        </td>
+                                        
+                                        <td x-text="fact.score"></td>
+
+                                        <td class="has-text-right" x-show="selectedFactIndex !== index && factIndexToDelete !== index">
+                                            <button class="button is-small" @click.stop="factIndexToDelete = index">
+                                                <span class="icon">
+                                                    <em class="fas fa-trash"></em>
+                                                </span>
+                                            </button>
+                                        </td>
+
+                                        <td class="has-text-right" x-show="factIndexToDelete === -1 && selectedFactIndex === index">
+                                            <button type="button"
+                                                    class="button is-small is-primary"
+                                                    x-on:click.stop="updateFactSource()">
+                                                <span class="icon">
+                                                    <em class="fas fa-save"></em>
+                                                </span>
+                                                <span>Save</span>
+                                            </button>
+                                            <button type="button"
+                                                    class="button is-small"
+                                                    x-on:click.stop="selectedFactIndex = -1; getSources();">
+                                                Cancel
+                                            </button>
+                                        </td>
+                                        
+                                        <td class="has-text-right" x-show="factIndexToDelete === index">
+                                            <div class="is-flex is-justify-content-end">
+                                                <p class="m-1 mr-3">Delete fact?</p>
+                                                <button type="button" class="button is-small is-danger mr-2" x-on:click.stop="deleteFact(factIndexToDelete)">
+                                                    Delete
+                                                </button>
+                                                <button type="button" class="button is-small" x-on:click.stop="factIndexToDelete = -1; selectedFactIndex = -1">
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>
                 </div>
+
                 <!-- RULES CONTENT -->
                 <div class="my-5" x-data="{collapseRules: false}">
                     <div class="collapsible-header">
-                        <button class="button px-0 no-style is-size-4" x-on:click="collapseRules = !collapseRules"
-                                x-bind:class="collapseRules ? 'collapsed' : 'expanded'">
+                        <button class="button px-0 no-style is-size-4" x-on:click="collapseRules = !collapseRules" x-bind:class="collapseRules ? 'collapsed' : 'expanded'">
                             Rules
+                            <span x-text="`&nbsp;(${filteredRules.length})`"></span>
                         </button>
                     </div>
                     <span class="navbar-divider"></span>
-                    <div x-show="!collapseRules" x-data="{selectedRule: null}">
-                        <!-- RULES SEARCH BAR -->
+                    <div x-show="!collapseRules">
                         <div class="is-flex is-flex-direction-row" x-data="{rulesFilterKeyword: ''}">
-                            <div class="mb-4 is-flex is-justify-content-space-between is-flex-direction-column">
-                                <div class="is-flex is-align-items-center filter-search-box">
-                                    <i class="fas fa-search"></i>
+                            <button type="button"
+                                    class="button is-primary is-small mr-2"
+                                    x-on:click="showAddRuleRow = true; selectedRuleIndex = -1">
+                                <span class="icon"><i class="fas fa-plus"></i></span>
+                                <span>Add Rule</span>
+                            </button>
+                            <div class="field mr-2" x-show="filteredFacts.length >= 1 || showAddFactRow">
+                                <p class="control has-icons-left">
                                     <input class="input is-small"
-                                           id="rule-search"
-                                           placeholder="Find a match rule or trait..."
-                                           x-model="rulesFilterKeyword"
-                                           x-on:keyup="filterRules($el.value)">
-                                    <i class="fas fa-times"
-                                       x-on:click="filterRules(''); rulesFilterKeyword=''"></i>
-                                </div>
-                            </div>
-                            <div class="pl-0 is-flex is-align-content-flex-start">
-                                <button type="button"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="showAddRuleRow = true; selectedRule = null">
-                                    <span class="icon"><i class="fas fa-plus"></i></span>
-                                    <span>Add Rule</span>
-                                </button>
-                                <button type="button"
-                                        x-bind:disabled="!selectedRule"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="openModalData.name = 'deleteRule'; openModalData.item = selectedRule"
-                                        title="Delete selected rule">
-                                    <i class="pr-1 fas fa-trash"></i>
-                                </button>
-
+                                        id="rule-search"
+                                        placeholder="Find a match rule or trait..."
+                                        x-model="rulesFilterKeyword"
+                                        x-on:keyup="filterRules($el.value)">
+                                    <span class="icon is-small is-left">
+                                        <i class="fas fa-search"></i>
+                                    </span>
+                                </p>
                             </div>
                         </div>
 
                         <!-- RULES TABLE -->
-                        <table class="table is-striped">
+                        <table class="table is-striped" x-show="filteredRules.length >= 1 || showAddRuleRow">
+                            <colgroup>
+                                <col width="5%">
+                                <col width="30%">
+                                <col width="30%">
+                                <col width="15%">
+                                <col width="20%">
+                            </colgroup>
                             <thead>
-                            <tr>
-                                <th class="index-column">Order</th>
-                                <th>Match</th>
-                                <th>Fact Trait</th>
-                                <th class="text-align-center">Action</th>
-                                <th></th>
-                            </tr>
-                            </thead>
-                            <template x-if="filteredRules.length < 1 && !showAddRuleRow">
-                                <tbody>
                                 <tr>
-                                    <td colspan="5" class="text-align-center py-2">
-                                        <em>No rules; click 'Add Rule' to get started.</em>
-                                    </td>
+                                    <th class="index-column">Order</th>
+                                    <th>Match</th>
+                                    <th>Fact Trait</th>
+                                    <th class="text-align-center">Action</th>
+                                    <th></th>
                                 </tr>
-                                </tbody>
-                            </template>
-                            <tbody>
-                            <template x-if="showAddRuleRow">
-                                <tr x-data="{newRule: EMPTY_RULE_OBJECT}">
-                                    <td></td>
-                                    <td>
-                                        <label x-show="false" for="new-rule-match">Rule Match</label>
-                                        <input id="new-rule-match" class="input is-small" x-model="newRule.match" contenteditable>
-                                    </td>
-                                    <td>
-                                        <label x-show="false" for="new-rule-trait">Rule Trait</label>
-                                        <input id="new-rule-trait" class="input is-small" x-model="newRule.trait" contenteditable>
-                                    </td>
-                                    <td>
-                                        <label x-show="false" for="new-rule-action">Rule Action</label>
-                                        <div class="toggleContainer is-flex is-justify-content-center"
-                                             id="new-rule-action">
-                                            <label class="has-text-danger" for="toggleAction">DENY</label>
-                                            <div class="toggleSwitch mx-2">
-                                                <input type="checkbox"
-                                                       id="toggleAction"
-                                                       x-model="newRule.action"
-                                                       x-bind:checked="newRule.action === 'ALLOW' ? 'checked' : null"/>
-                                                <span class="toggleSlider toggleSliderRound"
-                                                      x-on:click="newRule.action = (newRule.action === 'ALLOW' ? 'DENY' : 'ALLOW')"
-                                                      x-bind:class="newRule.action === 'ALLOW' ? 'toggle-on' : 'toggle-off'">
-                                                    <span x-bind:class="newRule.action === 'ALLOW' ? 'toggle-slider-on' : 'toggle-slider-off'"></span>
-                                                </span>
+                            </thead>
+                            <tbody @click.outside="selectedRuleIndex = -1; ruleIndexToDelete = -1;">
+                                <template x-if="showAddRuleRow">
+                                    <tr x-data="{newRule: EMPTY_RULE_OBJECT}">
+                                        <td></td>
+                                        <td>
+                                            <input id="new-rule-match" class="input is-small" x-model="newRule.match" contenteditable>
+                                        </td>
+                                        <td>
+                                            <input id="new-rule-trait" class="input is-small" x-model="newRule.trait" contenteditable>
+                                        </td>
+                                        <td>
+                                            <div class="toggleContainer is-flex is-justify-content-center"
+                                                id="new-rule-action">
+                                                <label class="has-text-danger" for="toggleAction">DENY</label>
+                                                <div class="toggleSwitch mx-2">
+                                                    <input type="checkbox"
+                                                        id="toggleAction"
+                                                        x-model="newRule.action"
+                                                        x-bind:checked="newRule.action === 'ALLOW' ? 'checked' : null"/>
+                                                    <span class="toggleSlider toggleSliderRound"
+                                                        x-on:click="newRule.action = (newRule.action === 'ALLOW' ? 'DENY' : 'ALLOW')"
+                                                        x-bind:class="newRule.action === 'ALLOW' ? 'toggle-on' : 'toggle-off'">
+                                                        <span x-bind:class="newRule.action === 'ALLOW' ? 'toggle-slider-on' : 'toggle-slider-off'"></span>
+                                                    </span>
+                                                </div>
+                                                <label class="has-text-success" for="toggleAction">ALLOW</label>
                                             </div>
-                                            <label class="has-text-success" for="toggleAction">ALLOW</label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <button type="button"
-                                                class="button is-small is-primary"
-                                                x-on:click="addRule(newRule); newRule = EMPTY_RULE_OBJECT">
-                                            Add
-                                        </button>
-                                    </td>
-                                </tr>
-                            </template>
-                            <template x-for="(rule, index) in filteredRules">
-                                <tr x-on:click="selectedRule = rule; showAddRuleRow = false;"
-                                    x-bind:class="selectedRule === rule ? 'selected' : ''">
-                                    <td class="index-column" x-text="index"></td>
-                                    <td x-show="selectedRule === rule">
-                                        <label x-show="false" for="edit-rule-match">Rule Match</label>
-                                        <input id="edit-rule-match" class="input is-small" x-model="rule.match" contenteditable>
-                                    </td>
-                                    <td x-show="selectedRule !== rule" x-text="rule.match"></td>
-                                    <td x-show="selectedRule === rule">
-                                        <label x-show="false" for="edit-rule-trait">Rule Trait</label>
-                                        <input id="edit-rule-trait" class="input is-small" x-model="rule.trait" contenteditable>
-                                    </td>
-                                    <td x-show="selectedRule !== rule" x-text="rule.trait"></td>
-                                    <td x-show="selectedRule === rule">
-                                        <div class="toggleContainer is-flex is-justify-content-center">
-                                            <label class="has-text-danger" for="toggleRuleAction">DENY</label>
-                                            <div class="toggleSwitch mx-2">
-                                                <input type="checkbox"
-                                                       id="toggleRuleAction"
-                                                       x-model="rule.action"
-                                                       x-bind:checked="rule.action === 'ALLOW' ? 'checked' : null"/>
-                                                <span class="toggleSlider toggleSliderRound"
-                                                      x-on:click="rule.action = (rule.action === 'ALLOW' ? 'DENY' : 'ALLOW')"
-                                                      x-bind:class="rule.action === 'ALLOW' ? 'toggle-on' : 'toggle-off'">
-                                                    <span x-bind:class="rule.action === 'ALLOW' ? 'toggle-slider-on' : 'toggle-slider-off'"></span>
-                                                </span>
+                                        </td>
+                                        <td>
+                                            <button type="button"
+                                                    class="button is-small is-primary"
+                                                    x-on:click="addRule(newRule); newRule = EMPTY_RULE_OBJECT">
+                                                + Add Rule
+                                            </button>
+                                            <button type="button"
+                                                    class="button is-small"
+                                                    x-on:click="showAddRuleRow = false; newRule = EMPTY_FACT_OBJECT">
+                                                Cancel
+                                            </button>
+                                        </td>
+                                    </tr>
+                                </template>
+                                <template x-for="(rule, index) in filteredRules">
+                                    <tr x-on:click="selectedRuleIndex = index; showAddRuleRow = false;" x-bind:class="selectedRuleIndex === rule ? 'selected' : ''">
+                                        <td class="index-column" x-text="index"></td>
+
+                                        <td x-show="selectedRuleIndex === index">
+                                            <input id="edit-rule-match" class="input is-small" x-model="rule.match" contenteditable>
+                                        </td>
+                                        <td x-show="selectedRuleIndex !== index" x-text="rule.match"></td>
+
+                                        <td x-show="selectedRuleIndex === index">
+                                            <input id="edit-rule-trait" class="input is-small" x-model="rule.trait" contenteditable>
+                                        </td>
+                                        <td x-show="selectedRuleIndex !== index" x-text="rule.trait"></td>
+
+                                        <td x-show="selectedRuleIndex === index">
+                                            <div class="toggleContainer is-flex is-justify-content-center">
+                                                <label class="has-text-danger" for="toggleRuleAction">DENY</label>
+                                                <div class="toggleSwitch mx-2">
+                                                    <input type="checkbox"
+                                                        id="toggleRuleAction"
+                                                        x-model="rule.action"
+                                                        x-bind:checked="rule.action === 'ALLOW' ? 'checked' : null"/>
+                                                    <span class="toggleSlider toggleSliderRound"
+                                                        x-on:click="rule.action = (rule.action === 'ALLOW' ? 'DENY' : 'ALLOW')"
+                                                        x-bind:class="rule.action === 'ALLOW' ? 'toggle-on' : 'toggle-off'">
+                                                        <span x-bind:class="rule.action === 'ALLOW' ? 'toggle-slider-on' : 'toggle-slider-off'"></span>
+                                                    </span>
+                                                </div>
+                                                <label class="has-text-success" for="toggleAction">ALLOW</label>
                                             </div>
-                                            <label class="has-text-success" for="toggleAction">ALLOW</label>
-                                        </div>
-                                    </td>
-                                    <td x-show="selectedRule !== rule" class="text-align-center"
-                                        x-bind:class="rule.action === 'ALLOW' ? 'has-text-success' : 'has-text-danger'"
-                                        x-text="rule.action"></td>
-                                    <td>
-                                        <button x-show="selectedRule === rule" type="button"
-                                                class="button is-small is-primary"
-                                                x-on:click="updateFactSource()">
-                                            Save
-                                        </button>
-                                    </td>
-                                </tr>
-                            </template>
+                                        </td>
+                                        <td x-show="selectedRuleIndex !== index" class="text-align-center"
+                                            x-bind:class="rule.action === 'ALLOW' ? 'has-text-success' : 'has-text-danger'"
+                                            x-text="rule.action">
+                                        </td>
+
+                                        <td class="has-text-right" x-show="selectedRuleIndex !== index && ruleIndexToDelete !== index">
+                                            <button class="button is-small" @click.stop="ruleIndexToDelete = index">
+                                                <span class="icon">
+                                                    <em class="fas fa-trash"></em>
+                                                </span>
+                                            </button>
+                                        </td>
+
+                                        <td class="has-text-right" x-show="ruleIndexToDelete === -1 && selectedRuleIndex === index">
+                                            <button type="button"
+                                                    class="button is-small is-primary"
+                                                    x-on:click.stop="updateFactSource()">
+                                                <span class="icon">
+                                                    <em class="fas fa-save"></em>
+                                                </span>
+                                                <span>Save</span>
+                                            </button>
+                                            <button type="button"
+                                                    class="button is-small"
+                                                    x-on:click.stop="selectedRuleIndex = -1; getSources();">
+                                                Cancel
+                                            </button>
+                                        </td>
+                                        
+                                        <td class="has-text-right" x-show="ruleIndexToDelete === index">
+                                            <div class="is-flex is-justify-content-end">
+                                                <p class="m-1 mr-3">Delete rule?</p>
+                                                <button type="button" class="button is-small is-danger mr-2" x-on:click.stop="deleteRule(ruleIndexToDelete)">
+                                                    Delete
+                                                </button>
+                                                <button type="button" class="button is-small" x-on:click.stop="ruleIndexToDelete = -1; selectedRuleIndex = -1">
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>
                 </div>
+
                 <!-- RELATIONSHIPS CONTENT -->
                 <div class="my-5" x-data="{collapseRelationships: false}">
                     <div class="collapsible-header">
@@ -353,31 +389,31 @@
                                 x-on:click="collapseRelationships = !collapseRelationships"
                                 x-bind:class="collapseRelationships ? 'collapsed' : 'expanded'">
                             Relationships
+                            <span x-text="`&nbsp;(${selectedSource.relationships.length})`"></span>
                         </button>
                     </div>
                     <span class="navbar-divider"></span>
-                    <div x-show="!collapseRelationships" x-data="{selectedRelationship: null}">
-                        <!-- RELATIONSHIPS CONTROLS BAR -->
+                    <div x-show="!collapseRelationships" x-data="{selectedRelationshipIndex: -1}">
                         <div class="is-flex is-flex-direction-row">
                             <div class="pl-0 is-flex is-align-content-flex-start">
                                 <button type="button"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="showAddRelationshipRow = true; selectedRelationship = null">
+                                        class="button is-primary is-small"
+                                        x-on:click="showAddRelationshipRow = true; selectedRelationshipIndex = -1">
                                     <span class="icon"><i class="fas fa-plus"></i></span>
                                     <span>Add Relationship</span>
-                                </button>
-                                <button type="button"
-                                        x-bind:disabled="!selectedRelationship"
-                                        class="ml-2 button is-primary is-small"
-                                        x-on:click="openModalData.name = 'deleteRelationship'; openModalData.item = selectedRelationship"
-                                        title="Delete selected relationship">
-                                    <i class="pr-1 fas fa-trash"></i>
                                 </button>
                             </div>
                         </div>
 
                         <!-- RELATIONSHIPS TABLE -->
-                        <table class="table is-striped">
+                        <table class="table is-striped" x-show="selectedSource.relationships.length > 0 || showAddRelationshipRow">
+                            <colgroup>
+                                <col width="5%">
+                                <col width="25%">
+                                <col width="20%">
+                                <col width="25%">
+                                <col width="25%">
+                            </colgroup>
                             <thead>
                                 <tr>
                                     <th class="index-column"></th>
@@ -387,48 +423,86 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <template x-if="selectedSource.relationships.length < 1 && !showAddRelationshipRow">
-                                <tbody>
-                                    <tr>
-                                        <td colspan="5" class="text-align-center py-2">
-                                            <em>No relationships; click 'Add Relationship' to get started.</em>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </template>
-                            <tbody>
-                                <template x-if="showAddRelationshipRow">
-                                    <tr>
-                                        <td></td>
-                                        <td>
-                                            <label x-show="false" for="new-relationship-source">Relationship Source</label>
-                                            <input id="new-relationship-source" class="input is-small" x-model="newRelationship.sourceTrait" contenteditable>
-                                        </td>
-                                        <td>
-                                            <label x-show="false" for="new-relationship-edge">Relationship Edge</label>
-                                            <input id="new-relationship-edge" class="input is-small" x-model="newRelationship.edge" contenteditable>
-                                        </td>
-                                        <td>
-                                            <label x-show="false" for="new-relationship-target">Relationship Target</label>
-                                            <input id="new-relationship-target" class="input is-small" x-model="newRelationship.targetTrait" contenteditable>
-                                        </td>
-                                        <td>
-                                            <button type="button"
-                                                    class="button is-small is-primary"
-                                                    x-on:click="addRelationship(newRelationship)">
-                                                Add
-                                            </button>
-                                        </td>
-                                    </tr>
-                                </template>
+                            <tbody @click.outside="selectedRelationshipIndex = -1; relationshipIndexToDelete = -1;">
+                                <tr x-show="showAddRelationshipRow">
+                                    <td></td>
+                                    <td>
+                                        <input id="new-relationship-source" class="input is-small" x-model="newRelationship.sourceTrait" contenteditable>
+                                    </td>
+                                    <td>
+                                        <input id="new-relationship-edge" class="input is-small" x-model="newRelationship.edge" contenteditable>
+                                    </td>
+                                    <td>
+                                        <input id="new-relationship-target" class="input is-small" x-model="newRelationship.targetTrait" contenteditable>
+                                    </td>
+                                    <td>
+                                        <button type="button"
+                                                class="button is-small is-primary"
+                                                x-on:click.stop="addRelationship(newRelationship)">
+                                            + Add Relationship
+                                        </button>
+                                        <button type="button"
+                                                class="button is-small"
+                                                x-on:click.stop="showAddRelationshipRow = false">
+                                            Cancel
+                                        </button>
+                                    </td>
+                                </tr>
 
                                 <template x-for="(rel, index) in selectedSource.relationships">
-                                    <tr x-on:click="selectedRelationship = rel; showAddRelationshipRow = false;" x-bind:class="selectedRelationship === rel ? 'selected' : ''">
+                                    <tr x-on:click="selectedRelationshipIndex = index; showAddRelationshipRow = false;" x-bind:class="selectedRelationshipIndex === index ? 'selected' : ''">
                                         <td class="index-column" x-text="index"></td>
-                                        <td x-text="rel.source?.trait"></td>
-                                        <td x-text="rel.edge"></td>
-                                        <td x-text="rel.target?.trait"></td>
-                                        <td></td>
+
+                                        <td x-show="selectedRelationshipIndex !== index" x-text="rel.source?.trait"></td>
+                                        <td x-show="selectedRelationshipIndex === index">
+                                            <input id="edit-rel-trait" class="input is-small" x-model="rel.source.trait" contenteditable>
+                                        </td>
+
+                                        <td x-show="selectedRelationshipIndex !== index" x-text="rel.edge"></td>
+                                        <td x-show="selectedRelationshipIndex === index">
+                                            <input id="edit-rel-trait" class="input is-small" x-model="rel.edge" contenteditable>
+                                        </td>
+
+                                        <td x-show="selectedRelationshipIndex !== index" x-text="rel.target?.trait"></td>
+                                        <td x-show="selectedRelationshipIndex === index">
+                                            <input id="edit-rel-trait" class="input is-small" x-model="rel.target.trait" contenteditable>
+                                        </td>
+                                        
+                                        <td class="has-text-right" x-show="selectedRelationshipIndex !== index && relationshipIndexToDelete !== index">
+                                            <button class="button is-small" @click.stop="relationshipIndexToDelete = index">
+                                                <span class="icon">
+                                                    <em class="fas fa-trash"></em>
+                                                </span>
+                                            </button>
+                                        </td>
+
+                                        <td class="has-text-right" x-show="relationshipIndexToDelete === -1 && selectedRelationshipIndex === index">
+                                            <button type="button"
+                                                    class="button is-small is-primary"
+                                                    x-on:click.stop="updateFactSource()">
+                                                <span class="icon">
+                                                    <em class="fas fa-save"></em>
+                                                </span>
+                                                <span>Save</span>
+                                            </button>
+                                            <button type="button"
+                                                    class="button is-small"
+                                                    x-on:click.stop="selectedRelationshipIndex = -1; getSources();">
+                                                Cancel
+                                            </button>
+                                        </td>
+                                        
+                                        <td class="has-text-right" x-show="relationshipIndexToDelete === index">
+                                            <div class="is-flex is-justify-content-end">
+                                                <p class="m-1 mr-3">Delete relationship?</p>
+                                                <button type="button" class="button is-small is-danger mr-2" x-on:click.stop="deleteRelationship(relationshipIndexToDelete)">
+                                                    Delete
+                                                </button>
+                                                <button type="button" class="button is-small" x-on:click.stop="relationshipIndexToDelete = -1; selectedRelationshipIndex = -1">
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </td>
                                     </tr>
                                 </template>
                             </tbody>
@@ -439,8 +513,8 @@
         </template>
     </div>
 
-    <div class="modal" x-bind:class="{ 'is-active': isConfirmDeleteModalOpen }">
-        <div class="modal-background" @click="isConfirmDeleteModalOpen = false"></div>
+    <div class="modal" x-bind:class="{ 'is-active': isConfirmSourceDeleteModalOpen }">
+        <div class="modal-background" @click="isConfirmSourceDeleteModalOpen = false"></div>
         <div class="modal-card" style="z-index: 20">
             <header class="modal-card-head">
                 <p class="modal-card-title">Delete Fact Source?</p>
@@ -454,12 +528,12 @@
                 <nav class="level">
                     <div class="level-left">
                         <div class="level-item">
-                            <button class="button is-small" @click="isConfirmDeleteModalOpen = false">Cancel</button>
+                            <button class="button is-small" @click="isConfirmSourceDeleteModalOpen = false">Cancel</button>
                         </div>
                     </div>
                     <div class="level-right">
                         <div class="level-item">
-                            <button class="button is-danger is-small" @click="deleteSource(); isConfirmDeleteModalOpen = false;">
+                            <button class="button is-danger is-small" @click="deleteSource(); isConfirmSourceDeleteModalOpen = false;">
                                 <span class="icon"><em class="fas fa-trash"></em></span>
                                 <span>Delete Source</span>
                             </button>
@@ -484,15 +558,18 @@
             filteredFacts: [],
             filteredRules: [],
 
-            selectedSource: null,
+            selectedSource: { name: '', relationships: [] },
             selectedSourceId: '',
-            selectedRelationship: null,
-            selectedFact: null,
-            selectedRule: null,
+            selectedRelationshipIndex: null,
+            selectedFactIndex: null,
+            selectedRuleIndex: null,
 
             isEditingSourceName: false,
 
-            isConfirmDeleteModalOpen: false,
+            isConfirmSourceDeleteModalOpen: false,
+            factIndexToDelete: -1,
+            ruleIndexToDelete: -1,
+            relationshipIndexToDelete: -1,
 
             showAddFactRow: false,
             showAddRuleRow: false,
@@ -507,6 +584,7 @@
             getSources() {
                 apiV2('GET', '/api/v2/sources').then((sources) => {
                     this.sources = sources.sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase());
+                    this.handleSelectSource();
                 }).catch((error) => {
                     toast('Error loading page', false);
                     console.error(error);
@@ -514,6 +592,7 @@
             },
 
             handleSelectSource() {
+                if (!this.selectedSourceId) return;
                 this.selectedSource = this.sources.find((source) => source.id === this.selectedSourceId);
                 this.filteredFacts = this.selectedSource.facts;
                 this.filteredRules = this.selectedSource.rules;
@@ -542,6 +621,7 @@
                     this.sources.push(newSource);
                     this.selectedSourceId = newSource.id;
                     this.selectedSource = newSource;
+                    this.handleSelectSource();
                     this.$nextTick(() => {
                         document.getElementById('sourceName').focus();
                     });
@@ -553,9 +633,12 @@
 
             duplicateSource(source) {
                 const newSource = { ...source, name: `${source.name} (copy)`, id: '' };
-                apiV2('POST', '/api/v2/sources', newSource).then((res) => {
-                    toast('Added new fact source', res);
-                    this.getSources();
+                apiV2('POST', '/api/v2/sources', newSource).then((newSource) => {
+                    this.sources.push(newSource);
+                    this.selectedSourceId = newSource.id;
+                    this.selectedSource = newSource;
+                    this.handleSelectSource();
+                    toast('Duplicated fact source', true);
                 }).catch((error) => {
                     toast('Error duplicating source', false);
                     console.error(error);
@@ -617,6 +700,7 @@
                 apiV2('DELETE', `/api/v2/sources/${this.selectedSourceId}`).then((res) => {
                     toast('Deleted fact source', true);
                     this.selectedSourceId = '';
+                    this.selectedSource = { name: '', relationships: [] };
                     this.getSources();
                 }).catch((error) => {
                     toast('Error deleting source', false);
@@ -624,18 +708,21 @@
                 });
             },
 
-            deleteFact(fact) {
-                this.selectedSource.facts.splice(this.selectedSource.facts.findIndex((f) => f.unique === fact.unique), 1);
+            deleteFact(index) {
+                this.selectedSource.facts.splice(index, 1);
+                this.factIndexToDelete = -1;
                 this.updateFactSource();
             },
 
-            deleteRule(rule) {
-                this.selectedSource.rules.splice(this.selectedSource.rules.findIndex((r) => r === rule), 1);
+            deleteRule(index) {
+                this.selectedSource.rules.splice(index, 1);
+                this.ruleIndexToDelete = -1;
                 this.updateFactSource();
             },
 
-            deleteRelationship(rel) {
-                this.selectedSource.relationships.splice(this.selectedSource.relationships.find((r) => r === rel), 1);
+            deleteRelationship(index) {
+                this.selectedSource.relationships.splice(index, 1);
+                this.relationshipIndexToDelete = -1;
                 this.updateFactSource();
             },
 
@@ -652,8 +739,9 @@
             updateFactSource() {
                 apiV2('PATCH', `/api/v2/sources/${this.selectedSource.id}`, this.selectedSource).then((res) => {
                     toast('Updated source', true);
-                    this.selectedFact = {};
-                    this.selectedRule = {};
+                    this.selectedFactIndex = -1;
+                    this.selectedRuleIndex = -1;
+                    this.selectedRelationshipIndex = -1;
                     this.getSources();
                 }).catch((error) => {
                     toast('Error loading page', false);
@@ -668,7 +756,6 @@
 
 <style>
     :scope {
-        --primary-color: #8B0000;
         --dark-gray: gray;
         --light-gray: #e6e6e6;
         --decisions-color: #4fdcfc;
@@ -755,6 +842,7 @@
 
     #sourcePage table tbody tr:hover, table tbody tr.selected {
         background-color: rgba(255, 255, 255, 0.1) !important;
+        cursor: pointer;
     }
 
     #sourcePage table input.fact-score {
@@ -763,6 +851,10 @@
 
     #sourcePage table .index-column {
         color: var(--dark-gray);
+    }
+
+    #sourcePage td {
+        word-wrap: anywhere;
     }
 
     #sourcePage .toggle-on.toggleSlider.toggleSlider::before {

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -70,7 +70,7 @@
                             </button>
                         </div>
                         <div class="level-item">
-                            <button class="button is-small is-primary" @click="isConfirmSourceDeleteModalOpen = true">
+                            <button class="button is-small is-danger is-outlined" @click="isConfirmSourceDeleteModalOpen = true">
                                 <span class="icon"><em class="fas fa-trash"></em></span>
                                 <span>Delete Source</span>
                             </button>
@@ -88,8 +88,8 @@
                     </div>
                     <span class="navbar-divider"></span>
                     <div x-show="!collapseFacts">
-                        <div class="is-flex is-flex-direction-row" x-data="{factsFilterKeyword: ''}">
-                            <button type="button" class="button is-primary is-small mr-2" x-on:click="showAddFactRow = true; selectedFactIndex = -1">
+                        <div class="is-flex is-flex-direction-row">
+                            <button type="button" class="button is-primary is-small mr-2" x-on:click="showAddFactRow = true; selectedFactIndex = -1" x-bind:disabled="showAddFactRow">
                                 <span class="icon"><i class="fas fa-plus"></i></span>
                                 <span>Add Fact</span>
                             </button>
@@ -98,7 +98,6 @@
                                     <input class="input is-small"
                                            id="fact-search"
                                            placeholder="Find a trait or value..."
-                                           x-model="factsFilterKeyword"
                                            x-on:keyup="filterFacts($el.value)">
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
@@ -223,10 +222,11 @@
                     </div>
                     <span class="navbar-divider"></span>
                     <div x-show="!collapseRules">
-                        <div class="is-flex is-flex-direction-row" x-data="{rulesFilterKeyword: ''}">
+                        <div class="is-flex is-flex-direction-row">
                             <button type="button"
                                     class="button is-primary is-small mr-2"
-                                    x-on:click="showAddRuleRow = true; selectedRuleIndex = -1">
+                                    x-on:click="showAddRuleRow = true; selectedRuleIndex = -1"
+                                    x-bind:disabled="showAddRuleRow">
                                 <span class="icon"><i class="fas fa-plus"></i></span>
                                 <span>Add Rule</span>
                             </button>
@@ -235,7 +235,6 @@
                                     <input class="input is-small"
                                         id="rule-search"
                                         placeholder="Find a matching rule or trait..."
-                                        x-model="rulesFilterKeyword"
                                         x-on:keyup="filterRules($el.value)">
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
@@ -397,11 +396,23 @@
                         <div class="is-flex is-flex-direction-row">
                             <div class="pl-0 is-flex is-align-content-flex-start">
                                 <button type="button"
-                                        class="button is-primary is-small"
-                                        x-on:click="showAddRelationshipRow = true; selectedRelationshipIndex = -1">
+                                        class="button is-primary is-small mr-2"
+                                        x-on:click="showAddRelationshipRow = true; selectedRelationshipIndex = -1"
+                                        x-bind:disabled="showAddRelationshipRow">
                                     <span class="icon"><i class="fas fa-plus"></i></span>
                                     <span>Add Relationship</span>
                                 </button>
+                                <div class="field mr-2" x-show="selectedSource.relationships && selectedSource.relationships.length >= 1 || showAddRelationshipRow">
+                                    <p class="control has-icons-left">
+                                        <input class="input is-small"
+                                               id="relationship-search"
+                                               placeholder="Find a source or target..."
+                                               x-on:keyup="filterRelationships($el.value)">
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </p>
+                                </div>
                             </div>
                         </div>
 
@@ -449,7 +460,7 @@
                                     </td>
                                 </tr>
 
-                                <template x-for="(rel, index) in selectedSource.relationships">
+                                <template x-for="(rel, index) in filteredRelationships">
                                     <tr x-on:click="selectedRelationshipIndex = index; showAddRelationshipRow = false;" x-bind:class="selectedRelationshipIndex === index ? 'selected' : ''">
                                         <td class="index-column" x-text="index"></td>
 
@@ -535,7 +546,7 @@
                         <div class="level-item">
                             <button class="button is-danger is-small" @click="deleteSource(); isConfirmSourceDeleteModalOpen = false;">
                                 <span class="icon"><em class="fas fa-trash"></em></span>
-                                <span>Delete Source</span>
+                                <span class="has-text-weight-bold">Delete Source</span>
                             </button>
                         <div>
                     </div>
@@ -557,6 +568,7 @@
             filteredSources: [],
             filteredFacts: [],
             filteredRules: [],
+            filteredRelationships: [],
 
             selectedSource: { name: '', relationships: [] },
             selectedSourceId: '',
@@ -596,6 +608,7 @@
                 this.selectedSource = this.sources.find((source) => source.id === this.selectedSourceId);
                 this.filteredFacts = this.selectedSource.facts;
                 this.filteredRules = this.selectedSource.rules;
+                this.filteredRelationships = this.selectedSource.relationships;
             },
 
             filterFacts(input = '') {
@@ -608,9 +621,14 @@
                 this.filteredRules = this.selectedSource.rules.filter((r) => (r.match.toLowerCase().includes(input) || r.trait.toLowerCase().includes(input)));
             },
 
+            filterRelationships(input = '') {
+                input = input.toLowerCase();
+                this.filteredRelationships = this.selectedSource.relationships.filter((r) => (r.source.trait.toLowerCase().includes(input) || r.target.trait.toLowerCase().includes(input)));
+            },
+            
             createSource(newSourceName) {
                 const newSource = {
-                    name: '',
+                    name: 'New source',
                     facts: [],
                     rules: [],
                     relationships: []
@@ -651,6 +669,7 @@
                 apiV2('PUT', `/api/v2/sources/${this.selectedSource.id}`, updatedSource).then((res) => {
                     toast('Updated source', res);
                     this.showAddFactRow = false;
+                    this.getSources();
                 }).catch((error) => {
                     toast('Error adding fact', false);
                     console.error(error);
@@ -671,6 +690,7 @@
                 apiV2('PUT', `/api/v2/sources/${this.selectedSource.id}`, updatedSource).then((res) => {
                     toast('Updated source', true);
                     this.showAddRuleRow = false;
+                    this.getSources();
                 }).catch((error) => {
                     toast('Error adding rule', false);
                     console.error(error);
@@ -690,6 +710,7 @@
                     this.newRelationship.sourceTrait = '';
                     this.newRelationship.targetTrait = '';
                     this.newRelationship.edge = '';
+                    this.getSources();
                 }).catch((error) => {
                     toast('Error adding relationship', false);
                     console.error(error);
@@ -727,6 +748,11 @@
             },
 
             saveSourceName() {
+                if (!this.selectedSource.name) {
+                    toast('Source name cannot be blank', false);
+                    return;
+                }
+
                 apiV2('PATCH', `/api/v2/sources/${this.selectedSource.id}`, { name: this.selectedSource.name }).then((res) => {
                     toast('Source name updated', true);
                     this.isEditingSourceName = false;


### PR DESCRIPTION
## Description

There was unexpected behavior and bugs when creating facts, rules, and relationships on a fact source. This PR ensures that all three categories can be created, edited, and removed.

The fact source selection was also changed to a dropdown to match other core pages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in FF, Chrome, and Safari, all of which produced no console errors and behaved as exected:
* Create, duplicate, and remove fact source
* Create, edit, delete facts, rules, and relationships
* Modify the name of the source

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
