### PR TITLE
Remove 404 errors on page load for contacts

### DIFF
--- a/app/api/v2/handlers/contact_api.py
+++ b/app/api/v2/handlers/contact_api.py
@@ -37,9 +37,9 @@ class ContactApi(BaseApi):
 
     @aiohttp_apispec.docs(tags=['contacts'],
                           summary='Retrieve a List of all available Contact reports',
-                          description='Returns a list of contact reports that are available for download.'
-                                      ' As soon as any agent beacons over a given contact, the report will'
-                                      ' be available for download.')
+                          description='Returns a list of contacts that at least one agent has beaconed to.'
+                                      ' As soon as any agent beacons over a given contact, the contact'
+                                      ' will be returned here.')
     async def get_available_contact_reports(self, request: web.Request):
         contacts = self._api_manager.get_available_contact_reports()
         return web.json_response(contacts)

--- a/app/api/v2/handlers/contact_api.py
+++ b/app/api/v2/handlers/contact_api.py
@@ -14,6 +14,7 @@ class ContactApi(BaseApi):
     def add_routes(self, app: web.Application):
         router = app.router
         router.add_get('/contacts/{name}', self.get_contact_report)
+        router.add_get('/contacts', self.get_available_contact_reports)
 
     @aiohttp_apispec.docs(tags=['contacts'],
                           summary='Retrieve a List of Beacons made by Agents to the specified Contact',
@@ -33,3 +34,12 @@ class ContactApi(BaseApi):
         contact_name = request.match_info['name']
         report = self._api_manager.get_contact_report(contact_name)
         return web.json_response(report)
+
+    @aiohttp_apispec.docs(tags=['contacts'],
+                          summary='Retrieve a List of all available Contact reports',
+                          description='Returns a list of contact reports that are available for download.'
+                                      ' As soon as any agent beacons over a given contact, the report will'
+                                      ' be available for download.')
+    async def get_available_contact_reports(self, request: web.Request):
+        contacts = self._api_manager.get_available_contact_reports()
+        return web.json_response(contacts)

--- a/app/api/v2/managers/contact_api_manager.py
+++ b/app/api/v2/managers/contact_api_manager.py
@@ -12,3 +12,6 @@ class ContactApiManager(BaseApiManager):
         if contact in self.contact_svc.report:
             return self.contact_svc.report.get(contact)
         raise JsonHttpNotFound(f'Contact not found: {contact}')
+
+    def get_available_contact_reports(self):
+        return list(self.contact_svc.report.keys())

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -1,5 +1,5 @@
 <div x-data="alpineContacts()" x-init="initPage()">
-    <div>
+    <div x-ref="contactsHeader">
         <h2>Contacts</h2>
         <p>
             <b>Contacts are touch points for agents.</b> A contact is a connection point on the server for agents to communicate through. Agents can be
@@ -9,12 +9,6 @@
     </div>
     <hr>
     <div>
-        <div class="buttons">
-            <button class="button is-primary is-small" @click="initPage()">
-                <span class="icon"><i class="fas fa-sync"></i></span>
-                <span>Refresh</span>
-            </button>
-        </div>
         <table class="table is-striped">
             <tbody>
                 <template x-for="contact of contacts" :key="contact.name">
@@ -22,8 +16,10 @@
                         <th x-text="contact.name"></th>
                         <td x-text="contact.description"></td>
                         <td>
-                            <span x-show="hasNoReport.has(contact.name)" class="is-size-7">No contacts to show</span>
-                            <template x-if="!hasNoReport.has(contact.name)">
+                            <template x-if="!availableContacts.includes(contact.name.toUpperCase())">
+                                <button class="button is-small" disabled>No report available</button>
+                            </template>
+                            <template x-if="availableContacts.includes(contact.name.toUpperCase())">
                                 <button class="button is-small is-primary" @click="downloadContactReport(contact.name)">
                                     <span class="icon"><i class="fas fa-file-download"></i></span>
                                     <span>Download Report</span>
@@ -41,24 +37,28 @@
     function alpineContacts() {
         return {
             contacts: JSON.parse('{{ contacts | tojson }}'),
-            hasNoReport: new Set(),
+            availableContacts: [],
 
-            initPage() {
-                this.hasNoReport = new Set();
-                this.contacts.forEach(async (contact) => {
-                    try {
-                        await apiV2('GET', `/api/v2/contacts/${contact.name}`);
-                    } catch (error) {
-                        this.hasNoReport.add(contact.name);
-                    }
-                });
+            async initPage() {
+                do {
+                    this.getAvailableReports();
+                    await sleep(2000);
+                } while (this.$refs.contactsHeader)
+            },
+
+            getAvailableReports() {
+                apiV2('GET', '/api/v2/contacts').then((reports) => {
+                    this.availableContacts = reports
+                }).catch((error) => {
+                    toast('Error getting available contacts', false)
+                })
             },
 
             downloadContactReport(contactName) {
                 apiV2('GET', `/api/v2/contacts/${contactName}`).then((contact) => {
                     downloadJson(`${contactName}_contact_report`, contact);
                 }).catch((error) => {
-                    toast('Error loading page', false);
+                    toast('Error downloading contact report', false);
                     console.error(error);
                 });
             }

--- a/tests/api/v2/handlers/test_contacts_api.py
+++ b/tests/api/v2/handlers/test_contacts_api.py
@@ -49,4 +49,4 @@ class TestContactsApi:
         resp = await api_v2_client.get('/api/v2/contacts', cookies=api_cookies)
         assert resp.status == HTTPStatus.OK
         output = await resp.json()
-        assert output == list('HTTP')
+        assert output == ['HTTP', 'HTML']

--- a/tests/api/v2/handlers/test_contacts_api.py
+++ b/tests/api/v2/handlers/test_contacts_api.py
@@ -44,3 +44,9 @@ class TestContactsApi:
     async def test_nonexistent_get_contact_report(self, api_v2_client, api_cookies, contact_report_data):
         resp = await api_v2_client.get('/api/v2/contacts/invalid_contact', cookies=api_cookies)
         assert resp.status == HTTPStatus.NOT_FOUND
+
+    async def test_get_available_contact_report(self, api_v2_client, api_cookies, contact_report_data):
+        resp = await api_v2_client.get('/api/v2/contacts', cookies=api_cookies)
+        assert resp.status == HTTPStatus.OK
+        output = await resp.json()
+        assert output == list('HTTP')


### PR DESCRIPTION
## Description

There was only one endpoint for getting contacts, and if the contact was not found it would return a 404 which shows as an error in the browser console. In order to show the user which reports are available for download, an endpoint was added to get the list of contacts that all agents have beaconed to at least once. This mitigates the 404 errors, and we can now auto-refresh the page so as soon as a contact report is available, it will make it available for download.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Contacts page no longer loads with errors, and only those reports that are available for download provide the link to do so.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
