### PR TITLE
[VIRTS-3580] add facts to running operation via rest api

### DIFF
--- a/app/api/v2/handlers/fact_api.py
+++ b/app/api/v2/handlers/fact_api.py
@@ -86,10 +86,11 @@ class FactApi(BaseObjectApi):
             if 'source' not in fact_data:
                 new_fact.source = WILDCARD_STRING
             new_fact.origin_type = OriginType.USER
+            await self._api_manager.verify_operation_state(new_fact)
             await knowledge_svc_handle.add_fact(new_fact)
             store = await knowledge_svc_handle.get_facts(criteria=dict(trait=new_fact.trait,
                                                                        value=new_fact.value,
-                                                                       source=WILDCARD_STRING,
+                                                                       source=new_fact.source,
                                                                        origin_type=OriginType.USER))
             resp = await self._api_manager.verify_fact_integrity(store)
             return web.json_response(dict(added=resp))

--- a/app/api/v2/managers/fact_api_manager.py
+++ b/app/api/v2/managers/fact_api_manager.py
@@ -1,4 +1,5 @@
 from app.api.v2.managers.base_api_manager import BaseApiManager
+from app.objects.c_operation import InvalidOperationStateError
 from json import JSONDecodeError
 from app.api.v2.responses import JsonHttpBadRequest
 from aiohttp import web
@@ -43,12 +44,9 @@ class FactApiManager(BaseApiManager):
 
     async def verify_operation_state(self, new_fact):
         if self._data_svc.is_uuid4(new_fact.source):
-            try:
-                operation = (await self._data_svc.locate('operations', match=dict(id=new_fact.source)))[0]
-            except IndexError:
-                return
-            if operation and await operation.is_finished():
-                raise ValueError("Cannot add fact to finished operation.")
+            operation = (await self._data_svc.locate('operations', match=dict(id=new_fact.source)))
+            if operation and await operation[0].is_finished():
+                raise InvalidOperationStateError("Cannot add fact to finished operation.")
 
     @staticmethod
     async def copy_object(obj):

--- a/app/api/v2/managers/fact_api_manager.py
+++ b/app/api/v2/managers/fact_api_manager.py
@@ -41,6 +41,15 @@ class FactApiManager(BaseApiManager):
                 self.log.warning(f"Unable to properly display relationship {x}. Specific error encountered - {e}.")
         return out
 
+    async def verify_operation_state(self, new_fact):
+        if self._data_svc.is_uuid4(new_fact.source):
+            try:
+                operation = (await self._data_svc.locate('operations', match=dict(id=new_fact.source)))[0]
+            except IndexError:
+                return
+            if operation and await operation.is_finished():
+                raise ValueError("Cannot add fact to finished operation.")
+
     @staticmethod
     async def copy_object(obj):
         return copy.deepcopy(obj)

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -25,6 +25,10 @@ from app.utility.base_service import BaseService
 NO_PREVIOUS_STATE = object()
 
 
+class InvalidOperationStateError(Exception):
+    pass
+
+
 class OperationOutputRequestSchema(ma.Schema):
     enable_agent_output = ma.fields.Boolean(default=False)
 

--- a/tests/api/v2/handlers/test_operations_api.py
+++ b/tests/api/v2/handlers/test_operations_api.py
@@ -216,9 +216,11 @@ class TestOperationsApi:
             assert op.name == test_operation['name']
             assert op.planner.name == test_operation['planner']['name']
 
-    async def test_update_finished_operation(self, api_v2_client, api_cookies, setup_finished_operation):
+    async def test_update_finished_operation(self, api_v2_client, api_cookies, setup_finished_operation,
+                                             finished_operation_payload):
         payload = dict(state='running', obfuscator='base64')
-        resp = await api_v2_client.patch('/api/v2/operations/000', cookies=api_cookies, json=payload)
+        op_id = finished_operation_payload['id']
+        resp = await api_v2_client.patch(f'/api/v2/operations/{op_id}', cookies=api_cookies, json=payload)
         assert resp.status == HTTPStatus.BAD_REQUEST
 
     async def test_get_links(self, api_v2_client, api_cookies, active_link):

--- a/tests/api/v2/test_knowledge.py
+++ b/tests/api/v2/test_knowledge.py
@@ -40,14 +40,13 @@ def base_world():
 
 
 @pytest.fixture
-def knowledge_webapp(loop, app_svc, base_world, data_svc):
-    link = app_svc(loop)
-    link.add_service('auth_svc', AuthService())
-    link.add_service('knowledge_svc', KnowledgeService())
-    link.add_service('data_svc', DataService())
-    link.add_service('event_svc', EventService())
-    link.add_service('file_svc', FileSvc())  # This needs to be done this way, or it we won't have a valid BaseWorld
-    services = link.get_services()
+def knowledge_webapp(event_loop, app_svc, base_world, data_svc):
+    app_svc.add_service('auth_svc', AuthService())
+    app_svc.add_service('knowledge_svc', KnowledgeService())
+    app_svc.add_service('data_svc', DataService())
+    app_svc.add_service('event_svc', EventService())
+    app_svc.add_service('file_svc', FileSvc())  # This needs to be done this way, or it we won't have a valid BaseWorld
+    services = app_svc.get_services()
     app = web.Application(
         middlewares=[
             authentication_required_middleware_factory(services['auth_svc']),

--- a/tests/api/v2/test_knowledge.py
+++ b/tests/api/v2/test_knowledge.py
@@ -223,6 +223,7 @@ async def test_add_fact_to_finished_operation(knowledge_webapp, aiohttp_client, 
     resp = await client.post('/facts', json=fact_data, headers=headers)
     data = await resp.json()
     assert 'error' in data
+    assert 'Cannot add fact to finished operation.' in data['error']
 
 
 async def test_add_relationship(knowledge_webapp, aiohttp_client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -552,10 +552,17 @@ def finished_link(test_executor, test_agent, test_ability):
 
 
 @pytest.fixture
-def setup_finished_operation(loop, test_operation):
-    finished_operation = OperationSchema().load(test_operation)
-    finished_operation.id = '000'
-    finished_operation.state = 'finished'
+def finished_operation_payload(test_operation):
+    op_id = "00000000-0000-0000-0000-000000000000"
+    test_operation['id'] = op_id
+    test_operation['name'] = op_id
+    test_operation['state'] = 'finished'
+    return test_operation
+
+
+@pytest.fixture
+def setup_finished_operation(loop, finished_operation_payload):
+    finished_operation = OperationSchema().load(finished_operation_payload)
     loop.run_until_complete(BaseService.get_service('data_svc').store(finished_operation))
 
 
@@ -572,6 +579,15 @@ def setup_operations_api_test(loop, api_v2_client, test_operation, test_agent, t
     finished_link.host = test_agent.host
     test_operation.chain.append(test_link)
     test_operation.chain.append(finished_link)
+    test_objective = Objective(id='123', name='test objective', description='test', goals=[])
+    test_operation.objective = test_objective
+    loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))
+
+
+@pytest.fixture
+def setup_empty_operation(loop, test_operation):
+    test_operation = OperationSchema().load(test_operation)
+    test_operation.set_start_details()
     test_objective = Objective(id='123', name='test objective', description='test', goals=[])
     test_operation.objective = test_objective
     loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,9 +567,9 @@ def finished_operation_payload(test_operation):
 
 
 @pytest.fixture
-def setup_finished_operation(loop, finished_operation_payload):
+def setup_finished_operation(event_loop, finished_operation_payload):
     finished_operation = OperationSchema().load(finished_operation_payload)
-    loop.run_until_complete(BaseService.get_service('data_svc').store(finished_operation))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(finished_operation))
 
 
 @pytest.fixture
@@ -587,14 +587,13 @@ def setup_operations_api_test(event_loop, api_v2_client, test_operation, test_ag
     test_operation.chain.append(finished_link)
     test_objective = Objective(id='123', name='test objective', description='test', goals=[])
     test_operation.objective = test_objective
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))
 
 
 @pytest.fixture
-def setup_empty_operation(loop, test_operation):
+def setup_empty_operation(event_loop, test_operation):
     test_operation = OperationSchema().load(test_operation)
     test_operation.set_start_details()
     test_objective = Objective(id='123', name='test objective', description='test', goals=[])
     test_operation.objective = test_objective
-    loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))
-
+    event_loop.run_until_complete(BaseService.get_service('data_svc').store(test_operation))


### PR DESCRIPTION
## Description
Two small changes to the Facts API:
* fixed bug where user-provided source was not added to the "get facts" criteria after creating a new fact
* Checks if source operation is finished (in which case a fact cannot be added with said source)

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added additional Pytests for changes. Additionally tested manually using Postman, verifying that a fact added through the API (and with the source being a running operation ID) would appear in the "facts" section of the Operation report. Additionally, if you test with an adversary profile (ex. "thief"), facts can be added by pausing the operation at the beginning, submitting the POST request, and then continuing the operation before the ability requiring said fact executes. Note that you may have to update rules depending on the fact source used for the operation.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
