### PR TITLE
Allow passing in location when retrieving compiled payloads

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -118,8 +118,8 @@ class AppService(AppServiceInterface, BaseService):
         templates.append('templates')
         aiohttp_jinja2.setup(self.application, loader=jinja2.FileSystemLoader(templates))
 
-    async def retrieve_compiled_file(self, name, platform):
-        _, path = await self._services.get('file_svc').find_file_path('%s-%s' % (name, platform))
+    async def retrieve_compiled_file(self, name, platform, location=''):
+        _, path = await self._services.get('file_svc').find_file_path('%s-%s' % (name, platform), location=location)
         signature = hashlib.sha256(open(path, 'rb').read()).hexdigest()
         display_name = await self._services.get('contact_svc').build_filename()
         self.log.debug('%s downloaded with hash=%s and name=%s' % (name, signature, display_name))

--- a/app/service/interfaces/i_app_svc.py
+++ b/app/service/interfaces/i_app_svc.py
@@ -53,7 +53,7 @@ class AppServiceInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def retrieve_compiled_file(self, name, platform):
+    def retrieve_compiled_file(self, name, platform, location=''):
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
## Description
To restrict compiled payload searches to the `payload` directory of plugins, we can leverage the `location` parameter in the file service's `find_file_path` function. Default behavior has not been changed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested in the sandcat plugin by specifying the `payloads` folder location - the correct sandcat.go-windows binary was picked up rather than a different binary in a separate plugin directory under a different folder structure.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
