### PR TITLE
Add rerun operation button

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1340,7 +1340,11 @@
 
             rerunOperation() {
                 let { id, start, state, chain, host_group, ...newOp } = this.selectedOperation;
-                newOp.name += ` (${new Date().toLocaleString()})`
+
+                let dateMatches = newOp.name.match(/[(]\d{1,2}\/\d{1,2}\/\d{2,4}, \d{1,2}:\d{2}:\d{2} [A|P]M[)]$/g);
+                let stringToReplace = (dateMatches && dateMatches.length) ? dateMatches[dateMatches.length - 1] : '';
+                let date = `(${new Date().toLocaleString()})`;
+                newOp.name = stringToReplace ? (newOp.name.replace(stringToReplace, date)) : (`${newOp.name} ${date}`);
                 
                 apiV2('POST', this.ENDPOINT, newOp).then((newOperation) => {
                     toast(`Started operation ${newOperation.name}!`, true);

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -60,13 +60,15 @@
 
                     <!-- OPERATION CONTROLS -->
                     <div class="controls-container is-flex is-justify-content-center is-align-items-center">
-                        <div class="is-flex is-flex-direction-column is-align-items-center">
-                            <button x-bind:disabled="!isOperationRunning" class="button no-style is-large"
-                                    x-on:click="updateOperation('state', 'cleanup')" id="op-stop-button"><em
-                                    title="stop" class="fas fa-stop"></em></button>
-                            <label class="label is-small" for="op-stop-button">Stop</label>
-                        </div>
-                        <template x-if="selectedOperation.state ==='running'">
+                        <template x-if="isOperationRunning">
+                            <div class="is-flex is-flex-direction-column is-align-items-center">
+                                <button x-bind:disabled="!isOperationRunning" class="button no-style is-large"
+                                        x-on:click="updateOperation('state', 'cleanup')" id="op-stop-button"><em
+                                        title="stop" class="fas fa-stop"></em></button>
+                                <label class="label is-small" for="op-stop-button">Stop</label>
+                            </div>
+                        </template>
+                        <template x-if="selectedOperation.state === 'running' && isOperationRunning">
                             <div class="is-flex is-flex-direction-column is-align-items-center">
                                 <button x-bind:disabled="!isOperationRunning"
                                         class="button no-style is-larger" id="op-pause-button"
@@ -75,7 +77,7 @@
                                 <label class="label is-small" for="op-pause-button">Pause</label>
                             </div>
                         </template>
-                        <template x-if="selectedOperation.state !== 'running'">
+                        <template x-if="selectedOperation.state !== 'running' && isOperationRunning">
                             <div class="is-flex is-flex-direction-column is-align-items-center">
                                 <button x-bind:disabled="!isOperationRunning"
                                         class="button no-style is-larger" id="op-run-button"
@@ -84,12 +86,22 @@
                                 <label class="label is-small" for="op-run-button">Run</label>
                             </div>
                         </template>
-                        <div class="is-flex is-flex-direction-column is-align-items-center">
-                            <button x-bind:disabled="!isOperationRunning" class="button no-style is-medium"
-                                    x-on:click="updateOperation('state', 'run_one_link')" id="op-run-1-button">
-                                <em title="run one step" class="fas fa-play"><sub>1</sub></em></button>
-                            <label class="label is-small" for="op-run-1-button">Run 1 Link</label>
-                        </div>
+                        <template x-if="isOperationRunning">
+                            <div class="is-flex is-flex-direction-column is-align-items-center">
+                                <button x-bind:disabled="!isOperationRunning" class="button no-style is-medium"
+                                        x-on:click="updateOperation('state', 'run_one_link')" id="op-run-1-button">
+                                    <em title="run one step" class="fas fa-play"><sub>1</sub></em></button>
+                                <label class="label is-small" for="op-run-1-button">Run 1 Link</label>
+                            </div>
+                        </template>
+                        <template x-if="!isOperationRunning">
+                            <div class="is-flex is-flex-direction-column is-align-items-center">
+                                <button class="button no-style is-large" x-on:click="rerunOperation()">
+                                        <em title="Re-run operation with same settings" class="fas fa-redo-alt"></em>
+                                </button>
+                                <label class="label is-small">Re-run operation</label>
+                            </div>
+                        </template>
                     </div>
 
                     <div class="is-flex is-flex-direction-row">
@@ -1324,6 +1336,21 @@
                         toast('Error adding operation');
                     });
                 }
+            },
+
+            rerunOperation() {
+                let { id, start, state, chain, host_group, ...newOp } = this.selectedOperation;
+                newOp.name += ` (${new Date().toLocaleString()})`
+                
+                apiV2('POST', this.ENDPOINT, newOp).then((newOperation) => {
+                    toast(`Started operation ${newOperation.name}!`, true);
+                    this.operations.push(newOperation);
+                    this.selectedOperation = newOperation;
+                    this.selectedOperationID = newOperation.id;
+                }).catch((error) => {
+                    toast('Error adding operation', false);
+                    console.error(error);
+                });
             },
 
             deleteOperation() {


### PR DESCRIPTION
## Description

When an operation finishes, the stop, pause, and other state controls are hidden and only a Re-run button is displayed. Clicking it will start a new operation with the exact settings used on the currently selected operation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Operations that aren't finished behave as they did before, and when they are finished only the re-run button is displayed. Clicking the re-run button yielded no errors and the new operation is selected.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
