### PR TITLE
Make auto-deletion of ability payload optional

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -27,6 +27,7 @@ class AbilitySchema(ma.Schema):
     access = ma.fields.Nested(AccessSchema, missing=None)
     singleton = ma.fields.Bool(missing=None)
     plugin = ma.fields.String(missing=None)
+    delete_payload = ma.fields.Bool(missing=None)
 
     @ma.pre_load
     def fix_id(self, data, **_):
@@ -58,7 +59,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
 
     def __init__(self, ability_id='', name=None, description=None, tactic=None, technique_id=None, technique_name=None,
                  executors=(), requirements=None, privilege=None, repeatable=False, buckets=None, access=None,
-                 additional_info=None, tags=None, singleton=False, plugin='', **kwargs):
+                 additional_info=None, tags=None, singleton=False, plugin='', delete_payload=True, **kwargs):
         super().__init__()
         self.ability_id = ability_id if ability_id else str(uuid.uuid4())
         self.tactic = tactic.lower() if tactic else None
@@ -81,6 +82,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.additional_info.update(**kwargs)
         self.tags = set(tags) if tags else set()
         self.plugin = plugin
+        self.delete_payload = delete_payload
 
     def __getattr__(self, item):
         try:
@@ -110,6 +112,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         existing.update('tags', self.tags)
         existing.update('singleton', self.singleton)
         existing.update('plugin', self.plugin)
+        existing.update('delete_payload', self.delete_payload)
         return existing
 
     async def which_plugin(self):

--- a/app/objects/secondclass/c_instruction.py
+++ b/app/objects/secondclass/c_instruction.py
@@ -12,6 +12,7 @@ class InstructionSchema(ma.Schema):
     payloads = ma.fields.List(ma.fields.String())
     deadman = ma.fields.Boolean()
     uploads = ma.fields.List(ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.String()))
+    delete_payload = ma.fields.Bool(missing=None)
 
     @ma.post_load
     def build_instruction(self, data, **_):
@@ -25,9 +26,10 @@ class Instruction(BaseObject):
     @property
     def display(self):
         return self.clean(dict(id=self.id, sleep=self.sleep, command=self.command, executor=self.executor,
-                               timeout=self.timeout, payloads=self.payloads, uploads=self.uploads, deadman=self.deadman))
+                               timeout=self.timeout, payloads=self.payloads, uploads=self.uploads, deadman=self.deadman,
+                               delete_payload=self.delete_payload))
 
-    def __init__(self, id, command, executor, payloads=None, uploads=None, sleep=0, timeout=60, deadman=False):
+    def __init__(self, id, command, executor, payloads=None, uploads=None, sleep=0, timeout=60, deadman=False, delete_payload=True):
         super().__init__()
         self.id = id
         self.sleep = sleep
@@ -37,3 +39,4 @@ class Instruction(BaseObject):
         self.payloads = payloads if payloads else []
         self.uploads = uploads if uploads else []
         self.deadman = deadman
+        self.delete_payload = delete_payload

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -182,7 +182,8 @@ class ContactService(ContactServiceInterface, BaseService):
                            timeout=link.executor.timeout,
                            payloads=payloads,
                            uploads=uploads,
-                           deadman=link.deadman)
+                           deadman=link.deadman,
+                           delete_payload=link.ability.delete_payload)
 
     async def _add_agent_to_operation(self, agent):
         """Determine which operation(s) incoming agent belongs to and

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -388,7 +388,6 @@ class DataService(DataServiceInterface, BaseService):
         required_fields = ['name', 'description', 'tactic', 'technique_id', 'technique_name']
         special_extensions = [special_payload for special_payload in
                               self.get_service('file_svc').special_payloads if special_payload.startswith('.')]
-        cleanup_abilities = await self.locate('abilities', dict(ability_id='4cd4eb44-29a7-4259-91ae-e457b283a880'))
         for ability in await self.locate('abilities'):
             for field in required_fields:
                 if not getattr(ability, field):
@@ -406,14 +405,6 @@ class DataService(DataServiceInterface, BaseService):
                     if not path:
                         self.log.warning('Payload referenced in %s but not found: %s', ability.ability_id, payload)
                         continue
-
-                    for cleanup_ability in cleanup_abilities:
-                        cleanup_executor = cleanup_ability.find_executor(executor.name, executor.platform)
-                        if cleanup_executor and cleanup_executor.cleanup:
-                            payload_name = '#{payload:%s}' % payload if self.is_uuid4(payload) else payload
-                            cleanup_command = executor.replace_cleanup(cleanup_executor.cleanup[0], payload_name)
-                            if cleanup_command not in executor.cleanup and not ability.delete_payload:
-                                executor.cleanup.append(cleanup_command)
 
     async def _verify_default_objective_exists(self):
         if not await self.locate('objectives', match=dict(name='default')):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -412,7 +412,7 @@ class DataService(DataServiceInterface, BaseService):
                         if cleanup_executor and cleanup_executor.cleanup:
                             payload_name = '#{payload:%s}' % payload if self.is_uuid4(payload) else payload
                             cleanup_command = executor.replace_cleanup(cleanup_executor.cleanup[0], payload_name)
-                            if cleanup_command not in executor.cleanup:
+                            if cleanup_command not in executor.cleanup and not ability.delete_payload:
                                 executor.cleanup.append(cleanup_command)
 
     async def _verify_default_objective_exists(self):

--- a/templates/abilities.html
+++ b/templates/abilities.html
@@ -230,6 +230,18 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="field is-horizontal">
+                                <div class="field-label is-small">
+                                    <label class="label">Delete payload</label>
+                                </div>
+                                <div class="field-body">
+                                    <div class="field">
+                                        <div class="control mt-2">
+                                            <input type="checkbox" x-model="selectedAbility.delete_payload">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </form>
                         <p class="has-text-centered">Executors</p>
                         <p x-show="fieldErrors.includes('executors')" class="help is-danger">At least one executor is required.</p>

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -481,6 +481,18 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="field is-horizontal">
+                                <div class="field-label is-small">
+                                    <label class="label">Delete payload</label>
+                                </div>
+                                <div class="field-body">
+                                    <div class="field">
+                                        <div class="control mt-2">
+                                            <input type="checkbox" x-model="selectedAbility.delete_payload">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </form>
                         <p class="has-text-centered">Executors</p>
                         <p x-show="fieldErrorsAbility.includes('executors')" class="help is-danger">At least one executor is required.</p>

--- a/tests/api/v2/handlers/test_abilities_api.py
+++ b/tests/api/v2/handlers/test_abilities_api.py
@@ -25,7 +25,8 @@ def new_ability_payload():
             'repeatable': False,
             'requirements': [],
             'singleton': False,
-            'plugin': ''
+            'plugin': '',
+            'delete_payload': True,
             }
 
 


### PR DESCRIPTION
## Description

Sandcat automatically deletes payloads after each ability. This PR adds an option to abilities to prevent that from happening, leaving the payload on disk, which can be useful if later abilities will use the same payload.

Requires https://github.com/mitre/sandcat/pull/404

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with an ability that has a payload. Tested:
- existing ability with no changes: same behavior as before, payload deleted
- ability with delete_payload=false and a cleanup command that removes the payload: payload deleted
- ability with delete_payload=true and a cleanup command that removes the payload: payload deleted before cleanup
- ability with delete_payload=true and no cleanup command: payload deleted
- ability with delete_payload=false and no cleanup command: payload remains

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
