### PR TITLE
Set jitter at time of operation creation

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -682,9 +682,6 @@
                                             Min and Max need to be >= 0, and Min must be <= Max
                                         </p>
                                     </div>
-                                    <p x-show="!isJitterValid()" class="help has-text-danger">
-                                        Min and Max need to be >= 0, and Min must be <= Max
-                                    </p>
                                 </div>
                                 <div>
                                     <label for="stealth-queue"><span

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1306,7 +1306,9 @@
 
             addOperation() {
                 if (!this.operationToStart.name) {
-                    toast('Error: Operation name field is empty.');
+                    toast('Error: Operation name field is empty.', false);
+                } else if (!this.isJitterValid()) {
+                    toast('Jitter values are invalid', false);
                 } else {
                     this.operationToStart.autonomous = Number(this.operationToStart.autonomous);
                     this.operationToStart.use_learning_parsers = parseInt(this.operationToStart.use_learning_parsers, 10) === 1;

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -678,6 +678,9 @@
                                                 x-on:click="jitterMin = 2; jitterMax = 8;">
                                             Reset
                                         </button>
+                                        <p x-show="!isJitterValid()" class="pl-3 help has-text-danger">
+                                            Min and Max need to be >= 0, and Min must be <= Max
+                                        </p>
                                     </div>
                                     <p x-show="!isJitterValid()" class="help has-text-danger">
                                         Min and Max need to be >= 0, and Min must be <= Max

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -655,7 +655,7 @@
                                             x-bind:data-tooltip="usage['Jitter']">Jitter (sec/sec)</span></label>
                                     <div class="modal-form-fields" id="stealth-jitter">
                                         <input class="input"
-                                               x-on:change.debounce.500ms="validateJitter()"
+                                               :class="{ 'is-danger': !isJitterValid() }"
                                                x-model="jitterMin"
                                                id="stealth-jitterMin"
                                                type="number"
@@ -665,7 +665,7 @@
                                         <label class="input-hover-label" for="stealth-jitterMin">min</label>
                                         <span>/</span>
                                         <input class="input"
-                                               x-on:change.debounce.500ms="validateJitter()"
+                                               :class="{ 'is-danger': !isJitterValid() }"
                                                x-model="jitterMax"
                                                id="stealth-jitterMax"
                                                type="number"
@@ -679,6 +679,9 @@
                                             Reset
                                         </button>
                                     </div>
+                                    <p x-show="!isJitterValid()" class="help has-text-danger">
+                                        Min and Max need to be >= 0, and Min must be <= Max
+                                    </p>
                                 </div>
                                 <div>
                                     <label for="stealth-queue"><span
@@ -1308,6 +1311,7 @@
                     this.operationToStart.autonomous = Number(this.operationToStart.autonomous);
                     this.operationToStart.use_learning_parsers = parseInt(this.operationToStart.use_learning_parsers, 10) === 1;
                     this.operationToStart.auto_close = parseInt(this.operationToStart.auto_close, 10) === 1;
+                    this.operationToStart.jitter = `${parseInt(this.jitterMin, 10)}/${parseInt(this.jitterMax, 10)}`;
                     apiV2('POST', this.ENDPOINT, this.operationToStart).then((newOperation) => {
                         toast(`Started operation ${this.operationToStart.name}!`, true);
                         this.operations.push(newOperation);
@@ -1673,21 +1677,10 @@
                 }
             },
 
-            validateJitter() {
-                jitterMin = parseInt(this.jitterMin, 10);
-                jitterMax = parseInt(this.jitterMax, 10);
-
-                if (jitterMin < 0 || jitterMax < 0) {
-                    toast(`Error: Jitter ${!jitterMin ? 'MIN' : 'MAX'} must be valid.`);
-                    return false;
-                }
-                if (jitterMin >= jitterMax) {
-                    toast('Error: Jitter MIN must be less than the jitter MAX.');
-                    return false;
-                }
-
-                this.operationToStart.jitter = `${jitterMin}/${jitterMax}`;
-                return true;
+            isJitterValid() {
+                const jitterMin = parseInt(this.jitterMin, 10);
+                const jitterMax = parseInt(this.jitterMax, 10); 
+                return (jitterMin >= 0 && jitterMax >= 0 && jitterMin <= jitterMax) 
             },
 
             filterAbilities(abilities) {


### PR DESCRIPTION
## Description

When jitter min or max was entered too quickly, the values would not be set correctly before the operation is created. There was also a potential that the toasts would spam the interface, so this opts for a warning label instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Incorrect values are correctly caught, and the operations jitter is set correctly.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
