### PR TITLE
[VIRTS-3150] added adversary apispec desc/params

### DIFF
--- a/app/api/v2/handlers/adversary_api.py
+++ b/app/api/v2/handlers/adversary_api.py
@@ -23,46 +23,95 @@ class AdversaryApi(BaseObjectApi):
         router.add_put(adversaries_by_id_path, self.create_or_update_adversary)
         router.add_delete(adversaries_by_id_path, self.delete_adversary)
 
-    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.docs(tags=['adversaries'],
+                          summary='Retrieve all adversaries',
+                          description='Returns a list of all available adversaries in the system, including plugin, name, description, '
+                          'and atomic ordering. Supply fields from the `AdversarySchema` to the include and exclude fields of the '
+                          '`BaseGetAllQuerySchema` in the request body to filter retrieved adversaries.')
     @aiohttp_apispec.querystring_schema(BaseGetAllQuerySchema)
-    @aiohttp_apispec.response_schema(AdversarySchema(many=True, partial=True))
+    @aiohttp_apispec.response_schema(AdversarySchema(many=True, partial=True),
+                                     description='Returns a list in `AdversarySchema` format of all available adversaries in the system.')
     async def get_adversaries(self, request: web.Request):
         adversaries = await self.get_all_objects(request)
         return web.json_response(adversaries)
 
-    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.docs(tags=['adversaries'],
+                          summary='Retrieve adversary by ID',
+                          description='Retrieve one adversary by ID. Use fields from the `AdversarySchema` in '
+                                      'the request body to filter retrieved adversary.',
+                          parameters=[{
+                            'in': 'path',
+                            'name': 'adversary_id',
+                            'schema': {'type': 'string'},
+                            'required': 'true',
+                            'description': 'UUID of the adversary to be retrieved'}])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
-    @aiohttp_apispec.response_schema(AdversarySchema(partial=True))
+    @aiohttp_apispec.response_schema(AdversarySchema(partial=True),
+                                     description='Returns single objective in AdversarySchema format.')
     async def get_adversary_by_id(self, request: web.Request):
         adversary = await self.get_object(request)
         return web.json_response(adversary)
 
-    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.docs(tags=['adversaries'],
+                          summary='Create a new adversary',
+                          description='Create a new adversary using the format provided in the `AdversarySchema`.')
     @aiohttp_apispec.request_schema(AdversarySchema)
-    @aiohttp_apispec.response_schema(AdversarySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema, description='A single adversary in AdversarySchema format.')
     async def create_adversary(self, request: web.Request):
         adversary = await self.create_on_disk_object(request)
         adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
+    @aiohttp_apispec.docs(tags=['adversaries'],
+                          summary='Update an adversary',
+                          description='Update an adversary using fields from the `AdversarySchema` in the request body.',
+                          parameters=[{
+                            'in': 'path',
+                            'name': 'adversary_id',
+                            'schema': {'type': 'string'},
+                            'required': 'true',
+                            'description': 'UUID of the adversary to be updated'
+                          }])
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True, exclude=['adversary_id']))
-    @aiohttp_apispec.response_schema(AdversarySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema,
+                                     description='The updated Objective in ObjectiveSchema format.')
     async def update_adversary(self, request: web.Request):
         adversary = await self.update_on_disk_object(request)
         adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
-    @aiohttp_apispec.docs(tags=['adversaries'])
+    @aiohttp_apispec.docs(tags=['adversaries'],
+                          summary='Create or update an adversary',
+                          description='Attempt to update an adversaries using fields from the `AdversarySchema` '
+                          'in the request body. If the adversary does not already exist, '
+                          'then create a new one using the `AdversarySchema` format.',
+                          parameters=[{
+                            'in': 'path',
+                            'name': 'adversary_id',
+                            'schema': {'type': 'string'},
+                            'required': 'true',
+                            'description': 'UUID of the adversaries to be created or updated'
+                          }])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
-    @aiohttp_apispec.response_schema(AdversarySchema)
+    @aiohttp_apispec.response_schema(AdversarySchema,
+                                     description='A single adversaries, either newly created or updated, in AdversarySchema format.')
     async def create_or_update_adversary(self, request: web.Request):
         adversary = await self.create_or_update_on_disk_object(request)
         adversary = await self._api_manager.verify_adversary(adversary)
         return web.json_response(adversary.display)
 
-    @aiohttp_apispec.docs(tags=['adversaries'])
-    @aiohttp_apispec.response_schema(AdversarySchema)
+    @aiohttp_apispec.docs(tags=['adversaries'], summary='Deletes an adversary.',
+                          description='Deletes an existing adversary.',
+                          parameters=[{
+                              'in': 'path',
+                              'name': 'adversary_id',
+                              'schema': {'type': 'string'},
+                              'required': 'true',
+                              'description': 'UUID of the Adversary to be retrieved'
+                          }])
+    @aiohttp_apispec.response_schema(AdversarySchema(partial=True), code=204,
+                                     description='HTTP 204 Status Code (No Content)')
     async def delete_adversary(self, request: web.Request):
         await self.delete_on_disk_object(request)
         return web.HTTPNoContent()

--- a/app/api/v2/handlers/adversary_api.py
+++ b/app/api/v2/handlers/adversary_api.py
@@ -47,7 +47,7 @@ class AdversaryApi(BaseObjectApi):
                             'description': 'UUID of the adversary to be retrieved'}])
     @aiohttp_apispec.querystring_schema(BaseGetOneQuerySchema)
     @aiohttp_apispec.response_schema(AdversarySchema(partial=True),
-                                     description='Returns single objective in AdversarySchema format.')
+                                     description='Returns single adversary in AdversarySchema format.')
     async def get_adversary_by_id(self, request: web.Request):
         adversary = await self.get_object(request)
         return web.json_response(adversary)
@@ -75,7 +75,7 @@ class AdversaryApi(BaseObjectApi):
     @aiohttp_apispec.docs(tags=['adversaries'])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True, exclude=['adversary_id']))
     @aiohttp_apispec.response_schema(AdversarySchema,
-                                     description='The updated Objective in ObjectiveSchema format.')
+                                     description='The updated adversary in AdversarySchema format.')
     async def update_adversary(self, request: web.Request):
         adversary = await self.update_on_disk_object(request)
         adversary = await self._api_manager.verify_adversary(adversary)
@@ -91,11 +91,11 @@ class AdversaryApi(BaseObjectApi):
                             'name': 'adversary_id',
                             'schema': {'type': 'string'},
                             'required': 'true',
-                            'description': 'UUID of the adversaries to be created or updated'
+                            'description': 'UUID of the adversary to be created or updated'
                           }])
     @aiohttp_apispec.request_schema(AdversarySchema(partial=True))
     @aiohttp_apispec.response_schema(AdversarySchema,
-                                     description='A single adversaries, either newly created or updated, in AdversarySchema format.')
+                                     description='A single adversary, either newly created or updated, in AdversarySchema format.')
     async def create_or_update_adversary(self, request: web.Request):
         adversary = await self.create_or_update_on_disk_object(request)
         adversary = await self._api_manager.verify_adversary(adversary)
@@ -108,7 +108,7 @@ class AdversaryApi(BaseObjectApi):
                               'name': 'adversary_id',
                               'schema': {'type': 'string'},
                               'required': 'true',
-                              'description': 'UUID of the Adversary to be retrieved'
+                              'description': 'UUID of the adversary to be retrieved'
                           }])
     @aiohttp_apispec.response_schema(AdversarySchema(partial=True), code=204,
                                      description='HTTP 204 Status Code (No Content)')


### PR DESCRIPTION
## Description

Added to the Adversary apispec docs for the HEAD/GET/POST/PATCH/DELETE requests to the /api​/v2​/adversaries and /api​/v2​/adversaries​/{adversary_id} API endpoints.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All descriptions and summaries appear in Swagger documentation.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
