### PR TITLE
Fix various unit testing deprecation errors and general pipeline cleanup

### DIFF
--- a/app/contacts/contact_ftp.py
+++ b/app/contacts/contact_ftp.py
@@ -39,14 +39,18 @@ class Contact(BaseWorld):
         self.user = self.get_config('app.contact.ftp.user')
         self.pword = self.get_config('app.contact.ftp.pword')
         self.server = None
+        self.task = None
 
     async def start(self):
         self.set_up_server()
         if sys.version_info >= (3, 7):
-            t = asyncio.create_task(self.ftp_server_python_new())
+            self.task = asyncio.create_task(self.ftp_server_python_new())
         else:
-            t = asyncio.create_task(self.ftp_server_python_old())
-        await t
+            self.task = asyncio.create_task(self.ftp_server_python_old())
+        await self.task
+
+    async def stop(self):
+        self.task.cancel()
 
     def set_up_server(self):
         user = self.setup_ftp_users()

--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -1,5 +1,4 @@
 import websockets
-import asyncio
 
 from app.utility.base_world import BaseWorld
 
@@ -25,6 +24,8 @@ class Contact(BaseWorld):
 
     async def stop(self):
         await self.socket.close()
+
+
 class Handler:
 
     def __init__(self, services):

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -127,6 +127,7 @@ class AppService(AppServiceInterface, BaseService):
 
     async def teardown(self, main_config_file='default'):
         await self._destroy_plugins()
+        await self._deregister_contacts()
         await self._save_configurations(main_config_file=main_config_file)
         await self._services.get('data_svc').save_state()
         await self._services.get('knowledge_svc').save_state()
@@ -146,6 +147,10 @@ class AppService(AppServiceInterface, BaseService):
             tunnel_module_name = tunnel_file.replace('/', '.').replace('\\', '.').replace('.py', '')
             tunnel_class = import_module(tunnel_module_name).Tunnel
             await contact_svc.register_tunnel(tunnel_class(self.get_services()))
+
+    async def _deregister_contacts(self):
+        contact_svc = self.get_service('contact_svc')
+        await contact_svc.deregister_contacts()
 
     async def validate_requirement(self, requirement, params):
         if not self.check_requirement(params):

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -38,6 +38,14 @@ class ContactService(ContactServiceInterface, BaseService):
         except Exception as e:
             self.log.error('Failed to start %s contact: %s' % (contact.name, e))
 
+    async def deregister_contacts(self):
+        try:
+            for contact in self.contacts:
+                await self._stop_c2_channel(contact=contact)
+                self.log.debug('Deregistered contact: %s' % contact.name)
+        except Exception as e:
+            self.log.error('Failed to stop %s contact: %s' % (contact.name, e))
+
     async def register_tunnel(self, tunnel):
         try:
             await self._start_c2_tunnel(tunnel=tunnel)
@@ -147,6 +155,10 @@ class ContactService(ContactServiceInterface, BaseService):
         loop = asyncio.get_event_loop()
         loop.create_task(tunnel.start())
         self.tunnels.append(tunnel)
+
+    async def _stop_c2_channel(self, contact):
+        if hasattr(contact, 'stop'):
+            await contact.stop()
 
     async def _get_instructions(self, agent):
         ops = await self.get_service('data_svc').locate('operations', match=dict(finish=None))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 tox
 pytest
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
 coverage
 pre-commit
 safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ svglib==1.0.1  # debrief
 Markdown==3.3.3  # training
 dnspython==2.1.0
 asyncssh==2.5.0
-aioftp~=0.18.1; python_version >= '3.7'
+aioftp~=0.20.0; python_version >= '3.7'
 aioftp==0.16.1; python_version < '3.7'
 pyminizip==0.2.4

--- a/tests/api/v2/handlers/test_abilities_api.py
+++ b/tests/api/v2/handlers/test_abilities_api.py
@@ -49,12 +49,12 @@ def replaced_ability_payload(test_ability):
 
 
 @pytest.fixture
-def test_ability(loop, api_v2_client, executor):
+def test_ability(event_loop, api_v2_client, executor):
     executor_linux = executor(name='sh', platform='linux')
     ability = Ability(ability_id='123', name='Test Ability', executors=[executor_linux],
                       technique_name='collection', technique_id='1', description='', privilege='', tactic='discovery',
                       plugin='testplugin')
-    loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
     return ability
 
 

--- a/tests/api/v2/handlers/test_adversaries_api.py
+++ b/tests/api/v2/handlers/test_adversaries_api.py
@@ -44,7 +44,7 @@ def expected_new_adversary_dump(new_adversary_payload):
 
 
 @pytest.fixture
-def test_adversary(loop):
+def test_adversary(event_loop):
     expected_adversary = {'name': 'test',
                           'description': 'an empty adversary profile',
                           'adversary_id': '123',
@@ -53,7 +53,7 @@ def test_adversary(loop):
                           'atomic_ordering': [],
                           'plugin': ''}
     test_adversary = AdversarySchema().load(expected_adversary)
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_adversary))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_adversary))
     return test_adversary
 
 

--- a/tests/api/v2/handlers/test_agents_api.py
+++ b/tests/api/v2/handlers/test_agents_api.py
@@ -68,12 +68,12 @@ def expected_new_agent_dump(new_agent_payload, mocker, mock_time):
 
 
 @pytest.fixture
-def test_agent(loop, mocker, mock_time):
+def test_agent(event_loop, mocker, mock_time):
     with mocker.patch('app.objects.c_agent.datetime') as mock_datetime:
         mock_datetime.return_value = mock_datetime
         mock_datetime.now.return_value = mock_time
         test_agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['sh'], platform='linux')
-        loop.run_until_complete(BaseService.get_service('data_svc').store(test_agent))
+        event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_agent))
         return test_agent
 
 
@@ -84,7 +84,7 @@ def test_executor(test_agent):
 
 
 @pytest.fixture
-def deploy_ability(test_executor, loop):
+def deploy_ability(test_executor, event_loop):
     ability = AbilitySchema().load(dict(ability_id='123',
                                         tactic='persistence',
                                         technique_id='auto-generated',
@@ -92,7 +92,7 @@ def deploy_ability(test_executor, loop):
                                         name='test deploy command',
                                         description='test ability',
                                         executors=[ExecutorSchema().dump(test_executor)]))
-    loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
     return ability
 
 

--- a/tests/api/v2/handlers/test_obfuscators_api.py
+++ b/tests/api/v2/handlers/test_obfuscators_api.py
@@ -7,9 +7,9 @@ from app.utility.base_service import BaseService
 
 
 @pytest.fixture
-def test_obfuscator(loop, api_v2_client):
+def test_obfuscator(event_loop, api_v2_client):
     obfuscator = Obfuscator(name='test', description='a test obfuscator', module='testmodule')
-    loop.run_until_complete(BaseService.get_service('data_svc').store(obfuscator))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(obfuscator))
     return obfuscator
 
 

--- a/tests/api/v2/handlers/test_objectives_api.py
+++ b/tests/api/v2/handlers/test_objectives_api.py
@@ -50,9 +50,9 @@ def test_goal():
 
 
 @pytest.fixture
-def test_objective(loop, test_goal):
+def test_objective(event_loop, test_goal):
     objective = Objective(id='123', name='test objective', description='a test objective', goals=[test_goal])
-    loop.run_until_complete(BaseService.get_service('data_svc').store(objective))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(objective))
     return objective
 
 

--- a/tests/api/v2/handlers/test_planners_api.py
+++ b/tests/api/v2/handlers/test_planners_api.py
@@ -7,9 +7,9 @@ from app.utility.base_service import BaseService
 
 
 @pytest.fixture
-def test_planner(loop, api_v2_client):
+def test_planner(event_loop, api_v2_client):
     planner = Planner(name="test planner", planner_id="123", description="a test planner", plugin="planner")
-    loop.run_until_complete(BaseService.get_service('data_svc').store(planner))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(planner))
     return planner
 
 

--- a/tests/api/v2/handlers/test_plugins_api.py
+++ b/tests/api/v2/handlers/test_plugins_api.py
@@ -7,9 +7,9 @@ from app.utility.base_service import BaseService
 
 
 @pytest.fixture
-def test_plugin(loop, api_v2_client):
+def test_plugin(event_loop, api_v2_client):
     plugin = Plugin(name="test_plugin", enabled=True, description="a test plugin", address="test_address")
-    loop.run_until_complete(BaseService.get_service('data_svc').store(plugin))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(plugin))
     return plugin
 
 

--- a/tests/api/v2/handlers/test_schedules_api.py
+++ b/tests/api/v2/handlers/test_schedules_api.py
@@ -77,12 +77,12 @@ def expected_new_schedule_dump(new_schedule_payload):
 
 
 @pytest.fixture
-def test_schedule(test_operation, loop):
+def test_schedule(test_operation, event_loop):
     operation = OperationSchema().load(test_operation)
     schedule = ScheduleSchema().load(dict(id='123',
                                           schedule='03:00:00.000000',
                                           task=operation.schema.dump(operation)))
-    loop.run_until_complete(BaseService.get_service('data_svc').store(schedule))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(schedule))
     return schedule
 
 

--- a/tests/api/v2/handlers/test_sources_api.py
+++ b/tests/api/v2/handlers/test_sources_api.py
@@ -112,7 +112,7 @@ def expected_replaced_source_dump(replaced_source_payload, mocker, mock_time):
 
 
 @pytest.fixture
-def test_source(loop, mocker, mock_time):
+def test_source(event_loop, mocker, mock_time):
     with mocker.patch('app.objects.secondclass.c_fact.datetime') as mock_datetime:
         mock_datetime.return_value = mock_datetime
         mock_datetime.now.return_value = mock_time
@@ -121,7 +121,7 @@ def test_source(loop, mocker, mock_time):
         relationship = Relationship(source=fact, edge="alpha", origin="test_operation")
         source = Source(id='123', name='Test Source', facts=[fact],
                         rules=[rule], adjustments=[], relationships=[relationship])
-        loop.run_until_complete(BaseService.get_service('data_svc').store(source))
+        event_loop.run_until_complete(BaseService.get_service('data_svc').store(source))
         return source
 
 

--- a/tests/api/v2/test_knowledge.py
+++ b/tests/api/v2/test_knowledge.py
@@ -37,12 +37,11 @@ def base_world():
 
 
 @pytest.fixture
-def knowledge_webapp(loop, app_svc, base_world, data_svc):
-    link = app_svc(loop)
-    link.add_service('auth_svc', AuthService())
-    link.add_service('knowledge_svc', KnowledgeService())
-    link.add_service('file_svc', FileSvc())  # This needs to be done this way, or it we won't have a valid BaseWorld
-    services = link.get_services()
+def knowledge_webapp(event_loop, app_svc, base_world, data_svc):
+    app_svc.add_service('auth_svc', AuthService())
+    app_svc.add_service('knowledge_svc', KnowledgeService())
+    app_svc.add_service('file_svc', FileSvc())  # This needs to be done this way, or it we won't have a valid BaseWorld
+    services = app_svc.get_services()
     app = web.Application(
         middlewares=[
             authentication_required_middleware_factory(services['auth_svc']),

--- a/tests/api/v2/test_responses.py
+++ b/tests/api/v2/test_responses.py
@@ -25,7 +25,7 @@ def base_world():
 
 
 @pytest.fixture
-def simple_webapp(loop, base_world):
+def simple_webapp(event_loop, base_world):
     async def raise_validation_error(request):
         raise errors.RequestValidationError(
             errors={

--- a/tests/api/v2/test_security.py
+++ b/tests/api/v2/test_security.py
@@ -27,7 +27,7 @@ def base_world():
 
 
 @pytest.fixture
-def simple_webapp(loop, base_world):
+def simple_webapp(event_loop, base_world):
     async def index(request):
         return web.Response(status=200, text='hello!')
 
@@ -50,13 +50,13 @@ def simple_webapp(loop, base_world):
 
     auth_svc = AuthService()
 
-    loop.run_until_complete(
+    event_loop.run_until_complete(
         auth_svc.apply(
             app=app,
             users=base_world.get_config('users')
         )
     )
-    loop.run_until_complete(auth_svc.set_login_handlers(auth_svc.get_services()))
+    event_loop.run_until_complete(auth_svc.set_login_handlers(auth_svc.get_services()))
 
     # The authentication_required middleware needs to run after the session middleware.
     # AuthService.apply(...) adds session middleware to the app, so we can append the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,14 +74,15 @@ def init_base_world():
     BaseWorld.apply_config('payloads', BaseWorld.strip_yml(os.path.join(CONFIG_DIR, 'payloads.yml'))[0])
 
 
-@pytest.fixture(scope='class')
-def app_svc():
-    async def _init_app_svc():
-        return AppService(None)
+@pytest.fixture
+async def app_svc():
+    # async def _init_app_svc():
+    #     return AppService(None)
 
-    def _app_svc(loop):
-        return loop.run_until_complete(_init_app_svc())
-    return _app_svc
+    # def _app_svc(event_loop):
+    #     return event_loop.run_until_complete(_init_app_svc())
+    # return _app_svc
+    return AppService(None)
 
 
 @pytest.fixture(scope='class')
@@ -99,18 +100,20 @@ def file_svc():
     return FileSvc()
 
 
-@pytest.fixture(scope='class')
-def contact_svc():
-    return ContactService()
+@pytest.fixture
+async def contact_svc():
+    contact_svc = ContactService()
+    yield contact_svc
+    await contact_svc.deregister_contacts()
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture
 def event_svc(contact_svc, init_base_world):
     return EventService()
 
 
-@pytest.fixture(scope='class')
-def rest_svc():
+@pytest.fixture
+async def rest_svc():
     """
     The REST service requires the test's loop in order to be initialized in the same Thread
     as the test. This mitigates the issue where the service's calls to `asyncio.get_event_loop`
@@ -120,9 +123,10 @@ def rest_svc():
     async def _init_rest_svc():
         return RestService()
 
-    def _rest_svc(loop):
-        return loop.run_until_complete(_init_rest_svc())
+    def _rest_svc(event_loop):
+        return event_loop.run_until_complete(_init_rest_svc())
     return _rest_svc
+    # return RestService()
 
 
 @pytest.fixture(scope='class')
@@ -188,14 +192,14 @@ def operation():
 
 
 @pytest.fixture
-def demo_operation(loop, data_svc, operation, adversary):
-    tadversary = loop.run_until_complete(data_svc.store(adversary()))
+def demo_operation(event_loop, data_svc, operation, adversary):
+    tadversary = event_loop.run_until_complete(data_svc.store(adversary()))
     return operation(name='my first op', agents=[], adversary=tadversary)
 
 
 @pytest.fixture
-def obfuscator(loop, data_svc):
-    loop.run_until_complete(data_svc.store(
+def obfuscator(event_loop, data_svc):
+    event_loop.run_until_complete(data_svc.store(
         Obfuscator(name='plain-text',
                    description='Does no obfuscation to any command, instead running it in plain text',
                    module='plugins.stockpile.app.obfuscators.plain_text')
@@ -324,7 +328,7 @@ def agent_config():
 
 
 @pytest.fixture
-def api_v2_client(loop, aiohttp_client, contact_svc):
+async def api_v2_client(event_loop, aiohttp_client, contact_svc):
     def make_app(svcs):
         warnings.filterwarnings(
             "ignore",
@@ -368,8 +372,8 @@ def api_v2_client(loop, aiohttp_client, contact_svc):
         services = app_svc.get_services()
         os.chdir(str(Path(__file__).parents[1]))
 
-        await app_svc.register_contacts()
         _ = await RestApi(services).enable()
+        await app_svc.register_contacts()
         await auth_svc.apply(app_svc.application, auth_svc.get_config('users'))
         await auth_svc.set_login_handlers(services)
 
@@ -385,18 +389,20 @@ def api_v2_client(loop, aiohttp_client, contact_svc):
         app_svc.application.middlewares.append(apispec_request_validation_middleware)
         app_svc.application.middlewares.append(validation_middleware)
 
-        return app_svc.application
+        return app_svc
 
-    app = loop.run_until_complete(initialize())
-    return loop.run_until_complete(aiohttp_client(app))
+    app_svc = await initialize()
+    app = app_svc.application
+    yield await aiohttp_client(app)
+    await app_svc._destroy_plugins()
 
 
 @pytest.fixture
-def api_cookies(loop, api_v2_client):
+def api_cookies(event_loop, api_v2_client):
     async def get_cookie():
         r = await api_v2_client.post('/enter', allow_redirects=False, data=dict(username='admin', password='admin'))
         return r.cookies
-    return loop.run_until_complete(get_cookie())
+    return event_loop.run_until_complete(get_cookie())
 
 
 @pytest.fixture
@@ -421,7 +427,7 @@ def parse_datestring():
 
 
 @pytest.fixture
-def test_adversary(loop):
+def test_adversary(event_loop):
     expected_adversary = {'name': 'ad-hoc',
                           'description': 'an empty adversary profile',
                           'adversary_id': 'ad-hoc',
@@ -429,12 +435,12 @@ def test_adversary(loop):
                           'tags': [],
                           'has_repeatable_abilities': False}
     test_adversary = AdversarySchema().load(expected_adversary)
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_adversary))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_adversary))
     return test_adversary
 
 
 @pytest.fixture
-def test_planner(loop):
+def test_planner(event_loop):
     expected_planner = {'name': 'test planner',
                         'description': 'test planner',
                         'module': 'test',
@@ -444,26 +450,26 @@ def test_planner(loop):
                         'ignore_enforcement_modules': [],
                         'id': '123'}
     test_planner = PlannerSchema().load(expected_planner)
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_planner))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_planner))
     return test_planner
 
 
 @pytest.fixture
-def test_source(loop):
+def test_source(event_loop):
     test_fact = Fact(trait='remote.host.fqdn', value='dc')
     test_source = Source(id='123', name='test', facts=[test_fact], adjustments=[])
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_source))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_source))
     return test_source
 
 
 @pytest.fixture
-def test_source_existing_relationships(loop):
+def test_source_existing_relationships(event_loop):
     test_fact_1 = Fact(trait='test_1', value='1')
     test_fact_2 = Fact(trait='test_2', value='2')
     test_relationship = Relationship(source=test_fact_1, edge='test_edge', target=test_fact_2)
     test_source = Source(id='123', name='test', facts=[test_fact_1, test_fact_2], adjustments=[],
                          relationships=[test_relationship])
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_source))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_source))
     return test_source
 
 
@@ -486,9 +492,9 @@ def test_operation(test_adversary, test_planner, test_source):
 
 
 @pytest.fixture
-def test_agent(loop):
+def test_agent(event_loop):
     agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['sh'], platform='linux')
-    loop.run_until_complete(BaseService.get_service('data_svc').store(agent))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(agent))
     return agent
 
 
@@ -498,7 +504,7 @@ def test_executor(test_agent):
 
 
 @pytest.fixture
-def test_ability(test_executor, loop):
+def test_ability(test_executor, event_loop):
     ability = AbilitySchema().load(dict(ability_id='123',
                                         tactic='discovery',
                                         technique_id='auto-generated',
@@ -506,7 +512,7 @@ def test_ability(test_executor, loop):
                                         name='Manual Command',
                                         description='test ability',
                                         executors=[ExecutorSchema().dump(test_executor)]))
-    loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(ability))
     return ability
 
 
@@ -550,17 +556,16 @@ def finished_link(test_executor, test_agent, test_ability):
         'output': 'test_dir'
     }
 
-
 @pytest.fixture
-def setup_finished_operation(loop, test_operation):
+def setup_finished_operation(event_loop, test_operation):
     finished_operation = OperationSchema().load(test_operation)
     finished_operation.id = '000'
     finished_operation.state = 'finished'
-    loop.run_until_complete(BaseService.get_service('data_svc').store(finished_operation))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(finished_operation))
 
 
 @pytest.fixture
-def setup_operations_api_test(loop, api_v2_client, test_operation, test_agent, test_ability,
+def setup_operations_api_test(event_loop, api_v2_client, test_operation, test_agent, test_ability,
                               active_link, finished_link, expected_link_output):
     test_operation = OperationSchema().load(test_operation)
     test_operation.agents.append(test_agent)
@@ -574,4 +579,4 @@ def setup_operations_api_test(loop, api_v2_client, test_operation, test_agent, t
     test_operation.chain.append(finished_link)
     test_objective = Objective(id='123', name='test objective', description='test', goals=[])
     test_operation.objective = test_objective
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -556,6 +556,7 @@ def finished_link(test_executor, test_agent, test_ability):
         'output': 'test_dir'
     }
 
+
 @pytest.fixture
 def setup_finished_operation(event_loop, test_operation):
     finished_operation = OperationSchema().load(test_operation)

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -32,17 +32,17 @@ def dns_contact_base_world():
 
 
 @pytest.fixture
-def dns_c2(loop, app_svc, contact_svc, data_svc, file_svc, obfuscator):
-    services = app_svc(loop).get_services()
+async def dns_c2(app_svc, contact_svc, data_svc, file_svc, obfuscator):
+    services = app_svc.get_services()
     dns_c2 = DnsContact(services)
     return dns_c2
 
 
 @pytest.fixture
-def get_dns_response(loop, dns_c2):
-    def _get_dns_response(qname, record_type):
+async def get_dns_response(dns_c2):
+    async def _get_dns_response(qname, record_type):
         query_bytes = message.make_query(qname, record_type).to_wire()
-        response_bytes = loop.run_until_complete(dns_c2.handler.generate_dns_tunneling_response_bytes(query_bytes))
+        response_bytes = await dns_c2.handler.generate_dns_tunneling_response_bytes(query_bytes)
         return message.from_wire(response_bytes)
     return _get_dns_response
 
@@ -88,10 +88,10 @@ def get_beacon_profile_qnames(beacon_profile_hex_chunks):
 
 
 @pytest.fixture
-def get_instruction_response(random_data, get_dns_response):
-    def _get_instruction_response(message_id):
+async def get_instruction_response(random_data, get_dns_response):
+    async def _get_instruction_response(message_id):
         qname = '%s.id.0.1.%s.mycaldera.caldera' % (message_id, random_data)
-        return get_dns_response(qname, 'txt')
+        return await get_dns_response(qname, 'txt')
     return _get_instruction_response
 
 
@@ -157,21 +157,21 @@ class TestContactDns:
         assert handler.domain == 'mycaldera.caldera'
         assert handler.name == 'dns'
 
-    def test_non_c2_domain_message(self, get_dns_response):
-        response_msg = get_dns_response('notthec2domain', 'a')
+    async def test_non_c2_domain_message(self, get_dns_response):
+        response_msg = await get_dns_response('notthec2domain', 'a')
         assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
 
-    def test_partial_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
+    async def test_partial_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
         first_qname = get_beacon_profile_qnames(message_id)[0]
-        response_msg = get_dns_response(first_qname, 'a')
+        response_msg = await get_dns_response(first_qname, 'a')
         self._assert_successful_ivp4(response_msg)
         self._assert_even_ipv4(response_msg)
 
-    def test_completed_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
+    async def test_completed_beacon_message(self, get_dns_response, get_beacon_profile_qnames, message_id):
         qnames = get_beacon_profile_qnames(message_id)
         final_index = len(qnames) - 1
         for index, qname in enumerate(qnames):
-            response_msg = get_dns_response(qname, 'a')
+            response_msg = await get_dns_response(qname, 'a')
             self._assert_successful_ivp4(response_msg)
 
             # Check final octet
@@ -180,14 +180,14 @@ class TestContactDns:
             else:
                 self._assert_even_ipv4(response_msg)
 
-    def test_instruction_download(self, get_dns_response, get_beacon_profile_qnames, message_id,
+    async def test_instruction_download(self, get_dns_response, get_beacon_profile_qnames, message_id,
                                   get_instruction_response):
         # Send beacon before asking for instructions
         for qname in get_beacon_profile_qnames(message_id):
-            get_dns_response(qname, 'a')
+            await get_dns_response(qname, 'a')
 
         # Get instructions
-        response_msg = get_instruction_response(message_id)
+        response_msg = await get_instruction_response(message_id)
         assert response_msg and response_msg.rcode() == self._RCODE_SUCCESS
 
         # Make sure we only get 1 TXT record
@@ -208,17 +208,17 @@ class TestContactDns:
                     instructions='[]')
         assert want == beacon_resp
 
-    def test_unsupported_client_request(self, get_dns_response, message_id, random_data):
+    async def test_unsupported_client_request(self, get_dns_response, message_id, random_data):
         invalid_qname = '%s.invalid.0.1.%s.mycaldera.caldera' % (message_id, random_data)
-        response_msg = get_dns_response(invalid_qname, 'a')
+        response_msg = await get_dns_response(invalid_qname, 'a')
         assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
 
-    def test_invalid_instruction_request(self, get_dns_response, message_id, random_data):
+    async def test_invalid_instruction_request(self, get_dns_response, message_id, random_data):
         invalid_qname = '%s.id.0.1.%s.mycaldera.caldera' % (message_id, random_data)
-        response_msg = get_dns_response(invalid_qname, 'a')  # Should be TXT request
+        response_msg = await get_dns_response(invalid_qname, 'a')  # Should be TXT request
         assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
 
-    def test_file_upload(self, get_dns_response, message_id, get_hex_chunks, get_file_upload_metadata_qnames,
+    async def test_file_upload(self, get_dns_response, message_id, get_hex_chunks, get_file_upload_metadata_qnames,
                          get_file_upload_data_qnames):
         paw = 'asdasd'
         filename = 'testupload.txt'
@@ -236,7 +236,7 @@ class TestContactDns:
         # Send file upload request
         final_index = len(metadata_qnames) - 1
         for index, qname in enumerate(metadata_qnames):
-            response_msg = get_dns_response(qname, 'a')
+            response_msg = await get_dns_response(qname, 'a')
             self._assert_successful_ivp4(response_msg)
             # Check final octet
             if index == final_index:
@@ -247,7 +247,7 @@ class TestContactDns:
         # Send file data
         final_index = len(file_data_qnames) - 1
         for index, qname in enumerate(file_data_qnames):
-            response_msg = get_dns_response(qname, 'a')
+            response_msg = await get_dns_response(qname, 'a')
             self._assert_successful_ivp4(response_msg)
             # Check final octet
             if index == final_index:

--- a/tests/contacts/test_contact_dns.py
+++ b/tests/contacts/test_contact_dns.py
@@ -181,7 +181,7 @@ class TestContactDns:
                 self._assert_even_ipv4(response_msg)
 
     async def test_instruction_download(self, get_dns_response, get_beacon_profile_qnames, message_id,
-                                  get_instruction_response):
+                                        get_instruction_response):
         # Send beacon before asking for instructions
         for qname in get_beacon_profile_qnames(message_id):
             await get_dns_response(qname, 'a')
@@ -219,7 +219,7 @@ class TestContactDns:
         assert response_msg and response_msg.rcode() == self._RCODE_NXDOMAIN
 
     async def test_file_upload(self, get_dns_response, message_id, get_hex_chunks, get_file_upload_metadata_qnames,
-                         get_file_upload_data_qnames):
+                               get_file_upload_data_qnames):
         paw = 'asdasd'
         filename = 'testupload.txt'
         hostname = 'testhost'

--- a/tests/contacts/test_contact_ftp.py
+++ b/tests/contacts/test_contact_ftp.py
@@ -44,14 +44,14 @@ def base_world():
     BaseWorld.clear_config()
 
 
-@pytest.fixture()
-def ftp_c2(loop, app_svc, base_world, contact_svc, data_svc, file_svc, obfuscator):
-    services = app_svc(loop).get_services()
+@pytest.fixture
+async def ftp_c2(app_svc, base_world, contact_svc, data_svc, file_svc, obfuscator):
+    services = app_svc.get_services()
     ftp_c2 = contact_ftp.Contact(services)
     return ftp_c2
 
 
-@pytest.fixture()
+@pytest.fixture
 def ftp_c2_my_server(ftp_c2):
     ftp_c2.set_up_server()
     return ftp_c2.server

--- a/tests/contacts/test_contact_gist.py
+++ b/tests/contacts/test_contact_gist.py
@@ -4,13 +4,13 @@ from app.utility.base_world import BaseWorld
 
 class TestContactGist:
 
-    def test_retrieve_config(self, loop, app_svc):
+    async def test_retrieve_config(self, app_svc):
         BaseWorld.apply_config(name='main', config={'app.contact.gist': 'arandomkeythatisusedtoconnecttogithubapi',
                                                     'plugins': ['sandcat', 'stockpile'],
                                                     'crypt_salt': 'BLAH',
                                                     'api_key': 'ADMIN123',
                                                     'encryption_key': 'ADMIN123',
                                                     'exfil_dir': '/tmp'})
-        gist_c2 = Contact(app_svc(loop).get_services())
-        loop.run_until_complete(gist_c2.start())
+        gist_c2 = Contact(app_svc.get_services())
+        await gist_c2.start()
         assert gist_c2.retrieve_config() == 'arandomkeythatisusedtoconnecttogithubapi'

--- a/tests/contacts/test_contact_tcp.py
+++ b/tests/contacts/test_contact_tcp.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class TestTcpSessionHandler:
 
-    def test_refresh_with_socket_errors(self, loop):
+    def test_refresh_with_socket_errors(self, event_loop):
         handler = TcpSessionHandler(services=None, log=logger)
 
         session_with_socket_error = mock.Mock()
@@ -21,11 +21,11 @@ class TestTcpSessionHandler:
             mock.Mock()
         ]
 
-        loop.run_until_complete(handler.refresh())
+        event_loop.run_until_complete(handler.refresh())
         assert len(handler.sessions) == 1
         assert all(x is not session_with_socket_error for x in handler.sessions)
 
-    def test_refresh_without_socket_errors(self, loop):
+    def test_refresh_without_socket_errors(self, event_loop):
         handler = TcpSessionHandler(services=None, log=logger)
         handler.sessions = [
             mock.Mock(),
@@ -33,5 +33,5 @@ class TestTcpSessionHandler:
             mock.Mock()
         ]
 
-        loop.run_until_complete(handler.refresh())
+        event_loop.run_until_complete(handler.refresh())
         assert len(handler.sessions) == 3

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -29,8 +29,8 @@ def ssh_contact_base_world():
 
 
 @pytest.fixture
-def ssh_contact(loop, app_svc, contact_svc, data_svc, file_svc, obfuscator):
-    services = app_svc(loop).get_services()
+def ssh_contact(app_svc, contact_svc, data_svc, file_svc, obfuscator):
+    services = app_svc.get_services()
     return SshTunnel(services)
 
 
@@ -45,11 +45,11 @@ class TestContactSsh:
                 print(resp.status)
                 print(await resp.text())
 
-    def test_tunnel(self, loop, ssh_contact):
-        loop.run_until_complete(ssh_contact.start())
-        conn = loop.run_until_complete(asyncssh.connect('127.0.0.1', port=8122, known_hosts=None, username='sandcat',
-                                                        password='s4ndc4t!', config=None))
+    async def test_tunnel(self, ssh_contact):
+        await ssh_contact.start()
+        conn = await asyncssh.connect('127.0.0.1', port=8122, known_hosts=None, username='sandcat',
+                                                        password='s4ndc4t!', config=None)
         assert conn and conn.get_extra_info('username') == 'sandcat'
-        listener = loop.run_until_complete(conn.forward_local_port('', 61234, 'localhost', 8888))
+        listener = await conn.forward_local_port('', 61234, 'localhost', 8888)
         assert listener and listener.get_port() == 61234
         listener.close()

--- a/tests/contacts/test_ssh_tunneling.py
+++ b/tests/contacts/test_ssh_tunneling.py
@@ -48,7 +48,7 @@ class TestContactSsh:
     async def test_tunnel(self, ssh_contact):
         await ssh_contact.start()
         conn = await asyncssh.connect('127.0.0.1', port=8122, known_hosts=None, username='sandcat',
-                                                        password='s4ndc4t!', config=None)
+                                      password='s4ndc4t!', config=None)
         assert conn and conn.get_extra_info('username') == 'sandcat'
         listener = await conn.forward_local_port('', 61234, 'localhost', 8888)
         assert listener and listener.get_port() == 61234

--- a/tests/objects/test_ability.py
+++ b/tests/objects/test_ability.py
@@ -4,50 +4,50 @@ from app.objects.c_agent import Agent
 
 class TestAbility:
 
-    def test_privileged_to_run__1(self, loop, data_svc):
+    def test_privileged_to_run__1(self, event_loop, data_svc):
         """ Test ability.privilege == None """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', privilege=None)
         ))
         assert agent.privileged_to_run(ability)
 
-    def test_privileged_to_run__2(self, loop, data_svc):
+    def test_privileged_to_run__2(self, event_loop, data_svc):
         """ Test ability.privilege == 'User' """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', privilege='User')
         ))
         assert agent.privileged_to_run(ability)
 
-    def test_privileged_to_run__3(self, loop, data_svc):
+    def test_privileged_to_run__3(self, event_loop, data_svc):
         """ Test ability.privilege == 'Elevated' """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0)))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', privilege='Elevated')
         ))
         assert not agent.privileged_to_run(ability)
 
-    def test_privileged_to_run__4(self, loop, data_svc):
+    def test_privileged_to_run__4(self, event_loop, data_svc):
         """ Test ability.privilege == 'User' and agent.privilege == 'Elevated' """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', privilege='User')
         ))
         assert agent.privileged_to_run(ability)
 
-    def test_privileged_to_run__5(self, loop, data_svc):
+    def test_privileged_to_run__5(self, event_loop, data_svc):
         """ Test ability.privilege == 'Elevated' and agent.privilege == 'Elevated' """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', privilege='Elevated')
         ))
         assert agent.privileged_to_run(ability)
 
-    def test_privileged_to_run__6(self, loop, data_svc):
+    def test_privileged_to_run__6(self, event_loop, data_svc):
         """ Test ability.privilege == 'None' and agent.privilege == 'Elevated' """
-        agent = loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
-        ability = loop.run_until_complete(data_svc.store(
+        agent = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=1, sleep_max=2, watchdog=0, privilege='Elevated')))
+        ability = event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123')
         ))
         assert agent.privileged_to_run(ability)
@@ -111,8 +111,8 @@ class TestAbility:
 
         assert len(list(test_ability.executors)) == 0
 
-    def test_ability_name_duplication(self, loop, data_svc):
-        ability1 = loop.run_until_complete(data_svc.store(Ability(ability_id='12345', name='testA')))
-        ability2 = loop.run_until_complete(data_svc.store(Ability(ability_id='54321', name='testA')))
+    def test_ability_name_duplication(self, event_loop, data_svc):
+        ability1 = event_loop.run_until_complete(data_svc.store(Ability(ability_id='12345', name='testA')))
+        ability2 = event_loop.run_until_complete(data_svc.store(Ability(ability_id='54321', name='testA')))
         assert ability1.name != ability2.name
         assert ability2.name == 'testA (2)'

--- a/tests/objects/test_agent.py
+++ b/tests/objects/test_agent.py
@@ -8,57 +8,57 @@ from app.objects.secondclass.c_fact import Fact
 
 class TestAgent:
 
-    def test_task_no_facts(self, loop, data_svc, obfuscator, init_base_world):
+    def test_task_no_facts(self, event_loop, data_svc, obfuscator, init_base_world):
         executor = Executor(name='psh', platform='windows', command='whoami')
         ability = Ability(ability_id='123', executors=[executor])
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
-        loop.run_until_complete(agent.task([ability], obfuscator='plain-text'))
+        event_loop.run_until_complete(agent.task([ability], obfuscator='plain-text'))
         assert 1 == len(agent.links)
 
-    def test_task_missing_fact(self, loop, obfuscator, init_base_world):
+    def test_task_missing_fact(self, event_loop, obfuscator, init_base_world):
         executor = Executor(name='psh', platform='windows', command='net user #{domain.user.name} /domain')
         ability = Ability(ability_id='123', executors=[executor])
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
-        loop.run_until_complete(agent.task([ability], obfuscator='plain-text'))
+        event_loop.run_until_complete(agent.task([ability], obfuscator='plain-text'))
         assert 0 == len(agent.links)
 
-    def test_task_with_facts(self, loop, obfuscator, init_base_world, knowledge_svc):
+    def test_task_with_facts(self, event_loop, obfuscator, init_base_world, knowledge_svc):
         executor = Executor(name='psh', platform='windows', command='net user #{domain.user.name} /domain')
         ability = Ability(ability_id='123', executors=[executor])
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
         fact = Fact(trait='domain.user.name', value='bob')
 
-        loop.run_until_complete(agent.task([ability], 'plain-text', [fact]))
+        event_loop.run_until_complete(agent.task([ability], 'plain-text', [fact]))
         assert 1 == len(agent.links)
 
-    def test_builtin_fact_replacement(self, loop, obfuscator, init_base_world):
+    def test_builtin_fact_replacement(self, event_loop, obfuscator, init_base_world):
         executor = Executor(name='psh', platform='windows',
                             command='echo #{paw} #{server} #{group} #{location} #{exe_name} #{upstream_dest}')
         ability = Ability(ability_id='123', executors=[executor])
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows',
                       group='my_group', server='http://localhost:8888', location='testlocation', exe_name='testexe')
-        loop.run_until_complete(agent.task([ability], 'plain-text', []))
+        event_loop.run_until_complete(agent.task([ability], 'plain-text', []))
         assert 1 == len(agent.links)
         link = agent.links[0]
         decoded_command = b64decode(link.command).decode('utf-8')
         want = 'echo 123 http://localhost:8888 my_group testlocation testexe http://localhost:8888'
         assert want == decoded_command
 
-    def test_builtin_fact_replacement_with_upstream_dest(self, loop, obfuscator, init_base_world):
+    def test_builtin_fact_replacement_with_upstream_dest(self, event_loop, obfuscator, init_base_world):
         executor = Executor(name='psh', platform='windows',
                             command='echo #{paw} #{server} #{group} #{location} #{exe_name} #{upstream_dest}')
         ability = Ability(ability_id='123', executors=[executor])
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows',
                       group='my_group', server='http://10.10.10.10:8888', location='testlocation', exe_name='testexe',
                       upstream_dest='http://127.0.0.1:12345')
-        loop.run_until_complete(agent.task([ability], 'plain-text', []))
+        event_loop.run_until_complete(agent.task([ability], 'plain-text', []))
         assert 1 == len(agent.links)
         link = agent.links[0]
         decoded_command = b64decode(link.command).decode('utf-8')
         want = 'echo 123 http://10.10.10.10:8888 my_group testlocation testexe http://127.0.0.1:12345'
         assert want == decoded_command
 
-    def test_preferred_executor_psh(self, loop, ability, executor):
+    def test_preferred_executor_psh(self, event_loop, ability, executor):
         executor_test = executor(name='test', platform='windows')
         executor_cmd = executor(name='cmd', platform='windows')
         executor_psh = executor(name='psh', platform='windows')
@@ -66,10 +66,10 @@ class TestAgent:
 
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['psh', 'cmd'], platform='windows')
 
-        preferred_executor = loop.run_until_complete(agent.get_preferred_executor(test_ability))
+        preferred_executor = event_loop.run_until_complete(agent.get_preferred_executor(test_ability))
         assert preferred_executor is executor_psh  # 'psh' preferred if available
 
-    def test_preferred_executor_from_agent_executor(self, loop, ability, executor):
+    def test_preferred_executor_from_agent_executor(self, event_loop, ability, executor):
         executor_test = executor(name='test', platform='windows')
         executor_cmd = executor(name='cmd', platform='windows')
         executor_psh = executor(name='psh', platform='windows')
@@ -77,7 +77,7 @@ class TestAgent:
 
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['cmd', 'test'], platform='windows')
 
-        preferred_executor = loop.run_until_complete(agent.get_preferred_executor(test_ability))
+        preferred_executor = event_loop.run_until_complete(agent.get_preferred_executor(test_ability))
         assert preferred_executor is executor_cmd  # prefer agent's first executor, not ability's
 
     def test_set_pending_executor_path_update(self):
@@ -120,11 +120,11 @@ class TestAgent:
         agent.set_pending_executor_path_update('idontexist', 'fakepath')
         assert agent.executor_change_to_assign is None
 
-    def test_heartbeat_modification_during_pending_executor_removal(self, loop):
+    def test_heartbeat_modification_during_pending_executor_removal(self, event_loop):
         original_executors = ['cmd', 'test']
         agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=original_executors, platform='windows')
         agent.set_pending_executor_removal('test')
-        loop.run_until_complete(agent.heartbeat_modification(executors=original_executors))
+        event_loop.run_until_complete(agent.heartbeat_modification(executors=original_executors))
         assert agent.executors == ['cmd']
 
     def test_store_new_agent(self, data_svc):

--- a/tests/objects/test_data_encoder.py
+++ b/tests/objects/test_data_encoder.py
@@ -17,21 +17,21 @@ def base64_encoder():
 
 
 @pytest.fixture
-def setup_data_encoders(loop, data_svc):
-    loop.run_until_complete(data_svc._load_data_encoders([]))
+def setup_data_encoders(event_loop, data_svc):
+    event_loop.run_until_complete(data_svc._load_data_encoders([]))
 
 
 @pytest.mark.usefixtures(
     'setup_data_encoders'
 )
 class TestDataEncoders:
-    def test_retrieval(self, loop, data_svc):
-        results = loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='plain-text')))
+    def test_retrieval(self, event_loop, data_svc):
+        results = event_loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='plain-text')))
         assert len(results) == 1
         plaintext_encoder = results[0]
         assert plaintext_encoder and isinstance(plaintext_encoder, PlainTextEncoder)
 
-        results = loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='base64')))
+        results = event_loop.run_until_complete(data_svc.locate('data_encoders', match=dict(name='base64')))
         assert len(results) == 1
         base64_encoder = results[0]
         assert base64_encoder and isinstance(base64_encoder, Base64Encoder)

--- a/tests/objects/test_link.py
+++ b/tests/objects/test_link.py
@@ -13,7 +13,7 @@ from app.utility.base_service import BaseService
 
 
 @pytest.fixture
-def fake_event_svc(loop):
+def fake_event_svc(event_loop):
     class FakeEventService(BaseService, EventServiceInterface):
         def __init__(self):
             self.fired = {}
@@ -75,13 +75,13 @@ class TestLink:
         link.status = -5
         mock_emit_status_change_method.assert_called_with(from_status=-3, to_status=-5)
 
-    def test_emit_status_change_event(self, loop, fake_event_svc, ability, executor):
+    def test_emit_status_change_event(self, event_loop, fake_event_svc, ability, executor):
         executor = executor('psh', 'windows')
         ability = ability(executor=executor)
         link = Link(command='net user a', paw='123456', ability=ability, executor=executor, status=-3)
         fake_event_svc.reset()
 
-        loop.run_until_complete(
+        event_loop.run_until_complete(
             link._emit_status_change_event(
                 from_status=-3,
                 to_status=-5
@@ -120,7 +120,7 @@ class TestLink:
         assert serialized_link['agent_reported_time'] == agent_reported_time
         assert loaded_link.agent_reported_time == BaseService.get_timestamp_from_string(agent_reported_time)
 
-    def test_link_knowledge_svc_synchronization(self, loop, executor, ability, knowledge_svc):
+    def test_link_knowledge_svc_synchronization(self, event_loop, executor, ability, knowledge_svc):
         test_executor = executor(name='psh', platform='windows')
         test_ability = ability(ability_id='123', executors=[test_executor])
         fact = Fact(trait='remote.host.fqdn', value='dc')
@@ -129,17 +129,17 @@ class TestLink:
         test_link = Link(command='echo "this was a triumph"',
                          paw='123456', ability=test_ability, id=111111, executor=test_executor)
 
-        loop.run_until_complete(test_link.create_relationships([relationship], None))
+        event_loop.run_until_complete(test_link.create_relationships([relationship], None))
         checkable = [(x.trait, x.value) for x in test_link.facts]
         assert (fact.trait, fact.value) in checkable
         assert (fact2.trait, fact2.value) in checkable
-        knowledge_base_f = loop.run_until_complete(knowledge_svc.get_facts(dict(source=test_link.id)))
+        knowledge_base_f = event_loop.run_until_complete(knowledge_svc.get_facts(dict(source=test_link.id)))
         assert len(knowledge_base_f) == 2
         assert test_link.id in knowledge_base_f[0].links
-        knowledge_base_r = loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='has_admin')))
+        knowledge_base_r = event_loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='has_admin')))
         assert len(knowledge_base_r) == 1
 
-    def test_create_relationship_source_fact(self, loop, ability, executor, operation, knowledge_svc):
+    def test_create_relationship_source_fact(self, event_loop, ability, executor, operation, knowledge_svc):
         test_executor = executor(name='psh', platform='windows')
         test_ability = ability(ability_id='123', executors=[test_executor])
         fact1 = Fact(trait='remote.host.fqdn', value='dc')
@@ -150,19 +150,19 @@ class TestLink:
                               adversary=Adversary(name='sample', adversary_id='XYZ', atomic_ordering=[],
                                                   description='test'),
                               source=Source(id='test-source', facts=[fact1]))
-        loop.run_until_complete(operation._init_source())
-        loop.run_until_complete(link1.create_relationships([relationship], operation))
+        event_loop.run_until_complete(operation._init_source())
+        event_loop.run_until_complete(link1.create_relationships([relationship], operation))
 
         link2 = Link(command='echo "Bob"', paw='789100', ability=test_ability, id='222222', executor=test_executor)
-        loop.run_until_complete(link2.create_relationships([relationship], operation))
+        event_loop.run_until_complete(link2.create_relationships([relationship], operation))
 
-        fact_store_operation_source = loop.run_until_complete(knowledge_svc.get_facts(dict(source=operation.source.id)))
-        fact_store_operation = loop.run_until_complete(knowledge_svc.get_facts(dict(source=operation.id)))
+        fact_store_operation_source = event_loop.run_until_complete(knowledge_svc.get_facts(dict(source=operation.source.id)))
+        fact_store_operation = event_loop.run_until_complete(knowledge_svc.get_facts(dict(source=operation.id)))
         assert len(fact_store_operation_source) == 1
         assert len(fact_store_operation) == 1
         assert len(fact_store_operation_source[0].collected_by) == 2
 
-    def test_save_discover_seeded_fact_not_in_command(self, loop, ability, executor, operation, knowledge_svc):
+    def test_save_discover_seeded_fact_not_in_command(self, event_loop, ability, executor, operation, knowledge_svc):
         test_executor = executor(name='psh', platform='windows')
         test_ability = ability(ability_id='123', executors=[test_executor])
         fact1 = Fact(trait='remote.host.fqdn', value='dc')
@@ -173,8 +173,8 @@ class TestLink:
                               adversary=Adversary(name='sample', adversary_id='XYZ', atomic_ordering=[],
                                                   description='test'),
                               source=Source(id='test-source', facts=[fact1, fact2]))
-        loop.run_until_complete(operation._init_source())
-        loop.run_until_complete(link.save_fact(operation, fact2, 1, relationship))
+        event_loop.run_until_complete(operation._init_source())
+        event_loop.run_until_complete(link.save_fact(operation, fact2, 1, relationship))
 
         assert fact2.origin_type == OriginType.SEEDED
         assert '123456' in fact2.collected_by

--- a/tests/services/test_contact_svc.py
+++ b/tests/services/test_contact_svc.py
@@ -17,19 +17,19 @@ class TestProcessor:
 
 
 @pytest.fixture
-def setup_contact_service(loop, data_svc, agent, ability, operation, link, adversary):
+def setup_contact_service(event_loop, data_svc, agent, ability, operation, link, adversary):
     texecutor = Executor(name='special_executor', platform='darwin', command='whoami', payloads=['wifi.sh'])
     tability = ability(tactic='discovery', technique_id='T1033', technique_name='Find', name='test',
                        description='find active user', privilege=None, executors=[texecutor])
     tability.HOOKS['special_executor'] = TestProcessor()
-    loop.run_until_complete(data_svc.store(tability))
+    event_loop.run_until_complete(data_svc.store(tability))
     tagent = agent(sleep_min=10, sleep_max=60, watchdog=0, executors=['special_executor'])
-    loop.run_until_complete(data_svc.store(tagent))
+    event_loop.run_until_complete(data_svc.store(tagent))
     toperation = operation(name='sample', agents=[tagent], adversary=adversary())
     tlink = link(command='', paw=tagent.paw, ability=tability, id='5212fca4-6544-49ce-a78d-a95d30e95705',
                  executor=texecutor)
-    loop.run_until_complete(toperation.apply(tlink))
-    loop.run_until_complete(data_svc.store(toperation))
+    event_loop.run_until_complete(toperation.apply(tlink))
+    event_loop.run_until_complete(data_svc.store(toperation))
     yield tlink
 
 

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -10,66 +10,66 @@ from app.objects.secondclass.c_executor import Executor
 
 class TestDataService:
 
-    def test_no_duplicate_adversary(self, loop, data_svc):
-        loop.run_until_complete(data_svc.store(
+    def test_no_duplicate_adversary(self, event_loop, data_svc):
+        event_loop.run_until_complete(data_svc.store(
             Adversary(adversary_id='123', name='test', description='test adversary', atomic_ordering=list())
         ))
-        loop.run_until_complete(data_svc.store(
+        event_loop.run_until_complete(data_svc.store(
             Adversary(adversary_id='123', name='test', description='test adversary', atomic_ordering=list())
         ))
-        adversaries = loop.run_until_complete(data_svc.locate('adversaries'))
+        adversaries = event_loop.run_until_complete(data_svc.locate('adversaries'))
 
         assert len(adversaries) == 1
         for x in adversaries:
             json.dumps(x.display)
 
-    def test_no_duplicate_planner(self, loop, data_svc):
-        loop.run_until_complete(data_svc.store(Planner(name='test', planner_id='some_id', module='some.path.here', params=None, description='description')))
-        loop.run_until_complete(data_svc.store(Planner(name='test', planner_id='some_id', module='some.path.here', params=None, description='description')))
-        planners = loop.run_until_complete(data_svc.locate('planners'))
+    def test_no_duplicate_planner(self, event_loop, data_svc):
+        event_loop.run_until_complete(data_svc.store(Planner(name='test', planner_id='some_id', module='some.path.here', params=None, description='description')))
+        event_loop.run_until_complete(data_svc.store(Planner(name='test', planner_id='some_id', module='some.path.here', params=None, description='description')))
+        planners = event_loop.run_until_complete(data_svc.locate('planners'))
 
         assert len(planners) == 1
         for x in planners:
             json.dumps(x.display)
 
-    def test_multiple_agents(self, loop, data_svc):
-        loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
-        loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
-        agents = loop.run_until_complete(data_svc.locate('agents'))
+    def test_multiple_agents(self, event_loop, data_svc):
+        event_loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
+        event_loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
+        agents = event_loop.run_until_complete(data_svc.locate('agents'))
 
         assert len(agents) == 2
         for x in agents:
             json.dumps(x.display)
 
-    def test_no_duplicate_ability(self, loop, data_svc):
+    def test_no_duplicate_ability(self, event_loop, data_svc):
         executor = Executor(name='special_executor', platform='darwin', command='whoami', payloads=['wifi.sh'])
-        loop.run_until_complete(data_svc.store(
+        event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', tactic='discovery', technique_id='1', technique_name='T1033', name='test',
                     description='find active user', privilege=None, executors=[executor])
         ))
-        loop.run_until_complete(data_svc.store(
+        event_loop.run_until_complete(data_svc.store(
             Ability(ability_id='123', tactic='discovery', technique_id='1', technique_name='T1033', name='test',
                     description='find active user', privilege=None, executors=[executor])
         ))
-        abilities = loop.run_until_complete(data_svc.locate('abilities'))
+        abilities = event_loop.run_until_complete(data_svc.locate('abilities'))
 
         assert len(abilities) == 1
 
-    def test_operation(self, loop, data_svc):
-        adversary = loop.run_until_complete(data_svc.store(
+    def test_operation(self, event_loop, data_svc):
+        adversary = event_loop.run_until_complete(data_svc.store(
             Adversary(adversary_id='123', name='test', description='test adversary', atomic_ordering=list())
         ))
-        loop.run_until_complete(data_svc.store(Operation(name='my first op', agents=[], adversary=adversary)))
+        event_loop.run_until_complete(data_svc.store(Operation(name='my first op', agents=[], adversary=adversary)))
 
-        operations = loop.run_until_complete(data_svc.locate('operations'))
+        operations = event_loop.run_until_complete(data_svc.locate('operations'))
         assert len(operations) == 1
         for x in operations:
             json.dumps(x.display)
 
-    def test_remove(self, loop, data_svc):
-        a1 = loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
-        agents = loop.run_until_complete(data_svc.locate('agents', match=dict(paw=a1.paw)))
+    def test_remove(self, event_loop, data_svc):
+        a1 = event_loop.run_until_complete(data_svc.store(Agent(sleep_min=2, sleep_max=8, watchdog=0)))
+        agents = event_loop.run_until_complete(data_svc.locate('agents', match=dict(paw=a1.paw)))
         assert len(agents) == 1
-        loop.run_until_complete(data_svc.remove('agents', match=dict(paw=a1.paw)))
-        agents = loop.run_until_complete(data_svc.locate('agents', match=dict(paw=a1.paw)))
+        event_loop.run_until_complete(data_svc.remove('agents', match=dict(paw=a1.paw)))
+        agents = event_loop.run_until_complete(data_svc.locate('agents', match=dict(paw=a1.paw)))
         assert len(agents) == 0

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -234,7 +234,7 @@ class TestFileService:
         upload_dir = event_loop.run_until_complete(file_svc.create_exfil_sub_directory('testencodeduploaddir'))
         upload_filename = 'testencodedupload.txt'
         event_loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir, encrypt=False,
-                                                   encoding=encoding))
+                                      encoding=encoding))
         uploaded_file_path = os.path.join(upload_dir, upload_filename)
         assert os.path.isfile(uploaded_file_path)
         with open(uploaded_file_path, 'rb') as file:

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -12,9 +12,9 @@ from app.utility.file_decryptor import decrypt
 
 
 @pytest.fixture
-def store_encoders(loop, data_svc):
-    loop.run_until_complete(data_svc.store(PlainTextEncoder()))
-    loop.run_until_complete(data_svc.store(Base64Encoder()))
+def store_encoders(event_loop, data_svc):
+    event_loop.run_until_complete(data_svc.store(PlainTextEncoder()))
+    event_loop.run_until_complete(data_svc.store(Base64Encoder()))
 
 
 @pytest.mark.usefixtures(
@@ -31,20 +31,20 @@ class TestFileService:
         assert f.read() == txt_str
         yield f
 
-    def test_save_file(self, loop, file_svc, tmp_path):
+    def test_save_file(self, event_loop, file_svc, tmp_path):
         filename = "test_file.txt"
         payload = b'These are the file contents.'
         # Save temporary test file
-        loop.run_until_complete(file_svc.save_file(filename, payload, tmp_path, encrypt=False))
+        event_loop.run_until_complete(file_svc.save_file(filename, payload, tmp_path, encrypt=False))
         file_location = tmp_path / filename
         # Read file contents from saved file
         assert os.path.isfile(file_location)
         with open(file_location, "r") as file_contents:
             assert payload.decode("utf-8") == file_contents.read()
 
-    def test_create_exfil_sub_directory(self, loop, file_svc):
+    def test_create_exfil_sub_directory(self, event_loop, file_svc):
         exfil_dir_name = 'unit-testing-Rocks'
-        new_dir = loop.run_until_complete(file_svc.create_exfil_sub_directory(exfil_dir_name))
+        new_dir = event_loop.run_until_complete(file_svc.create_exfil_sub_directory(exfil_dir_name))
         assert os.path.isdir(new_dir)
         os.rmdir(new_dir)
 
@@ -58,29 +58,29 @@ class TestFileService:
         output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
         assert output_data == output
 
-    def test_upload_decode_plaintext(self, loop, file_svc, data_svc):
+    def test_upload_decode_plaintext(self, event_loop, file_svc, data_svc):
         content = b'this will be encoded and decoded as plaintext'
-        self._test_upload_file_with_encoding(loop, file_svc, data_svc, encoding='plain-text', upload_content=content,
+        self._test_upload_file_with_encoding(event_loop, file_svc, data_svc, encoding='plain-text', upload_content=content,
                                              decoded_content=content)
 
-    def test_upload_decode_b64(self, loop, file_svc, data_svc):
+    def test_upload_decode_b64(self, event_loop, file_svc, data_svc):
         original_content = b'this will be encoded and decoded as base64'
         upload_content = b64encode(original_content)
-        self._test_upload_file_with_encoding(loop, file_svc, data_svc, encoding='base64', upload_content=upload_content,
+        self._test_upload_file_with_encoding(event_loop, file_svc, data_svc, encoding='base64', upload_content=upload_content,
                                              decoded_content=original_content)
 
-    def test_download_plaintext_file(self, loop, file_svc, data_svc):
+    def test_download_plaintext_file(self, event_loop, file_svc, data_svc):
         payload_content = b'plaintext content'
-        self._test_download_file_with_encoding(loop, file_svc, data_svc, encoding='plain-text',
+        self._test_download_file_with_encoding(event_loop, file_svc, data_svc, encoding='plain-text',
                                                original_content=payload_content, encoded_content=payload_content)
 
-    def test_download_base64_file(self, loop, file_svc, data_svc):
+    def test_download_base64_file(self, event_loop, file_svc, data_svc):
         payload_content = b'b64 content'
-        self._test_download_file_with_encoding(loop, file_svc, data_svc, encoding='base64',
+        self._test_download_file_with_encoding(event_loop, file_svc, data_svc, encoding='base64',
                                                original_content=payload_content,
                                                encoded_content=b64encode(payload_content))
 
-    def test_pack_file(self, loop, mocker, tmpdir, file_svc, data_svc):
+    def test_pack_file(self, event_loop, mocker, tmpdir, file_svc, data_svc):
         payload = 'unittestpayload'
         payload_content = b'content'
         new_payload_content = b'new_content'
@@ -101,13 +101,13 @@ class TestFileService:
         file_svc.data_svc = data_svc
         file_svc.read_file = AsyncMock(return_value=(payload, payload_content))
 
-        file_path, content, display_name = loop.run_until_complete(file_svc.get_file(headers=dict(file='%s:%s' % (packer_name, payload))))
+        file_path, content, display_name = event_loop.run_until_complete(file_svc.get_file(headers=dict(file='%s:%s' % (packer_name, payload))))
 
         packer.pack.assert_called_once()
         assert payload == file_path
         assert content == new_payload_content
 
-    def test_xored_filename_removal(self, loop, mocker, tmpdir, file_svc, data_svc):
+    def test_xored_filename_removal(self, event_loop, mocker, tmpdir, file_svc, data_svc):
         payload = 'unittestpayload.exe.xored'
         payload_content = b'content'
         new_payload_content = b'new_content'
@@ -129,18 +129,18 @@ class TestFileService:
         file_svc.data_svc = data_svc
         file_svc.read_file = AsyncMock(return_value=(payload, payload_content))
 
-        file_path, content, display_name = loop.run_until_complete(file_svc.get_file(headers=dict(file='%s:%s' % (packer_name, payload))))
+        file_path, content, display_name = event_loop.run_until_complete(file_svc.get_file(headers=dict(file='%s:%s' % (packer_name, payload))))
 
         packer.pack.assert_called_once()
         assert payload == file_path
         assert content == new_payload_content
         assert display_name == expected_display_name
 
-    def test_upload_file(self, loop, file_svc):
-        upload_dir = loop.run_until_complete(file_svc.create_exfil_sub_directory('test-upload'))
+    def test_upload_file(self, event_loop, file_svc):
+        upload_dir = event_loop.run_until_complete(file_svc.create_exfil_sub_directory('test-upload'))
         upload_filename = 'uploadedfile.txt'
         upload_content = b'this is a test upload file'
-        loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir, encrypt=False))
+        event_loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir, encrypt=False))
         uploaded_file_path = os.path.join(upload_dir, upload_filename)
         assert os.path.isfile(uploaded_file_path)
         with open(uploaded_file_path, 'rb') as file:
@@ -149,11 +149,11 @@ class TestFileService:
         os.remove(uploaded_file_path)
         os.rmdir(upload_dir)
 
-    def test_encrypt_upload(self, loop, file_svc):
-        upload_dir = loop.run_until_complete(file_svc.create_exfil_sub_directory('test-encrypted-upload'))
+    def test_encrypt_upload(self, event_loop, file_svc):
+        upload_dir = event_loop.run_until_complete(file_svc.create_exfil_sub_directory('test-encrypted-upload'))
         upload_filename = 'encryptedupload.txt'
         upload_content = b'this is a test upload file'
-        loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir))
+        event_loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir))
         uploaded_file_path = os.path.join(upload_dir, upload_filename)
         decrypted_file_path = upload_filename + '_decrypted'
         config_to_use = 'conf/default.yml'
@@ -168,18 +168,18 @@ class TestFileService:
         os.remove(decrypted_file_path)
         os.rmdir(upload_dir)
 
-    def test_walk_file_path_exists_nonxor(self, loop, text_file, file_svc):
-        ret = loop.run_until_complete(file_svc.walk_file_path(text_file.dirname, text_file.basename))
+    def test_walk_file_path_exists_nonxor(self, event_loop, text_file, file_svc):
+        ret = event_loop.run_until_complete(file_svc.walk_file_path(text_file.dirname, text_file.basename))
         assert ret == text_file
 
-    def test_walk_file_path_notexists(self, loop, text_file, file_svc):
-        ret = loop.run_until_complete(file_svc.walk_file_path(text_file.dirname, 'not-a-real.file'))
+    def test_walk_file_path_notexists(self, event_loop, text_file, file_svc):
+        ret = event_loop.run_until_complete(file_svc.walk_file_path(text_file.dirname, 'not-a-real.file'))
         assert ret is None
 
-    def test_walk_file_path_xor_fn(self, loop, tmpdir, file_svc):
+    def test_walk_file_path_xor_fn(self, event_loop, tmpdir, file_svc):
         f = tmpdir.mkdir('txt').join('xorfile.txt.xored')
         f.write("test")
-        ret = loop.run_until_complete(file_svc.walk_file_path(f.dirname, 'xorfile.txt'))
+        ret = event_loop.run_until_complete(file_svc.walk_file_path(f.dirname, 'xorfile.txt'))
         assert ret == f
 
     def test_remove_xored_extension(self, file_svc):
@@ -217,11 +217,11 @@ class TestFileService:
         assert ret is False
 
     @staticmethod
-    def _test_download_file_with_encoding(loop, file_svc, data_svc, encoding, original_content, encoded_content):
+    def _test_download_file_with_encoding(event_loop, file_svc, data_svc, encoding, original_content, encoded_content):
         filename = 'testencodedpayload.txt'
         file_svc.read_file = AsyncMock(return_value=(filename, original_content))
         file_svc.data_svc = data_svc
-        file_path, content, display_name = loop.run_until_complete(
+        file_path, content, display_name = event_loop.run_until_complete(
             file_svc.get_file(headers={'file': filename, 'x-file-encoding': encoding})
         )
         assert file_path == filename
@@ -229,11 +229,11 @@ class TestFileService:
         assert display_name == filename
 
     @staticmethod
-    def _test_upload_file_with_encoding(loop, file_svc, data_svc, encoding, upload_content, decoded_content):
+    def _test_upload_file_with_encoding(event_loop, file_svc, data_svc, encoding, upload_content, decoded_content):
         file_svc.data_svc = data_svc
-        upload_dir = loop.run_until_complete(file_svc.create_exfil_sub_directory('testencodeduploaddir'))
+        upload_dir = event_loop.run_until_complete(file_svc.create_exfil_sub_directory('testencodeduploaddir'))
         upload_filename = 'testencodedupload.txt'
-        loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir, encrypt=False,
+        event_loop.run_until_complete(file_svc.save_file(upload_filename, upload_content, upload_dir, encrypt=False,
                                                    encoding=encoding))
         uploaded_file_path = os.path.join(upload_dir, upload_filename)
         assert os.path.isfile(uploaded_file_path)

--- a/tests/services/test_knowledge_svc.py
+++ b/tests/services/test_knowledge_svc.py
@@ -8,9 +8,9 @@ class TestKnowledgeService:
 
     async def test_no_duplicate_fact(self, knowledge_svc):
         await knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234'))
+                                     collected_by=['thin_air'], technique_id='T1234'))
         await knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234'))
+                                     collected_by=['thin_air'], technique_id='T1234'))
         facts = await knowledge_svc.get_facts(dict(trait='test'))
         assert len(facts) == 1
 
@@ -29,10 +29,10 @@ class TestKnowledgeService:
 
     async def test_remove_fact(self, knowledge_svc):
         await knowledge_svc.add_fact(Fact(trait='rtest', value='rdemo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234'),
-                                                       constraints=dict(test_field='test_value'))
+                                     collected_by=['thin_air'], technique_id='T1234'),
+                                     constraints=dict(test_field='test_value'))
         await knowledge_svc.add_fact(Fact(trait='ktest', value='rdemo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234'))
+                                          collected_by=['thin_air'], technique_id='T1234'))
         await knowledge_svc.delete_fact(dict(trait='rtest'))
         facts = await knowledge_svc.get_facts(dict(value='rdemo'))
         assert len(facts) == 1
@@ -40,7 +40,7 @@ class TestKnowledgeService:
 
     async def test_remove_rules(self, knowledge_svc):
         await knowledge_svc.add_rule(Rule(action='rBLOCK', trait='ra.c', match='.*'),
-                                                       constraints=dict(test_field='test_value'))
+                                     constraints=dict(test_field='test_value'))
         await knowledge_svc.delete_rule(dict(trait='ra.c'))
         rules = await knowledge_svc.get_rules(dict(trait='ra.c'))
         assert len(rules) == 0
@@ -49,7 +49,7 @@ class TestKnowledgeService:
     async def test_remove_relationship(self, knowledge_svc):
         dummy = Fact(trait='rtest', value='rdemo', score=1, collected_by=['thin_air'], technique_id='T1234')
         await knowledge_svc.add_relationship(Relationship(source=dummy, edge='rpotato', target=dummy),
-                                                               constraints=dict(test_field='test_value'))
+                                             constraints=dict(test_field='test_value'))
         await knowledge_svc.delete_relationship(dict(edge='rpotato'))
         relationships = await knowledge_svc.get_relationships(dict(edge='rpotato'))
         assert len(relationships) == 0
@@ -57,9 +57,9 @@ class TestKnowledgeService:
 
     async def test_update_fact(self, knowledge_svc):
         await knowledge_svc.add_fact(Fact(trait='utest', value='udemo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234'))
+                                     collected_by=['thin_air'], technique_id='T1234'))
         await knowledge_svc.update_fact(criteria=dict(trait='utest'),
-                                                          updates=dict(trait='utest2', value='udemo2'))
+                                        updates=dict(trait='utest2', value='udemo2'))
         facts = await knowledge_svc.get_facts(dict(trait='utest2'))
         assert len(facts) == 1
         assert facts[0].value == 'udemo2'
@@ -69,16 +69,16 @@ class TestKnowledgeService:
         dummy2 = Fact(trait='utest2', value='udemo2', score=1, collected_by=['thin_air'], technique_id='T4321')
         await knowledge_svc.add_relationship(Relationship(source=dummy, edge='upotato', target=dummy))
         await knowledge_svc.update_relationship(criteria=dict(edge='upotato'),
-                                                                  updates=dict(source=dummy2, edge='ubacon'))
+                                                updates=dict(source=dummy2, edge='ubacon'))
         relationships = await knowledge_svc.get_relationships(dict(edge='ubacon'))
         assert len(relationships) == 1
         assert relationships[0].source == dummy2
 
     async def test_retrieve_fact(self, knowledge_svc):
         await knowledge_svc.add_fact(Fact(trait='ttestA', value='tdemoB', score=24,
-                                                            collected_by=['thin_airA'], technique_id='T1234'))
+                                     collected_by=['thin_airA'], technique_id='T1234'))
         await knowledge_svc.add_fact(Fact(trait='ttestB', value='tdemoA', score=42,
-                                                            collected_by=['thin_airB'], technique_id='T4321'))
+                                          collected_by=['thin_airB'], technique_id='T4321'))
         facts = await knowledge_svc.get_facts(dict(trait='ttestB'))
         assert len(facts) == 1
         readable = facts[0].display
@@ -88,10 +88,8 @@ class TestKnowledgeService:
     async def test_retrieve_relationship(self, knowledge_svc):
         dummy = Fact(trait='ttest', value='tdemo', score=1, collected_by=['thin_air'], technique_id='T1234')
         dummy2 = Fact(trait='ttest2', value='tdemo2', score=1, collected_by=['thin_air'], technique_id='T1234')
-        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='tpotato',
-                                                                            target=dummy2))
-        await knowledge_svc.add_relationship(Relationship(source=dummy2, edge='tpotato',
-                                                                            target=dummy))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='tpotato', target=dummy2))
+        await knowledge_svc.add_relationship(Relationship(source=dummy2, edge='tpotato', target=dummy))
         relationships = await knowledge_svc.get_relationships(dict(edge='tpotato'))
         assert len(relationships) == 2
         specific = await knowledge_svc.get_relationships(dict(source=dummy))

--- a/tests/services/test_knowledge_svc.py
+++ b/tests/services/test_knowledge_svc.py
@@ -6,115 +6,115 @@ from app.objects.secondclass.c_link import Link
 
 class TestKnowledgeService:
 
-    def test_no_duplicate_fact(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234')))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234')))
-        facts = loop.run_until_complete(knowledge_svc.get_facts(dict(trait='test')))
+    async def test_no_duplicate_fact(self, knowledge_svc):
+        await knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
+                                                            collected_by=['thin_air'], technique_id='T1234'))
+        await knowledge_svc.add_fact(Fact(trait='test', value='demo', score=1,
+                                                            collected_by=['thin_air'], technique_id='T1234'))
+        facts = await knowledge_svc.get_facts(dict(trait='test'))
         assert len(facts) == 1
 
-    def test_no_duplicate_rules(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_rule(Rule(action='BLOCK', trait='a.c', match='.*')))
-        loop.run_until_complete(knowledge_svc.add_rule(Rule(action='BLOCK', trait='a.c', match='.*')))
-        rules = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='a.c')))
+    async def test_no_duplicate_rules(self, knowledge_svc):
+        await knowledge_svc.add_rule(Rule(action='BLOCK', trait='a.c', match='.*'))
+        await knowledge_svc.add_rule(Rule(action='BLOCK', trait='a.c', match='.*'))
+        rules = await knowledge_svc.get_rules(dict(trait='a.c'))
         assert len(rules) == 1
 
-    def test_no_duplicate_relationship(self, loop, knowledge_svc):
+    async def test_no_duplicate_relationship(self, knowledge_svc):
         dummy = Fact(trait='test', value='demo', score=1, collected_by=['thin_air'], technique_id='T1234')
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy, edge='potato', target=dummy)))
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy, edge='potato', target=dummy)))
-        relationships = loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='potato')))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='potato', target=dummy))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='potato', target=dummy))
+        relationships = await knowledge_svc.get_relationships(dict(edge='potato'))
         assert len(relationships) == 1
 
-    def test_remove_fact(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='rtest', value='rdemo', score=1,
+    async def test_remove_fact(self, knowledge_svc):
+        await knowledge_svc.add_fact(Fact(trait='rtest', value='rdemo', score=1,
                                                             collected_by=['thin_air'], technique_id='T1234'),
-                                                       constraints=dict(test_field='test_value')))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='ktest', value='rdemo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234')))
-        loop.run_until_complete(knowledge_svc.delete_fact(dict(trait='rtest')))
-        facts = loop.run_until_complete(knowledge_svc.get_facts(dict(value='rdemo')))
+                                                       constraints=dict(test_field='test_value'))
+        await knowledge_svc.add_fact(Fact(trait='ktest', value='rdemo', score=1,
+                                                            collected_by=['thin_air'], technique_id='T1234'))
+        await knowledge_svc.delete_fact(dict(trait='rtest'))
+        facts = await knowledge_svc.get_facts(dict(value='rdemo'))
         assert len(facts) == 1
         assert len(knowledge_svc._KnowledgeService__loaded_knowledge_module.fact_ram['constraints']) == 0
 
-    def test_remove_rules(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_rule(Rule(action='rBLOCK', trait='ra.c', match='.*'),
-                                                       constraints=dict(test_field='test_value')))
-        loop.run_until_complete(knowledge_svc.delete_rule(dict(trait='ra.c')))
-        rules = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='ra.c')))
+    async def test_remove_rules(self, knowledge_svc):
+        await knowledge_svc.add_rule(Rule(action='rBLOCK', trait='ra.c', match='.*'),
+                                                       constraints=dict(test_field='test_value'))
+        await knowledge_svc.delete_rule(dict(trait='ra.c'))
+        rules = await knowledge_svc.get_rules(dict(trait='ra.c'))
         assert len(rules) == 0
         assert len(knowledge_svc._KnowledgeService__loaded_knowledge_module.fact_ram['constraints']) == 0
 
-    def test_remove_relationship(self, loop, knowledge_svc):
+    async def test_remove_relationship(self, knowledge_svc):
         dummy = Fact(trait='rtest', value='rdemo', score=1, collected_by=['thin_air'], technique_id='T1234')
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy, edge='rpotato', target=dummy),
-                                                               constraints=dict(test_field='test_value')))
-        loop.run_until_complete(knowledge_svc.delete_relationship(dict(edge='rpotato')))
-        relationships = loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='rpotato')))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='rpotato', target=dummy),
+                                                               constraints=dict(test_field='test_value'))
+        await knowledge_svc.delete_relationship(dict(edge='rpotato'))
+        relationships = await knowledge_svc.get_relationships(dict(edge='rpotato'))
         assert len(relationships) == 0
         assert len(knowledge_svc._KnowledgeService__loaded_knowledge_module.fact_ram['constraints']) == 0
 
-    def test_update_fact(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='utest', value='udemo', score=1,
-                                                            collected_by=['thin_air'], technique_id='T1234')))
-        loop.run_until_complete(knowledge_svc.update_fact(criteria=dict(trait='utest'),
-                                                          updates=dict(trait='utest2', value='udemo2')))
-        facts = loop.run_until_complete(knowledge_svc.get_facts(dict(trait='utest2')))
+    async def test_update_fact(self, knowledge_svc):
+        await knowledge_svc.add_fact(Fact(trait='utest', value='udemo', score=1,
+                                                            collected_by=['thin_air'], technique_id='T1234'))
+        await knowledge_svc.update_fact(criteria=dict(trait='utest'),
+                                                          updates=dict(trait='utest2', value='udemo2'))
+        facts = await knowledge_svc.get_facts(dict(trait='utest2'))
         assert len(facts) == 1
         assert facts[0].value == 'udemo2'
 
-    def test_update_relationship(self, loop, knowledge_svc):
+    async def test_update_relationship(self, knowledge_svc):
         dummy = Fact(trait='utest', value='udemo', score=1, collected_by=['thin_air'], technique_id='T1234')
         dummy2 = Fact(trait='utest2', value='udemo2', score=1, collected_by=['thin_air'], technique_id='T4321')
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy, edge='upotato', target=dummy)))
-        loop.run_until_complete(knowledge_svc.update_relationship(criteria=dict(edge='upotato'),
-                                                                  updates=dict(source=dummy2, edge='ubacon')))
-        relationships = loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='ubacon')))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='upotato', target=dummy))
+        await knowledge_svc.update_relationship(criteria=dict(edge='upotato'),
+                                                                  updates=dict(source=dummy2, edge='ubacon'))
+        relationships = await knowledge_svc.get_relationships(dict(edge='ubacon'))
         assert len(relationships) == 1
         assert relationships[0].source == dummy2
 
-    def test_retrieve_fact(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='ttestA', value='tdemoB', score=24,
-                                                            collected_by=['thin_airA'], technique_id='T1234')))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='ttestB', value='tdemoA', score=42,
-                                                            collected_by=['thin_airB'], technique_id='T4321')))
-        facts = loop.run_until_complete(knowledge_svc.get_facts(dict(trait='ttestB')))
+    async def test_retrieve_fact(self, knowledge_svc):
+        await knowledge_svc.add_fact(Fact(trait='ttestA', value='tdemoB', score=24,
+                                                            collected_by=['thin_airA'], technique_id='T1234'))
+        await knowledge_svc.add_fact(Fact(trait='ttestB', value='tdemoA', score=42,
+                                                            collected_by=['thin_airB'], technique_id='T4321'))
+        facts = await knowledge_svc.get_facts(dict(trait='ttestB'))
         assert len(facts) == 1
         readable = facts[0].display
         assert readable['value'] == 'tdemoA'
         assert readable['score'] == 42
 
-    def test_retrieve_relationship(self, loop, knowledge_svc):
+    async def test_retrieve_relationship(self, knowledge_svc):
         dummy = Fact(trait='ttest', value='tdemo', score=1, collected_by=['thin_air'], technique_id='T1234')
         dummy2 = Fact(trait='ttest2', value='tdemo2', score=1, collected_by=['thin_air'], technique_id='T1234')
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy, edge='tpotato',
-                                                                            target=dummy2)))
-        loop.run_until_complete(knowledge_svc.add_relationship(Relationship(source=dummy2, edge='tpotato',
-                                                                            target=dummy)))
-        relationships = loop.run_until_complete(knowledge_svc.get_relationships(dict(edge='tpotato')))
+        await knowledge_svc.add_relationship(Relationship(source=dummy, edge='tpotato',
+                                                                            target=dummy2))
+        await knowledge_svc.add_relationship(Relationship(source=dummy2, edge='tpotato',
+                                                                            target=dummy))
+        relationships = await knowledge_svc.get_relationships(dict(edge='tpotato'))
         assert len(relationships) == 2
-        specific = loop.run_until_complete(knowledge_svc.get_relationships(dict(source=dummy)))
+        specific = await knowledge_svc.get_relationships(dict(source=dummy))
         assert len(specific) == 1
         readable = specific[0].display
         assert readable['edge'] == 'tpotato'
         assert readable['target'].trait == 'ttest2'
 
-    def test_retrieve_rule(self, loop, knowledge_svc):
-        loop.run_until_complete(knowledge_svc.add_rule(Rule(action='tBLOCK', trait='ta.d', match='4.5.*')))
-        loop.run_until_complete(knowledge_svc.add_rule(Rule(action='tALLOW', trait='ta.d', match='*.5.*')))
-        rules = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='ta.d')))
+    async def test_retrieve_rule(self, knowledge_svc):
+        await knowledge_svc.add_rule(Rule(action='tBLOCK', trait='ta.d', match='4.5.*'))
+        await knowledge_svc.add_rule(Rule(action='tALLOW', trait='ta.d', match='*.5.*'))
+        rules = await knowledge_svc.get_rules(dict(trait='ta.d'))
         assert len(rules) == 2
 
-        fuzzy1 = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='ta.d', match='4.5.6')))
+        fuzzy1 = await knowledge_svc.get_rules(dict(trait='ta.d', match='4.5.6'))
         assert len(fuzzy1) == 2
-        fuzzy2 = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='ta.d', match='6.5.4')))
+        fuzzy2 = await knowledge_svc.get_rules(dict(trait='ta.d', match='6.5.4'))
         assert len(fuzzy2) == 1
         assert fuzzy2[0].action == 'tALLOW'
-        fuzzy3 = loop.run_until_complete(knowledge_svc.get_rules(dict(trait='ta.d', match='5.*')))
+        fuzzy3 = await knowledge_svc.get_rules(dict(trait='ta.d', match='5.*'))
         assert len(fuzzy3) == 2
 
-    def test_fact_origin(self, loop, knowledge_svc, ability, executor):
+    async def test_fact_origin(self, knowledge_svc, ability, executor):
         texecutor = executor(name='sh', platform='darwin', command='mkdir test', cleanup='rm -rf test')
         tability = ability(ability_id='123', executors=[texecutor], repeatable=True, buckets=['test'])
         link = Link.load(dict(command='', paw='n1234', ability=tability, executor=next(tability.executors), status=0,
@@ -125,12 +125,12 @@ class TestKnowledgeService:
                           links=[link.id], origin_type=OriginType.LEARNED)
         type3_fact = Fact(trait='t3', value='d3', score=1, collected_by=['tiny_lightning_bolts_running_through_sand'],
                           technique_id='T1234', origin_type=OriginType.SEEDED, source="Europa")
-        loop.run_until_complete(knowledge_svc.add_fact(type1_fact))
-        loop.run_until_complete(knowledge_svc.add_fact(type2_fact))
-        loop.run_until_complete(knowledge_svc.add_fact(type3_fact))
-        origin_1, type_1 = loop.run_until_complete(knowledge_svc.get_fact_origin(type1_fact))
-        origin_2, type_2 = loop.run_until_complete(knowledge_svc.get_fact_origin(type2_fact.trait))
-        origin_3, type_3 = loop.run_until_complete(knowledge_svc.get_fact_origin(type3_fact.trait))
+        await knowledge_svc.add_fact(type1_fact)
+        await knowledge_svc.add_fact(type2_fact)
+        await knowledge_svc.add_fact(type3_fact)
+        origin_1, type_1 = await knowledge_svc.get_fact_origin(type1_fact)
+        origin_2, type_2 = await knowledge_svc.get_fact_origin(type2_fact.trait)
+        origin_3, type_3 = await knowledge_svc.get_fact_origin(type3_fact.trait)
         assert origin_1 == link.id
         assert origin_2 == link.id
         assert origin_3 == 'Europa'

--- a/tests/services/test_learning_svc.py
+++ b/tests/services/test_learning_svc.py
@@ -6,14 +6,14 @@ from app.utility.base_world import BaseWorld
 
 
 @pytest.fixture
-def setup_learning_service(loop, data_svc, ability, operation, link):
+async def setup_learning_service(data_svc, ability, operation, link):
     texecutor = Executor(name='sh', platform='darwin', command='whoami', payloads=['wifi.sh'])
     tability = ability(tactic='discovery', technique_id='T1033', technique_name='Find', name='test',
                        description='find active user', privilege=None, executors=[texecutor])
-    loop.run_until_complete(data_svc.store(tability))
+    await data_svc.store(tability)
     toperation = operation(name='sample', agents=None, adversary=Adversary(name='sample', adversary_id='XYZ',
                                                                            atomic_ordering=[], description='test'))
-    loop.run_until_complete(data_svc.store(toperation))
+    await data_svc.store(toperation)
     tlink1 = link(ability=tability, command='', paw='1234', executor=texecutor)
     tlink2 = link(ability=tability, command='', paw='5678', executor=texecutor)
     yield toperation, tlink1, tlink2
@@ -21,47 +21,44 @@ def setup_learning_service(loop, data_svc, ability, operation, link):
 
 class TestLearningSvc:
 
-    def test_learn(self, loop, setup_learning_service, learning_svc, knowledge_svc):
+    async def test_learn(self, setup_learning_service, learning_svc, knowledge_svc):
         operation, link, _ = setup_learning_service
         operation.add_link(link)
-        all_facts = loop.run_until_complete(operation.all_facts())
-        loop.run_until_complete(learning_svc.learn(
+        all_facts = await operation.all_facts()
+        await learning_svc.learn(
             facts=all_facts,
             link=link,
             blob=BaseWorld.encode_string('i contain 1 ip address 192.168.0.1 and one file /etc/host.txt. that is all.'))
-        )
-        knowledge_facts = loop.run_until_complete(knowledge_svc.get_facts(dict(source=link.id)))
+        knowledge_facts = await knowledge_svc.get_facts(dict(source=link.id))
         assert len(link.facts) == 2
         assert len(knowledge_facts) == 2
 
-    def test_same_fact_different_agents(self, loop, setup_learning_service, learning_svc, knowledge_svc):
+    async def test_same_fact_different_agents(self, setup_learning_service, learning_svc, knowledge_svc):
         operation, link1, link2 = setup_learning_service
         link1.id = 'link1'
         link2.id = 'link2'
         operation.add_link(link1)
-        all_facts = loop.run_until_complete(operation.all_facts())
-        loop.run_until_complete(learning_svc.learn(
+        all_facts = await operation.all_facts()
+        await learning_svc.learn(
             facts=all_facts,
             link=link1,
             blob=BaseWorld.encode_string('i contain 1 ip address 192.168.0.1 and one file /etc/host.txt. that is all.'),
             operation=operation)
-        )
         operation.add_link(link2)
-        all_facts = loop.run_until_complete(operation.all_facts())
-        loop.run_until_complete(learning_svc.learn(
+        all_facts = await operation.all_facts()
+        await learning_svc.learn(
             facts=all_facts,
             link=link2,
             blob=BaseWorld.encode_string('i contain 1 ip address 192.168.0.1 and one file /etc/host.txt. that is all.'),
             operation=operation)
-        )
 
-        knowledge_facts = loop.run_until_complete(knowledge_svc.get_facts(dict(source=operation.id)))
+        knowledge_facts = await knowledge_svc.get_facts(dict(source=operation.id))
         assert len(link1.facts) == 2
         assert len(link2.facts) == 2
         assert len(knowledge_facts) == 2
         assert len(knowledge_facts[0].collected_by) == 2
 
-    def test_build_relationships(self, loop, setup_learning_service, learning_svc, knowledge_svc):
+    async def test_build_relationships(self, setup_learning_service, learning_svc, knowledge_svc):
         _, link, _ = setup_learning_service
         learning_svc.model.add(frozenset({'host.user.name', 'target.org.name'}))
         learning_svc.model.add(frozenset({'host.file.extension', 'host.user.name', 'domain.user.name'}))
@@ -72,5 +69,5 @@ class TestLearningSvc:
             Fact(trait='domain.user.name', value='user'),
             Fact(trait='not.really.here', value='should never be found')
         ]
-        loop.run_until_complete(learning_svc._store_results(link, facts))
+        await learning_svc._store_results(link, facts)
         assert len(link.relationships) == 4

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -98,8 +98,7 @@ def stop_bucket_exhaustion_setup(request, setup_planning_test):
 
 
 class TestPlanningService:
-    async def test_wait_for_links_and_monitor(self, planning_svc, fact,
-                                        setup_planning_test):
+    async def test_wait_for_links_and_monitor(self, planning_svc, fact, setup_planning_test):
         # PART A:
         ability, agent, operation, _ = setup_planning_test
         # Add a link to operation.chain
@@ -134,8 +133,7 @@ class TestPlanningService:
         #   is returned in "links"
         tability, agent, operation, cability = setup_planning_test
         operation.adversary.atomic_ordering = ["123", "321"]
-        links = await planning_svc.get_links(operation=operation, buckets=None,
-                                         agent=agent)
+        links = await planning_svc.get_links(operation=operation, buckets=None, agent=agent)
         assert links[0].ability.ability_id == tability.ability_id
 
         # PART B: Fill in facts to allow "cability" to be returned in "links"
@@ -148,8 +146,7 @@ class TestPlanningService:
         await knowledge_svc.add_fact(Fact(trait='a.b.d', value='2', source=operation.id))
         await knowledge_svc.add_fact(Fact(trait='a.b.e', value='3', source=operation.id))
 
-        links = await planning_svc.get_links(operation=operation, buckets=None,
-                                         agent=agent)
+        links = await planning_svc.get_links(operation=operation, buckets=None, agent=agent)
 
         assert links[0].ability.ability_id == cability.ability_id
         assert links[1].ability.ability_id == tability.ability_id
@@ -295,7 +292,7 @@ class TestPlanningService:
         ability, agent, operation, _ = setup_planning_test
         executor = next(ability.executors)
         operation.add_link(Link.load(dict(command='', paw=agent.paw, ability=ability, executor=executor, status=0)))
-        links =  await planning_svc.get_cleanup_links(operation=operation, agent=agent)
+        links = await planning_svc.get_cleanup_links(operation=operation, agent=agent)
         link_list = list(links)
         assert len(link_list) == 1
         assert BaseWorld.decode_bytes(link_list[0].command) == executor.cleanup[0]
@@ -360,8 +357,8 @@ class TestPlanningService:
 
         # test parallel filtering
         flat_fil = await planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
-                                                                                               [l0, l1, l2, l3],
-                                                                                               [l0, l1, l2, l3]])
+                                                                            [l0, l1, l2, l3],
+                                                                            [l0, l1, l2, l3]])
         assert 7 == len(flat_fil)
 
     async def test_trait_with_one_part(self, setup_planning_test, planning_svc):

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -59,7 +59,7 @@ def planner_stub(**kwargs):
 
 
 @pytest.fixture
-def setup_planning_test(loop, executor, ability, agent, operation, data_svc, event_svc, init_base_world):
+async def setup_planning_test(executor, ability, agent, operation, data_svc, event_svc, init_base_world):
     texecutor = executor(name='sh', platform='darwin', command='mkdir test', cleanup='rm -rf test')
     tability = ability(ability_id='123', executors=[texecutor], repeatable=True, buckets=['test'], name='test1')
     tagent = agent(sleep_min=1, sleep_max=2, watchdog=0, executors=['sh'], platform='darwin',
@@ -74,14 +74,14 @@ def setup_planning_test(loop, executor, ability, agent, operation, data_svc, eve
     cexecutor = executor(name='sh', platform='darwin', command=test_string, cleanup='whoami')
     cability = ability(ability_id='321', executors=[cexecutor], singleton=True, name='test2')
 
-    loop.run_until_complete(data_svc.store(tability))
-    loop.run_until_complete(data_svc.store(cability))
+    await data_svc.store(tability)
+    await data_svc.store(cability)
 
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Obfuscator(name='plain-text',
                    description='Does no obfuscation to any command, instead running it in plain text',
                    module='plugins.stockpile.app.obfuscators.plain_text')
-    ))
+    )
 
     yield tability, tagent, toperation, cability
 
@@ -98,7 +98,7 @@ def stop_bucket_exhaustion_setup(request, setup_planning_test):
 
 
 class TestPlanningService:
-    def test_wait_for_links_and_monitor(self, loop, planning_svc, fact,
+    async def test_wait_for_links_and_monitor(self, planning_svc, fact,
                                         setup_planning_test):
         # PART A:
         ability, agent, operation, _ = setup_planning_test
@@ -112,31 +112,30 @@ class TestPlanningService:
         link_ids = ["123"]
         # Make sure program doesn't hang in wait_for_links_completion()
         planner.operation.chain[0].finish = True
-        assert loop.run_until_complete(planning_svc.wait_for_links_and_monitor(
-            planner, operation, link_ids, condition_stop=True)) is False
+        assert await planning_svc.wait_for_links_and_monitor(
+            planner, operation, link_ids, condition_stop=True) is False
 
         # PART B:
         # Make sure program hangs in wait_for_links_completion()
         planner.operation.chain[0].finish = False
         timeout = False
         try:
-            loop.run_until_complete(asyncio.wait_for(
+            await asyncio.wait_for(
                 planning_svc.wait_for_links_and_monitor(planner, operation,
                                                         link_ids,
                                                         condition_stop=True),
-                timeout=5.0))
+                timeout=5.0)
         except asyncio.TimeoutError:
             timeout = True
         assert timeout is True
 
-    def test_get_links(self, loop, setup_planning_test, planning_svc, data_svc, knowledge_svc):
+    async def test_get_links(self, setup_planning_test, planning_svc, data_svc, knowledge_svc):
         # PART A: Don't fill in facts for "cability" so only "tability"
         #   is returned in "links"
         tability, agent, operation, cability = setup_planning_test
         operation.adversary.atomic_ordering = ["123", "321"]
-        links = loop.run_until_complete(planning_svc.get_links
-                                        (operation=operation, buckets=None,
-                                         agent=agent))
+        links = await planning_svc.get_links(operation=operation, buckets=None,
+                                         agent=agent)
         assert links[0].ability.ability_id == tability.ability_id
 
         # PART B: Fill in facts to allow "cability" to be returned in "links"
@@ -144,20 +143,19 @@ class TestPlanningService:
         operation.add_link(Link.load(
             dict(command='', paw=agent.paw, ability=tability, executor=next(tability.executors), status=0)))
 
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='1_2_3', value='0', source=operation.id)))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='a.b.c', value='1', source=operation.id)))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='a.b.d', value='2', source=operation.id)))
-        loop.run_until_complete(knowledge_svc.add_fact(Fact(trait='a.b.e', value='3', source=operation.id)))
+        await knowledge_svc.add_fact(Fact(trait='1_2_3', value='0', source=operation.id))
+        await knowledge_svc.add_fact(Fact(trait='a.b.c', value='1', source=operation.id))
+        await knowledge_svc.add_fact(Fact(trait='a.b.d', value='2', source=operation.id))
+        await knowledge_svc.add_fact(Fact(trait='a.b.e', value='3', source=operation.id))
 
-        links = loop.run_until_complete(planning_svc.get_links
-                                        (operation=operation, buckets=None,
-                                         agent=agent))
+        links = await planning_svc.get_links(operation=operation, buckets=None,
+                                         agent=agent)
 
         assert links[0].ability.ability_id == cability.ability_id
         assert links[1].ability.ability_id == tability.ability_id
         assert base64.b64decode(links[0].command).decode('utf-8') == target_string
 
-    def test_exhaust_bucket(self, loop, setup_planning_test, planning_svc):
+    async def test_exhaust_bucket(self, setup_planning_test, planning_svc):
         ability, agent, operation, _ = setup_planning_test
         operation.adversary.atomic_ordering = ["123"]
         operation.add_link(Link.load(
@@ -167,56 +165,56 @@ class TestPlanningService:
         bucket = "test"
         timeout = False
         try:
-            loop.run_until_complete(asyncio.wait_for(planning_svc.exhaust_bucket(
-                planner, bucket, operation, agent), timeout=5.0))
+            await asyncio.wait_for(planning_svc.exhaust_bucket(
+                planner, bucket, operation, agent), timeout=5.0)
         except asyncio.TimeoutError:
             timeout = True
         assert timeout is True
 
-    def test_add_ability_to_bucket(self, loop, setup_planning_test, planning_svc):
+    async def test_add_ability_to_bucket(self, setup_planning_test, planning_svc):
         b1 = 'salvador'
         b2 = 'hardin'
         a, _, _, _ = setup_planning_test
-        loop.run_until_complete(planning_svc.add_ability_to_bucket(a, b1))
+        await planning_svc.add_ability_to_bucket(a, b1)
         assert a.buckets == ['test', b1]
-        loop.run_until_complete(planning_svc.add_ability_to_bucket(a, b2))
+        await planning_svc.add_ability_to_bucket(a, b2)
         assert a.buckets == ['test', b1, b2]
 
-    def test_default_next_bucket(self, loop, planning_svc):
+    async def test_default_next_bucket(self, planning_svc):
         sm = ['alpha', 'bravo', 'charlie']
-        assert loop.run_until_complete(planning_svc.default_next_bucket(sm[0], sm)) == sm[1]
-        assert loop.run_until_complete(planning_svc.default_next_bucket(sm[1], sm)) == sm[2]
-        assert loop.run_until_complete(planning_svc.default_next_bucket(sm[2], sm)) == sm[0]    # loops around
+        assert await planning_svc.default_next_bucket(sm[0], sm) == sm[1]
+        assert await planning_svc.default_next_bucket(sm[1], sm) == sm[2]
+        assert await planning_svc.default_next_bucket(sm[2], sm) == sm[0]    # loops around
 
-    def test_stopping_condition_met(self, loop, planning_svc, fact):
+    async def test_stopping_condition_met(self, planning_svc, fact):
         facts = [
             fact(trait='m.b.k', value='michael'),
             fact(trait='l.r.k', value='laura')
         ]
         stopping_condition = fact(trait='c.p.k', value='cole')
 
-        assert loop.run_until_complete(planning_svc._stopping_condition_met(facts, stopping_condition)) is False
+        assert await planning_svc._stopping_condition_met(facts, stopping_condition) is False
         facts.append(stopping_condition)
-        assert loop.run_until_complete(planning_svc._stopping_condition_met(facts, stopping_condition)) is True
+        assert await planning_svc._stopping_condition_met(facts, stopping_condition) is True
 
-    def test_check_stopping_conditions(self, loop, fact, link, setup_planning_test, planning_svc):
+    async def test_check_stopping_conditions(self, fact, link, setup_planning_test, planning_svc):
         ability, agent, operation, _ = setup_planning_test
         executor = next(ability.executors)
         operation.source.facts = []
         stopping_conditions = [fact(trait='s.o.f.', value='seldon')]
 
         # first verify stopping conditions not met
-        assert loop.run_until_complete(planning_svc.check_stopping_conditions(stopping_conditions, operation)) is False
+        assert await planning_svc.check_stopping_conditions(stopping_conditions, operation) is False
         # add stopping condition to a fact, then to a link, then the link to the operation
         l0 = link(command='test', paw='0', ability=ability, executor=executor)
         l1 = link(command='test1', paw='1', ability=ability, executor=executor)
-        loop.run_until_complete(l1.save_fact(operation, stopping_conditions[0], 1, "dummy_relationship_visual_string"))
+        await l1.save_fact(operation, stopping_conditions[0], 1, "dummy_relationship_visual_string")
         operation.add_link(l0)
         operation.add_link(l1)
         # now verify stopping condition is met since we directly inserted fact that matches stopping condition
-        assert loop.run_until_complete(planning_svc.check_stopping_conditions(stopping_conditions, operation)) is True
+        assert await planning_svc.check_stopping_conditions(stopping_conditions, operation) is True
 
-    def test_update_stopping_condition_met(self, loop, fact, link, setup_planning_test, planning_svc):
+    async def test_update_stopping_condition_met(self, fact, link, setup_planning_test, planning_svc):
         ability, agent, operation, _ = setup_planning_test
         stopping_condition = fact(trait='t.c.t', value='boss')
 
@@ -226,44 +224,44 @@ class TestPlanningService:
         p = PlannerStub()
 
         # first call should not result in 'met' flag being flipped
-        loop.run_until_complete(planning_svc.update_stopping_condition_met(p, operation))
+        await planning_svc.update_stopping_condition_met(p, operation)
         assert p.stopping_condition_met is False
         # add stopping condition to a fact, then to a link, then the link to the operation
         l1 = link(command='test1', paw='1', ability=ability, executor=next(ability.executors))
-        loop.run_until_complete(l1.save_fact(operation, stopping_condition, 1, "dummy_relationship_visual_string"))
+        await l1.save_fact(operation, stopping_condition, 1, "dummy_relationship_visual_string")
         operation.add_link(l1)
         # now verify stopping condition is met since we directly inserted fact that matches stopping conidition
-        loop.run_until_complete(planning_svc.update_stopping_condition_met(p, operation))
+        await planning_svc.update_stopping_condition_met(p, operation)
         assert p.stopping_condition_met is True
 
-    def test_sort_links(self, loop, link, planning_svc, setup_planning_test):
+    async def test_sort_links(self, link, planning_svc, setup_planning_test):
         a, _, _, _ = setup_planning_test
         executor = next(a.executors)
         l1 = link(command='m', paw='1', ability=a, executor=executor, score=1)
         l2 = link(command='a', paw='2', ability=a, executor=executor, score=2)
         l3 = link(command='l', paw='3', ability=a, executor=executor, score=3)
-        sl = loop.run_until_complete(planning_svc.sort_links([l2, l1, l3]))
+        sl = await planning_svc.sort_links([l2, l1, l3])
         assert sl[0] == l3
         assert sl[1] == l2
         assert sl[2] == l1
 
-    def test_stop_bucket_exhaustion(self, loop, stop_bucket_exhaustion_setup, planning_svc):
+    async def test_stop_bucket_exhaustion(self, stop_bucket_exhaustion_setup, planning_svc):
         """
         NOTE: Test runs 5x, each with parameter sets found in 'stop_bucket_exhaustion_params'.
         """
         planner, operation, condition_stop, assert_value = stop_bucket_exhaustion_setup
-        assert loop.run_until_complete(planning_svc._stop_bucket_exhaustion(planner, operation, condition_stop)) is assert_value
+        assert await planning_svc._stop_bucket_exhaustion(planner, operation, condition_stop) is assert_value
 
-    def test_execute_planner(self, loop, setup_planning_test, planning_svc, monkeypatch):
+    async def test_execute_planner(self, setup_planning_test, planning_svc, monkeypatch):
         """
         Case 1 - let planner run until it stops itself after bucket 'three'.
         """
         ability, agent, operation, _ = setup_planning_test
         p = PlannerFake(operation)
-        loop.run_until_complete(planning_svc.execute_planner(p, publish_transitions=False))
+        await planning_svc.execute_planner(p, publish_transitions=False)
         assert p.calls == ['one', 'two', 'three']
 
-    def test_execute_planner_2(self, monkeypatch, loop, planning_svc, setup_planning_test):
+    async def test_execute_planner_2(self, monkeypatch, planning_svc, setup_planning_test):
         """
         Case 2 - start planner but then hijack operation after bucket 'two and flag that stopping condition
         been found, thus stopping the planner when it attempt to proceed to next bucket
@@ -275,10 +273,10 @@ class TestPlanningService:
                 planner.stopping_condition_met = True
         monkeypatch.setattr(planning_svc, 'update_stopping_condition_met', stub_update_stopping_condition_met)
         p = PlannerFake(operation)
-        loop.run_until_complete(planning_svc.execute_planner(p, publish_transitions=False))
+        await planning_svc.execute_planner(p, publish_transitions=False)
         assert p.calls == ['one', 'two']
 
-    def test_execute_planner_3(self, monkeypatch, loop, planning_svc, setup_planning_test):
+    async def test_execute_planner_3(self, monkeypatch, planning_svc, setup_planning_test):
         """
         Case 3 - start planner but then hijack operation and set it to 'FINISH' state, thus
         stopping the planner when it attempts to proceed to next bucket
@@ -290,26 +288,24 @@ class TestPlanningService:
                 operation.state = operation.states['FINISHED']
         monkeypatch.setattr(planning_svc, 'update_stopping_condition_met', stub_update_stopping_condition_met_1)
         p = PlannerFake(operation)
-        loop.run_until_complete(planning_svc.execute_planner(p, publish_transitions=False))
+        await planning_svc.execute_planner(p, publish_transitions=False)
         assert p.calls == ['one']
 
-    def test_get_cleanup_links(self, loop, setup_planning_test, planning_svc):
+    async def test_get_cleanup_links(self, setup_planning_test, planning_svc):
         ability, agent, operation, _ = setup_planning_test
         executor = next(ability.executors)
         operation.add_link(Link.load(dict(command='', paw=agent.paw, ability=ability, executor=executor, status=0)))
-        links = loop.run_until_complete(
-            planning_svc.get_cleanup_links(operation=operation, agent=agent)
-        )
+        links =  await planning_svc.get_cleanup_links(operation=operation, agent=agent)
         link_list = list(links)
         assert len(link_list) == 1
         assert BaseWorld.decode_bytes(link_list[0].command) == executor.cleanup[0]
 
-    def test_generate_and_trim_links(self, loop, setup_planning_test, planning_svc):
+    async def test_generate_and_trim_links(self, setup_planning_test, planning_svc):
         ability, agent, operation, _ = setup_planning_test
-        generated_links = loop.run_until_complete(planning_svc.generate_and_trim_links(agent, operation, [ability]))
+        generated_links = await planning_svc.generate_and_trim_links(agent, operation, [ability])
         assert 1 == len(generated_links)
 
-    def test_link_fact_coverage(self, loop, setup_planning_test, planning_svc):
+    async def test_link_fact_coverage(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         link = Link.load(dict(command=BaseWorld.encode_string(test_string), paw=agent.paw, ability=ability,
                               executor=next(ability.executors), status=0))
@@ -319,12 +315,12 @@ class TestPlanningService:
         f2 = Fact(trait='a.b.d', value='2')
         f3 = Fact(trait='a.b.e', value='3')
 
-        gen = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3]))
+        gen = await planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3])
 
         assert len(gen) == 2
         assert BaseWorld.decode_bytes(gen[1].display['command']) == target_string
 
-    def test_filter_bs(self, loop, setup_planning_test, planning_svc):
+    async def test_filter_bs(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
         link = Link.load(dict(command=BaseWorld.encode_string(test_string), paw=agent.paw, ability=ability,
                               executor=next(ability.executors), status=0))
@@ -337,12 +333,12 @@ class TestPlanningService:
         f5 = Fact(trait='a.b.e', value='5')
         f6 = Fact(trait='a.b.e', value='6')
 
-        gen = loop.run_until_complete(planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3, f4, f5, f6]))
+        gen = await planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3, f4, f5, f6])
 
         assert len(gen) == 4
         assert BaseWorld.decode_bytes(gen[1].display['command']) == target_string
 
-    def test_duplicate_lateral_filter(self, loop, setup_planning_test, planning_svc, link, fact):
+    async def test_duplicate_lateral_filter(self, setup_planning_test, planning_svc, link, fact):
         ability, agent, operation, sability = setup_planning_test
 
         l0 = link(command='a0', paw='0', ability=ability, executor=next(ability.executors))
@@ -359,13 +355,13 @@ class TestPlanningService:
         operation.chain = [l0, l1]
 
         # test historical filtering
-        filt = loop.run_until_complete(planning_svc.remove_completed_links(operation, agent, [l2, l3]))
+        filt = await planning_svc.remove_completed_links(operation, agent, [l2, l3])
         assert 1 == len(filt)
 
         # test parallel filtering
-        flat_fil = loop.run_until_complete(planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
+        flat_fil = await planning_svc._remove_links_of_duplicate_singletons([[l0, l1, l2, l3],
                                                                                                [l0, l1, l2, l3],
-                                                                                               [l0, l1, l2, l3]]))
+                                                                                               [l0, l1, l2, l3]])
         assert 7 == len(flat_fil)
 
     async def test_trait_with_one_part(self, setup_planning_test, planning_svc):

--- a/tests/services/test_rest_svc.py
+++ b/tests/services/test_rest_svc.py
@@ -14,54 +14,54 @@ from app.utility.base_world import BaseWorld
 
 
 @pytest.fixture
-def setup_rest_svc_test(loop, data_svc):
+async def setup_rest_svc_test(data_svc):
     BaseWorld.apply_config(name='main', config={'app.contact.http': '0.0.0.0',
                                                 'plugins': ['sandcat', 'stockpile'],
                                                 'crypt_salt': 'BLAH',
                                                 'api_key': 'ADMIN123',
                                                 'encryption_key': 'ADMIN123',
                                                 'exfil_dir': '/tmp'})
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Ability(ability_id='123', name='testA', executors=[
             Executor(name='psh', platform='windows', command='curl #{app.contact.http}')
         ])
-    ))
-    loop.run_until_complete(data_svc.store(
+    )
+    await data_svc.store(
         Ability(ability_id='456', name='testB', executors=[
             Executor(name='sh', platform='linux', command='whoami')
         ])
-    ))
-    loop.run_until_complete(data_svc.store(
+    )
+    await data_svc.store(
         Ability(ability_id='789', name='testC', executors=[
             Executor(name='sh', platform='linux', command='hostname')
         ])
-    ))
+    )
     adversary = Adversary(adversary_id='123', name='test', description='test', atomic_ordering=[])
-    loop.run_until_complete(data_svc.store(adversary))
+    await data_svc.store(adversary)
 
     agent = Agent(paw='123', sleep_min=2, sleep_max=8, watchdog=0, executors=['pwsh', 'psh'], platform='windows')
-    loop.run_until_complete(data_svc.store(agent))
+    await data_svc.store(agent)
 
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Objective(id='495a9828-cab1-44dd-a0ca-66e58177d8cc', name='default', goals=[Goal()])
-    ))
+    )
 
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Planner(planner_id='123', name='test', module='test', params=dict())
-    ))
+    )
 
     source = Source(id='123', name='test', facts=[], adjustments=[])
-    loop.run_until_complete(data_svc.store(source))
+    await data_svc.store(source)
 
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Operation(name='test', agents=[agent], adversary=adversary, id='123', source=source)
-    ))
+    )
 
-    loop.run_until_complete(data_svc.store(
+    await data_svc.store(
         Obfuscator(name='plain-text',
                    description='Does no obfuscation to any command, instead running it in plain text',
                    module='plugins.stockpile.app.obfuscators.plain_text')
-    ))
+    )
 
 
 @pytest.mark.usefixtures(
@@ -69,7 +69,7 @@ def setup_rest_svc_test(loop, data_svc):
 )
 class TestRestSvc:
 
-    def test_delete_operation(self, loop, rest_svc, data_svc):
+    def test_delete_operation(self, event_loop, rest_svc, data_svc):
         # PART A: Create an operation
         expected_operation = {'name': 'My Test Operation',
                               'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc',
@@ -101,13 +101,13 @@ class TestRestSvc:
                                             'percentage': 0.0, 'description': '',
                                             'id': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
                                             'name': 'default'}}
-        internal_rest_svc = rest_svc(loop)
-        operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
+        internal_rest_svc = rest_svc(event_loop)
+        operation = event_loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),
             data=dict(name='My Test Operation', planner='test', source='123', state='finished')))
         operation_id = operation[0]["id"]
         expected_operation['id'] = operation_id
-        found_operation = loop.run_until_complete(data_svc.locate('operations', match=dict(id=operation_id)))[0].display
+        found_operation = event_loop.run_until_complete(data_svc.locate('operations', match=dict(id=operation_id)))[0].display
         found_operation['host_group'][0].pop('last_seen')
         found_operation.pop('start')
         found_operation["host_group"][0].pop("created")
@@ -118,32 +118,32 @@ class TestRestSvc:
                            'name': 'My Test Operation', 'jitter': '2/8', 'state': 'finished', 'autonomous': True,
                            'last_ran': None, 'obfuscator': 'plain-text', 'auto_close': False, 'visibility': 50,
                            'chain': [], 'potential_links': []}
-        loop.run_until_complete(internal_rest_svc.delete_operation(delete_criteria))
-        assert loop.run_until_complete(data_svc.locate('operations', match=dict(id=operation_id))) == []
+        event_loop.run_until_complete(internal_rest_svc.delete_operation(delete_criteria))
+        assert event_loop.run_until_complete(data_svc.locate('operations', match=dict(id=operation_id))) == []
 
-    def test_update_config(self, loop, data_svc, rest_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_update_config(self, event_loop, data_svc, rest_svc):
+        internal_rest_svc = rest_svc(event_loop)
         # check that an ability reflects the value in app. property
-        pre_ability = loop.run_until_complete(data_svc.locate('abilities', dict(ability_id='123')))
+        pre_ability = event_loop.run_until_complete(data_svc.locate('abilities', dict(ability_id='123')))
         assert '0.0.0.0' == BaseWorld.get_config('app.contact.http')
         assert 'curl 0.0.0.0' == next(pre_ability[0].executors).test
 
         # update property
-        loop.run_until_complete(internal_rest_svc.update_config(data=dict(prop='app.contact.http', value='127.0.0.1')))
+        event_loop.run_until_complete(internal_rest_svc.update_config(data=dict(prop='app.contact.http', value='127.0.0.1')))
 
         # verify ability reflects new value
-        post_ability = loop.run_until_complete(data_svc.locate('abilities', dict(ability_id='123')))
+        post_ability = event_loop.run_until_complete(data_svc.locate('abilities', dict(ability_id='123')))
         assert '127.0.0.1' == BaseWorld.get_config('app.contact.http')
         assert 'curl 127.0.0.1' == next(post_ability[0].executors).test
 
-    def test_update_config_plugin(self, loop, rest_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_update_config_plugin(self, event_loop, rest_svc):
+        internal_rest_svc = rest_svc(event_loop)
         # update plugin property
         assert ['sandcat', 'stockpile'] == BaseWorld.get_config('plugins')
-        loop.run_until_complete(internal_rest_svc.update_config(data=dict(prop='plugin', value='ssl')))
+        event_loop.run_until_complete(internal_rest_svc.update_config(data=dict(prop='plugin', value='ssl')))
         assert ['sandcat', 'stockpile', 'ssl'] == BaseWorld.get_config('plugins')
 
-    def test_create_operation(self, loop, rest_svc, data_svc):
+    def test_create_operation(self, event_loop, rest_svc, data_svc):
         want = {'name': 'Test',
                 'adversary': {'description': 'an empty adversary profile', 'name': 'ad-hoc', 'adversary_id': 'ad-hoc',
                               'atomic_ordering': [], 'objective': '495a9828-cab1-44dd-a0ca-66e58177d8cc', 'tags': [],
@@ -166,8 +166,8 @@ class TestRestSvc:
                      'host_ip_addrs': [], 'upstream_dest': '://None:None'}],
                 'visibility': 50, 'autonomous': 1, 'chain': [], 'auto_close': False, 'objective': '',
                 'obfuscator': 'plain-text', 'use_learning_parsers': False}
-        internal_rest_svc = rest_svc(loop)
-        operation = loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
+        internal_rest_svc = rest_svc(event_loop)
+        operation = event_loop.run_until_complete(internal_rest_svc.create_operation(access=dict(
             access=(internal_rest_svc.Access.RED, internal_rest_svc.Access.APP)),
             data=dict(name='Test', planner='test', source='123', state='finished')))
         operation[0].pop('id')
@@ -176,13 +176,13 @@ class TestRestSvc:
         operation[0]['host_group'][0].pop('created')
         assert want == operation[0]
 
-    def test_delete_ability(self, loop, rest_svc, file_svc):
-        internal_rest_svc = rest_svc(loop)
-        response = loop.run_until_complete(internal_rest_svc.delete_ability(data=dict(ability_id='123')))
+    def test_delete_ability(self, event_loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(event_loop)
+        response = event_loop.run_until_complete(internal_rest_svc.delete_ability(data=dict(ability_id='123')))
         assert 'Delete action completed' == response
 
-    def test_persist_objective_single_new(self, loop, rest_svc, file_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_persist_objective_single_new(self, event_loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(event_loop)
         req = {
                 'name': 'new objective',
                 'description': 'test new objective',
@@ -195,13 +195,13 @@ class TestRestSvc:
                     }
                 ]
             }
-        objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
+        objs = event_loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
         # clear out subobject difference
         objs[0]['goals'][0].pop('achieved')
         assert req.items() <= objs[0].items()
 
-    def test_persist_objective_single_existing(self, loop, rest_svc, file_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_persist_objective_single_existing(self, event_loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(event_loop)
         req = {
                 'name': 'new objective',
                 'description': 'test new objective',
@@ -214,17 +214,17 @@ class TestRestSvc:
                     }
                 ]
             }
-        objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
+        objs = event_loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, req))
         # clear out subobject difference
         objs[0]['goals'][0].pop('achieved')
         assert req.items() <= objs[0].items()
         # modify
         modified_req = {'id': objs[0]['id'], 'description': 'modified objective'}
-        modified_objs = loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, modified_req))
+        modified_objs = event_loop.run_until_complete(internal_rest_svc.persist_objective({'access': [BaseWorld.Access.RED]}, modified_req))
         assert modified_req.items() <= modified_objs[0].items()
 
-    def test_delete_adversary(self, loop, rest_svc, file_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_delete_adversary(self, event_loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(event_loop)
         data = """
 ---
 - id: 123
@@ -234,33 +234,33 @@ class TestRestSvc:
         """
         with open('data/adversaries/123.yml', 'w') as f:
             f.write(data)
-        response = loop.run_until_complete(internal_rest_svc.delete_adversary(data=dict(adversary_id='123')))
+        response = event_loop.run_until_complete(internal_rest_svc.delete_adversary(data=dict(adversary_id='123')))
         assert 'Delete action completed' == response
 
-    def test_delete_agent(self, loop, rest_svc, file_svc):
-        internal_rest_svc = rest_svc(loop)
-        response = loop.run_until_complete(internal_rest_svc.delete_agent(data=dict(paw='123')))
+    def test_delete_agent(self, event_loop, rest_svc, file_svc):
+        internal_rest_svc = rest_svc(event_loop)
+        response = event_loop.run_until_complete(internal_rest_svc.delete_agent(data=dict(paw='123')))
         assert 'Delete action completed' == response
 
-    def test_get_potential_links(self, loop, rest_svc, planning_svc, data_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_get_potential_links(self, event_loop, rest_svc, planning_svc, data_svc):
+        internal_rest_svc = rest_svc(event_loop)
         internal_rest_svc.add_service('planning_svc', planning_svc)
         internal_rest_svc.add_service('data_svc', data_svc)
-        links = loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
+        links = event_loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
         assert 1 == len(links['links'])
 
-    def test_apply_potential_link(self, loop, rest_svc, planning_svc, data_svc, app_svc):
-        internal_rest_svc = rest_svc(loop)
+    def test_apply_potential_link(self, event_loop, rest_svc, planning_svc, data_svc, app_svc):
+        internal_rest_svc = rest_svc(event_loop)
         internal_rest_svc.add_service('planning_svc', planning_svc)
         internal_rest_svc.add_service('data_svc', data_svc)
-        internal_rest_svc.add_service('app_svc', app_svc(loop))
-        loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
-        operation = loop.run_until_complete(data_svc.locate('operations', match=dict(id='123'))).pop()
+        internal_rest_svc.add_service('app_svc', app_svc)
+        event_loop.run_until_complete(internal_rest_svc.get_potential_links('123', '123'))
+        operation = event_loop.run_until_complete(data_svc.locate('operations', match=dict(id='123'))).pop()
         link = operation.potential_links[0]
-        loop.run_until_complete(internal_rest_svc.apply_potential_link(link))
+        event_loop.run_until_complete(internal_rest_svc.apply_potential_link(link))
         assert 1 == len(operation.chain)
 
-    def test_set_single_bootstrap_ability(self, loop, rest_svc):
+    def test_set_single_bootstrap_ability(self, event_loop, rest_svc):
         update_data = {
             'sleep_min': 5,
             'sleep_max': 5,
@@ -271,11 +271,11 @@ class TestRestSvc:
             'deadman_abilities': ''
         }
         want = ['123']
-        internal_rest_svc = rest_svc(loop)
-        agent_config = loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
+        internal_rest_svc = rest_svc(event_loop)
+        agent_config = event_loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
         assert agent_config.get('bootstrap_abilities') == want
 
-    def test_set_multiple_bootstrap_ability(self, loop, rest_svc):
+    def test_set_multiple_bootstrap_ability(self, event_loop, rest_svc):
         update_data = {
             'sleep_min': 5,
             'sleep_max': 5,
@@ -286,11 +286,11 @@ class TestRestSvc:
             'deadman_abilities': ''
         }
         want = ['123', '456', '789']
-        internal_rest_svc = rest_svc(loop)
-        agent_config = loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
+        internal_rest_svc = rest_svc(event_loop)
+        agent_config = event_loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
         assert agent_config.get('bootstrap_abilities') == want
 
-    def test_clear_bootstrap_deadman_ability(self, loop, rest_svc):
+    def test_clear_bootstrap_deadman_ability(self, event_loop, rest_svc):
         update_data = {
             'sleep_min': 5,
             'sleep_max': 5,
@@ -301,12 +301,12 @@ class TestRestSvc:
             'deadman_abilities': '',
         }
         want = []
-        internal_rest_svc = rest_svc(loop)
-        agent_config = loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
+        internal_rest_svc = rest_svc(event_loop)
+        agent_config = event_loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
         assert agent_config.get('bootstrap_abilities') == want
         assert agent_config.get('deadman_abilities') == want
 
-    def test_set_single_deadman_ability(self, loop, rest_svc):
+    def test_set_single_deadman_ability(self, event_loop, rest_svc):
         update_data = {
             'sleep_min': 5,
             'sleep_max': 5,
@@ -317,11 +317,11 @@ class TestRestSvc:
             'deadman_abilities': '123'
         }
         want = ['123']
-        internal_rest_svc = rest_svc(loop)
-        agent_config = loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
+        internal_rest_svc = rest_svc(event_loop)
+        agent_config = event_loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
         assert agent_config.get('deadman_abilities') == want
 
-    def test_set_multiple_deadman_ability(self, loop, rest_svc):
+    def test_set_multiple_deadman_ability(self, event_loop, rest_svc):
         update_data = {
             'sleep_min': 5,
             'sleep_max': 5,
@@ -332,6 +332,6 @@ class TestRestSvc:
             'deadman_abilities': '123, 456, 789'
         }
         want = ['123', '456', '789']
-        internal_rest_svc = rest_svc(loop)
-        agent_config = loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
+        internal_rest_svc = rest_svc(event_loop)
+        agent_config = event_loop.run_until_complete(internal_rest_svc.update_agent_data(update_data))
         assert agent_config.get('deadman_abilities') == want

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     codecov
 commands =
     py37: coverage run -p -m pytest --tb=short -Werror --asyncio-mode=auto tests
-    py{38,39}: coverage run -p -m pytest --tb=short --asyncio-mode=auto tests
+    py{38,39,310}: coverage run -p -m pytest --tb=short --asyncio-mode=auto tests
 
 [testenv:style]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ skip_missing_interpreters = true
 
 [testenv]
 description = run tests
-passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
+passenv = TOXENV CI
 deps =
     -rrequirements.txt
     virtualenv!=20.0.22
@@ -24,7 +24,6 @@ deps =
     pytest
     pytest-aiohttp
     coverage
-    codecov
 commands =
     py37: coverage run -p -m pytest --tb=short -Werror --asyncio-mode=auto tests
     py{38,39,310}: coverage run -p -m pytest --tb=short --asyncio-mode=auto tests

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ deps =
     coverage
     codecov
 commands =
-    py37: coverage run -p -m pytest --tb=short -Werror tests
-    py{38,39,310}: coverage run -p -m pytest --tb=short tests
+    py37: coverage run -p -m pytest --tb=short -Werror --asyncio-mode=auto tests
+    py{38,39}: coverage run -p -m pytest --tb=short --asyncio-mode=auto tests
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
## Description

`pytest-aiohttp` v1 has begun to use `pytest-asyncio` fixtures. This has deprecated many of the fixtures currently in-use in the CI pipeline causing consistent failure.

All tests have been refactored to replace the old `loop` fixture from `pytest-aiohttp` with the new `event_loop` fixture. Tests that did not require explicit use of the event loop have also been refactored as `async` tests.

In order to eliminate pipeline errors resulting from the ungraceful shutdown of contacts from the `contact_svc`, the `deregister_contacts` function has been implemented. This will loop through any registered contact and will call the `stop` function of the contact if it is defined. It has been implemented in the `contact_ftp` and `contact_websocket` contacts.

Quality gate fails due to lack of coverage for exception blocks and default teardown functionality not utilized in unit testing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Changes were tested with test runs across all versions locally and through workflow.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
