### PR TITLE
virts-1902: Default Objects

### DIFF
--- a/tests/api/v2/handlers/test_planners_api.py
+++ b/tests/api/v2/handlers/test_planners_api.py
@@ -8,7 +8,15 @@ from app.utility.base_service import BaseService
 
 @pytest.fixture
 def test_planner(loop, api_v2_client):
-    planner = Planner(name="test planner", planner_id="123", description="a test planner", plugin="planner")
+    planner = Planner(name="123test planner", planner_id="123", description="a test planner", plugin="planner")
+    loop.run_until_complete(BaseService.get_service('data_svc').store(planner))
+    return planner
+
+
+@pytest.fixture
+def test_planner_2(loop, api_v2_client):
+    planner = Planner(name="atomic", planner_id="456", description="an alphabetically superior test planner (fake)",
+                      plugin="planner")
     loop.run_until_complete(BaseService.get_service('data_svc').store(planner))
     return planner
 
@@ -42,3 +50,10 @@ class TestPlannersApi:
     async def test_get_nonexistent_planner_by_id(self, api_v2_client, api_cookies):
         resp = await api_v2_client.get('/api/v2/planners/999', cookies=api_cookies)
         assert resp.status == HTTPStatus.NOT_FOUND
+
+    async def test_planner_defaults(self, api_v2_client, api_cookies, test_planner, test_planner_2):
+        resp = await api_v2_client.get('/api/v2/planners', cookies=api_cookies)
+        planners_list = await resp.json()
+        assert len(planners_list) == 2
+        assert planners_list[0]["id"] == "456"
+        assert planners_list[0]["name"][0] > planners_list[1]["name"][0]  # prove that this wasn't an alphabetical sort


### PR DESCRIPTION
## Description

Adds a default planner validation test to further validate the changes of [virts-1902](https://github.com/mitre/caldera/pull/2399)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This is the test.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
