### PR TITLE
Python 3.7 build fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 tox
 pytest
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
 coverage
 pre-commit
 safety

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     coverage
     codecov
 commands =
-    py37: coverage run -p -m pytest --tb=short -Werror tests --asyncio-mode=auto
+    py37: coverage run -p -m pytest --tb=short -Werror tests --asyncio-mode=legacy
     py{38,39,310}: coverage run -p -m pytest --tb=short tests
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     coverage
     codecov
 commands =
-    py37: coverage run -p -m pytest --tb=short tests --asyncio-mode=legacy
+    py37: coverage run -p -m pytest --tb=short -Werror tests --asyncio-mode=auto
     py{38,39,310}: coverage run -p -m pytest --tb=short tests
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     coverage
     codecov
 commands =
-    py37: coverage run -p -m pytest --tb=short -Werror tests --asyncio-mode=legacy
+    py37: coverage run -p -m pytest --tb=short tests --asyncio-mode=legacy
     py{38,39,310}: coverage run -p -m pytest --tb=short tests
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     coverage
     codecov
 commands =
-    py37: coverage run -p -m pytest --tb=short -Werror tests
+    py37: coverage run -p -m pytest --tb=short -Werror tests --asyncio-mode=auto
     py{38,39,310}: coverage run -p -m pytest --tb=short tests
 
 [testenv:style]


### PR DESCRIPTION
## Description

This PR is an attempt to fix the tox configuration invocation of the 3.7 test set so it stops erroring (currently, it's complaining about "legacy" being replaced with "auto").

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in the pipeline on github (here).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
