### PR TITLE
Add getSources() call on click outside of edit row in sources

### DIFF
--- a/templates/sources.html
+++ b/templates/sources.html
@@ -126,7 +126,7 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <tbody @click.outside="selectedFactIndex = -1; factIndexToDelete = -1;">
+                            <tbody @click.outside="selectedFactIndex = -1; factIndexToDelete = -1; getSources();">
                                 <tr x-data="{ newFact: EMPTY_FACT_OBJECT }" x-show="showAddFactRow">
                                     <td></td>
                                     <td></td>
@@ -261,7 +261,7 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <tbody @click.outside="selectedRuleIndex = -1; ruleIndexToDelete = -1;">
+                            <tbody @click.outside="selectedRuleIndex = -1; ruleIndexToDelete = -1; getSources();">
                                 <template x-if="showAddRuleRow">
                                     <tr x-data="{newRule: EMPTY_RULE_OBJECT}">
                                         <td></td>
@@ -434,7 +434,7 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <tbody @click.outside="selectedRelationshipIndex = -1; relationshipIndexToDelete = -1;">
+                            <tbody @click.outside="selectedRelationshipIndex = -1; relationshipIndexToDelete = -1; getSources();">
                                 <tr x-show="showAddRelationshipRow">
                                     <td></td>
                                     <td>


### PR DESCRIPTION
## Description

When editing a row value in a source and the user clicks away without saving the values, the values are retained which could lead to user erroneously thinking edited values are saved--when they refresh the page, the previous unedited values will display.

This PR is part of VIRTS-3546 release prep.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
