### PR TITLE
Fix error when adding a potential link w/r/t its command

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1433,6 +1433,8 @@
                         })
                     })
                 });
+
+                this.setPotentialLinksToAdd();
             },
 
             setPotentialLinksToAdd() {


### PR DESCRIPTION
## Description

Potential links could not be added to an operations because the command for the executor was not set before the POST request was made. This PR makes it so the command is added to the body of the request.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Users can now add potential links


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
