### PR TITLE
Fixed negative tab index

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -27,7 +27,7 @@ function alpineCore() {
 
         checkIfFirstVisit() {
             let localStorage = window.localStorage;
-            this.isFirstVisit = !localStorage.getItem('firstVisit')
+            this.isFirstVisit = !localStorage.getItem('firstVisit');
             if (this.isFirstVisit) {
                 localStorage.setItem('firstVisit', new Date().toISOString());
             }
@@ -88,9 +88,9 @@ function alpineCore() {
             }
 
             if (this.activeTabIndex >= index) {
-                this.activeTabIndex -= 1;
+                this.activeTabIndex = Math.max(0, this.activeTabIndex - 1);
             }
-            
+
             this.openTabs.splice(index, 1);
         },
 


### PR DESCRIPTION
## Description

When multiple tabs are open, and user closes a tab, it might show a blank page rather than defaulting to another open tab or the instruction page

This PR is part of VIRTS-3546 release prep

<img width="893" alt="Screen Shot 2022-01-18 at 12 20 05" src="https://user-images.githubusercontent.com/32778440/149987024-619ba383-23d2-497f-a860-0c8fb4ddc22f.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
