### PR TITLE
Add blank agent deployment config field values as default

### DIFF
--- a/templates/agents.html
+++ b/templates/agents.html
@@ -689,7 +689,7 @@
                 });
                 fields = [...new Set(fields)];
                 fields.forEach((field) => {
-                    this.agentFields.push({ name: field, value: this.agentFieldConfig[field] });
+                    this.agentFields.push({ name: field, value: this.agentFieldConfig.hasOwnProperty(field) ? this.agentFieldConfig[field] : "" });
                 });
             },
 


### PR DESCRIPTION
## Description
In preparation for allowing users to specify sandcat agent extensions via the agent deployment GUI, we will update the deployment modal to use empty strings as the default value if an agent config field is not found.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Used chrome to deploy agents for all 3 operation systems

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
