### PR TITLE
Highlight slack instead of email in welcome banner

### DIFF
--- a/templates/BLUE.html
+++ b/templates/BLUE.html
@@ -134,8 +134,8 @@
                                 <label class="label">📚 Learn</label>
                                 <div class="is-flex is-justify-content-space-between">
                                     <p>
-                                        Never used CALDERA before? The training plugin will walk you through all the capabilities of the platform
-                                        in hands-on, capture-the-flag style exercises.
+                                        Never used CALDERA before? The User Certificate in the training plugin will walk you through all 
+                                        the capabilities of the platform in hands-on, capture-the-flag style exercises.
                                     </p>
                                     <button class="button is-small is-primary" @click="addTab('training', '/plugin/training/gui'); isFirstVisit = false">Start Training</button>
                                 </div>
@@ -151,14 +151,14 @@
                             </div>
                             <div class="block">
                                 <label class="label">📬 Get in touch</label>
-                                <div class="is-flex is-justify-content-left">
-                                    <a class="button is-small is-primary mr-2" href="mailto:caldera@mitre.org">
-                                        <span class="icon"><em class="far fa-envelope"></em></span>
-                                        <span>Email us</span>
-                                    </a>
+                                <div class="buttons">
                                     <a class="button is-small is-primary" target="_blank" rel="noopener" href="https://join.slack.com/t/mitre-caldera/shared_invite/zt-rvngjjpw-OQHAqpUT87DcyClTosF8dQ">
                                         <span class="icon"><em class="fab fa-slack"></em></span>
                                         <span>Join our Slack</span>
+                                    </a>
+                                    <a class="button is-small" href="mailto:caldera@mitre.org">
+                                        <span class="icon"><em class="far fa-envelope"></em></span>
+                                        <span>Email us</span>
                                     </a>
                                 </div>
                             </div>

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -170,8 +170,8 @@
                                 <label class="label">📚 Learn</label>
                                 <div class="is-flex is-justify-content-space-between">
                                     <p>
-                                        Never used CALDERA before? The training plugin will walk you through all the capabilities of the platform
-                                        in hands-on, capture-the-flag style exercises.
+                                        Never used CALDERA before? The User Certificate in the training plugin will walk you through all 
+                                        the capabilities of the platform in hands-on, capture-the-flag style exercises.
                                     </p>
                                     <button class="button is-small is-primary" @click="addTab('training', '/plugin/training/gui'); isFirstVisit = false">Start Training</button>
                                 </div>
@@ -187,14 +187,14 @@
                             </div>
                             <div class="block">
                                 <label class="label">📬 Get in touch</label>
-                                <div class="is-flex is-justify-content-left">
-                                    <a class="button is-small is-primary mr-2" href="mailto:caldera@mitre.org">
-                                        <span class="icon"><em class="far fa-envelope"></em></span>
-                                        <span>Email us</span>
-                                    </a>
+                                <div class="buttons">
                                     <a class="button is-small is-primary" target="_blank" rel="noopener" href="https://join.slack.com/t/mitre-caldera/shared_invite/zt-rvngjjpw-OQHAqpUT87DcyClTosF8dQ">
                                         <span class="icon"><em class="fab fa-slack"></em></span>
                                         <span>Join our Slack</span>
+                                    </a>
+                                    <a class="button is-small" href="mailto:caldera@mitre.org">
+                                        <span class="icon"><em class="far fa-envelope"></em></span>
+                                        <span>Email us</span>
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
## Description

This PR rearranges the Contact Us buttons in the welcome banner to prioritize slack over email. It also mentions the User Certificate in the training section to give new users more direction in where to start.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Banner shows the same both as a Blue and Red user.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
