### PR TITLE
Fix Jitter min/max input errors

### DIFF
--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -461,12 +461,6 @@ p[onclick] {
   text-align: left;
 }
 
-.section-profile input {
-  height: 18px;
-  width: 75%;
-  margin: 5px;
-}
-
 .section-profile input[type=checkbox] {
   width: auto;
   vertical-align: middle;

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -641,7 +641,7 @@
                                             x-bind:data-tooltip="usage['Jitter']">Jitter (sec/sec)</span></label>
                                     <div class="modal-form-fields" id="stealth-jitter">
                                         <input class="input"
-                                               x-on:change.debounce.500ms="validateJitter(operationToStart, jitterMin+'/'+jitterMax)"
+                                               x-on:change.debounce.500ms="validateJitter()"
                                                x-model="jitterMin"
                                                id="stealth-jitterMin"
                                                type="number"
@@ -651,7 +651,7 @@
                                         <label class="input-hover-label" for="stealth-jitterMin">min</label>
                                         <span>/</span>
                                         <input class="input"
-                                               x-on:change.debounce.500ms="validateJitter(operationToStart, jitterMin+'/'+jitterMax)"
+                                               x-on:change.debounce.500ms="validateJitter()"
                                                x-model="jitterMax"
                                                id="stealth-jitterMax"
                                                type="number"
@@ -1657,11 +1657,9 @@
                 }
             },
 
-            validateJitter(newValue = '') {
-                if (!newValue.includes('/')) return false;
-                let [jitterMin, jitterMax] = newValue.split('/');
-                jitterMin = parseInt(jitterMin, 10);
-                jitterMax = parseInt(jitterMax, 10);
+            validateJitter() {
+                jitterMin = parseInt(this.jitterMin, 10);
+                jitterMax = parseInt(this.jitterMax, 10);
 
                 if (jitterMin < 0 || jitterMax < 0) {
                     toast(`Error: Jitter ${!jitterMin ? 'MIN' : 'MAX'} must be valid.`);
@@ -1672,7 +1670,7 @@
                     return false;
                 }
 
-                this.operationToStart.jitter = newValue;
+                this.operationToStart.jitter = `${jitterMin}/${jitterMax}`;
                 return true;
             },
 


### PR DESCRIPTION
## Description

Fixes the validateJitter function so that the correct min/max is sent to the API for the operation to start.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No console errors when starting an operation or changing Jitter values.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
