### PR TITLE
[VIRTS-2551] Fix Duplicate Adversary Bug

### DIFF
--- a/tests/api/v2/handlers/test_adversaries_api.py
+++ b/tests/api/v2/handlers/test_adversaries_api.py
@@ -18,6 +18,13 @@ def updated_adversary_payload():
 
 
 @pytest.fixture
+def invalid_updated_adversary_payload(updated_adversary_payload):
+    payload = updated_adversary_payload.copy()
+    payload['id'] = '000'
+    return payload
+
+
+@pytest.fixture
 def expected_updated_adversary_dump(test_adversary, updated_adversary_payload):
     adversary_dict = test_adversary.schema.dump(test_adversary)
     adversary_dict.update(updated_adversary_payload)
@@ -40,6 +47,28 @@ def new_adversary_payload():
 @pytest.fixture
 def expected_new_adversary_dump(new_adversary_payload):
     adversary = Adversary.load(new_adversary_payload)
+    return adversary.schema.dump(adversary)
+
+
+@pytest.fixture
+def new_adversary_duplicate_id_payload():
+    return {
+        'name': 'test new adversary',
+        'description': 'a new adversary with an invalid payload',
+        'adversary_id': '456',
+        'id': '000',
+        'objective': '495a9828-cab1-44dd-a0ca-66e58177d8cc',
+        'tags': [],
+        'atomic_ordering': [],
+        'plugin': ''
+    }
+
+
+@pytest.fixture
+def expected_new_duplicate_id_adversary_dump(new_adversary_duplicate_id_payload):
+    payload = new_adversary_duplicate_id_payload.copy()
+    payload.pop('id')
+    adversary = Adversary.load(payload)
     return adversary.schema.dump(adversary)
 
 
@@ -93,6 +122,20 @@ class TestAdversariesApi:
                                                                 match={'adversary_id': output['adversary_id']})
         assert output == expected_new_adversary_dump
 
+    async def test_create_adversary_with_invalid_payload(self, api_v2_client, api_cookies, test_adversary,
+                                                         new_adversary_duplicate_id_payload,
+                                                         expected_new_duplicate_id_adversary_dump):
+        resp = await api_v2_client.post('/api/v2/adversaries', cookies=api_cookies,
+                                        json=new_adversary_duplicate_id_payload)
+        assert resp.status == HTTPStatus.OK
+        invalid_id = new_adversary_duplicate_id_payload['id']
+        assert not (await BaseService.get_service('data_svc').locate('adversaries',
+                                                                     match={'adversary_id': invalid_id}))
+        output = await resp.json()
+        assert await BaseService.get_service('data_svc').locate('adversaries',
+                                                                match={'adversary_id': output['adversary_id']})
+        assert output == expected_new_duplicate_id_adversary_dump
+
     async def test_unauthorized_create_adversary(self, api_v2_client, test_adversary, new_adversary_payload):
         resp = await api_v2_client.post('/api/v2/adversaries', json=new_adversary_payload)
         assert resp.status == HTTPStatus.UNAUTHORIZED
@@ -114,6 +157,22 @@ class TestAdversariesApi:
                 output = await resp.json()
                 assert output == expected_updated_adversary_dump
 
+    async def test_update_adversary_invalid_payload(self, api_v2_client, api_cookies, test_adversary,
+                                                    updated_adversary_payload, invalid_updated_adversary_payload,
+                                                    mocker, expected_updated_adversary_dump):
+        with mocker.patch('app.api.v2.managers.adversary_api_manager.AdversaryApiManager.strip_yml') as mock_strip_yml:
+            mock_strip_yml.return_value = [test_adversary.schema.dump(test_adversary)]
+            with mocker.patch('app.objects.c_adversary.Adversary.verify') as mock_verify:
+                mock_verify.return_value = None
+                resp = await api_v2_client.patch(f'/api/v2/adversaries/{test_adversary.adversary_id}',
+                                                 cookies=api_cookies, json=invalid_updated_adversary_payload)
+                assert resp.status == HTTPStatus.OK
+                output = await resp.json()
+                assert output == expected_updated_adversary_dump
+                invalid_id = invalid_updated_adversary_payload['id']
+                assert not (await BaseService.get_service('data_svc').locate('adversaries',
+                                                                             match={'adversary_id': invalid_id}))
+
     async def test_unauthorized_update_adversary(self, api_v2_client, test_adversary, updated_adversary_payload):
         resp = await api_v2_client.patch('/api/v2/adversaries/123', json=updated_adversary_payload)
         assert resp.status == HTTPStatus.UNAUTHORIZED
@@ -131,6 +190,21 @@ class TestAdversariesApi:
             assert resp.status == HTTPStatus.OK
             output = await resp.json()
             assert output == expected_updated_adversary_dump
+
+    async def test_create_or_update_adversary_with_invalid_payload(self, api_v2_client, api_cookies, mocker,
+                                                                   new_adversary_duplicate_id_payload,
+                                                                   expected_new_duplicate_id_adversary_dump):
+        with mocker.patch('app.objects.c_adversary.Adversary.verify') as mock_verify:
+            mock_verify.return_value = None
+            valid_id = new_adversary_duplicate_id_payload.get('adversary_id')
+            invalid_id = new_adversary_duplicate_id_payload.get('id')
+            resp = await api_v2_client.put(f'/api/v2/adversaries/{valid_id}', cookies=api_cookies,
+                                           json=new_adversary_duplicate_id_payload)
+            assert resp.status == HTTPStatus.OK
+            output = await resp.json()
+            assert output == expected_new_duplicate_id_adversary_dump
+            assert not (await BaseService.get_service('data_svc').locate('adversaries',
+                                                                         match={'adversary_id': invalid_id}))
 
     async def test_unauthorized_create_or_update_adversary(self, api_v2_client, test_adversary, new_adversary_payload):
         resp = await api_v2_client.put('/api/v2/adversaries/123', json=new_adversary_payload)


### PR DESCRIPTION
## Description
There is a slight difference in UUID keys for adversary yaml files and adversary objects. In yaml files, this key is `id`, and in adversary objects, it is `adversary_id`. Because of this mismatch, UUIDs need to be converted when objects are dumped/loaded. This was working correctly when loading from adversary yaml files, but if users included the "id" key in a `POST /api/v2/adversaries payload`, the request would end in a HTTP 500 error (despite `id` not being a key in the Adversary Schema). Two adversary yaml files would be generated as well. 

This PR pops the `id` key from API requests, as they should only expect the `adversary_id` key for UUIDs.
 
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added pytests with invalid payloads to show that invalid `id` keys will be removed, and adversaries will be created successfully.

Additionally tested using postman, adding in both `id` and `adversary_id` keys to verify that only one adversary was created.

An example curl request:

```
curl --location --request POST 'localhost:8888/api/v2/adversaries' \
--header 'KEY: $API_KEY' \
--header 'Content-Type: application/json' \
--data-raw '{
    "atomic_ordering": [
    ],
    "tags": [],
    "has_repeatable_abilities": false,
    "plugin": "stockpile",
    "name": "Test Adversary",
    "description": "Test adversary for API",
    "objective": "495a9828-cab1-44dd-a0ca-66e58177d8cc",
    "adversary_id": "729d604b-b06b-4134-bd43-80a240494e66",
    "id": "729d604b-0000-4134-bd43-80a240494e66"
}'
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
