### PR TITLE
Download report button would show when there are no reports available, only in Safari, when clicked nothing would happen

### DIFF
--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -22,11 +22,13 @@
                         <th x-text="contact.name"></th>
                         <td x-text="contact.description"></td>
                         <td>
-                            <span x-show="hasNoReport.includes(contact.name)" class="is-size-7">No contacts to show</span>
-                            <button class="button is-small is-primary" @click="downloadContactReport(contact.name)" x-show="!hasNoReport.includes(contact.name)">
-                                <span class="icon"><i class="fas fa-file-download"></i></span>
-                                <span>Download Report</span>
-                            </button>
+                            <span x-show="hasNoReport.has(contact.name)" class="is-size-7">No contacts to show</span>
+                            <template x-if="!hasNoReport.has(contact.name)">
+                                <button class="button is-small is-primary" @click="downloadContactReport(contact.name)">
+                                    <span class="icon"><i class="fas fa-file-download"></i></span>
+                                    <span>Download Report</span>
+                                </button>
+                            </template>
                         </td>
                     </tr>
                 </template>
@@ -39,15 +41,15 @@
     function alpineContacts() {
         return {
             contacts: JSON.parse('{{ contacts | tojson }}'),
-            hasNoReport: [],
+            hasNoReport: new Set(),
 
             initPage() {
-                this.hasNoReport = [];
+                this.hasNoReport = new Set();
                 this.contacts.forEach(async (contact) => {
                     try {
                         await apiV2('GET', `/api/v2/contacts/${contact.name}`);
                     } catch (error) {
-                        this.hasNoReport.push(contact.name);
+                        this.hasNoReport.add(contact.name);
                     }
                 });
             },


### PR DESCRIPTION
## Description

Alpine bug showing button that should be hidden in Safari--fixed by switching usage of `x-show` to `<template x-if` instead

This PR is part of VIRTS-3546 release prep

<img width="1638" alt="Screen Shot 2022-01-18 at 11 07 36" src="https://user-images.githubusercontent.com/32778440/149985553-8aad20bb-f202-4b52-bd25-4f0029d95c38.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
