### PR TITLE
Remove quirks mode, enable standard mode for browser

### DIFF
--- a/templates/BLUE.html
+++ b/templates/BLUE.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>Blue | CALDERA</title>

--- a/templates/RED.html
+++ b/templates/RED.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>Red | CALDERA</title>


### PR DESCRIPTION
## Description

This PR enables Standards Mode in the browser by simply adding a `DOCTYPE` to the root HTML elements. Without it, the browser is in legacy (quirks) mode, which supports the HTML standard way back to the Netscape days. Standards mode _should_ make the browser abide by modern HTML and CSS standards.

[Read more about it here](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Quirks mode warning in FF disappeared.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
