### PR TITLE
Remove duplicate group options

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1065,7 +1065,7 @@
 
             docs: '{{ usage | tojson }}'.toString().replace(/["\[\]]/g, '').split('}'),
             usage: {},
-            agentGroups: '{{ groups | tojson }}'.toString().replace(/["\[\]]/g, '').split(','),
+            agentGroups: [],
             selectedOperationID: '',
             selectedOperation: null,
             selectedAgentIndex: 0,
@@ -1666,11 +1666,8 @@
             },
 
             updateAgentGroups(agents) {
-                if (agents) {
-                    agents.forEach((agent) => {
-                        if (!this.agentGroups.includes(agent.group)) this.agentGroups.push(agent.group);
-                    });
-                }
+                if (!agents) return;
+                this.agentGroups = [...new Set(agents.map((agent) => agent.group))];
             },
 
             validateJitter() {


### PR DESCRIPTION
## Description

When creating an operation, most of the groups would have duplicate options. This PR ensures that all options are unique.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

When creating an operation only unique group values are displayed.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
