### PR TITLE
Show fact breakdown on adversary profiles

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1,6 +1,5 @@
 <div id="operationsPage" x-data="alpineOperations()" x-init="initOperations()"
-     xmlns="http://www.w3.org/1999/html"
-     @resize.window="getOperationsMenuCaretDisplay()">
+     xmlns="http://www.w3.org/1999/html">
     <div>
         <div>
             <div x-ref="operationsHeader">
@@ -178,7 +177,7 @@
                         </div>
                     </template>
                     <div class="timeline-table">
-                        <table class="table" @click.outside="selectedLink = null;">
+                        <table class="table">
                             <thead>
                             <tr class="table-header">
                                 <th class="decideColumn">Decide</th>
@@ -228,49 +227,31 @@
                                     </td>
                                     <td class="agentDetails">
                                         <p x-show="!link.host"><em>n/a</em></p>
-                                        <p x-show="link.host"><em
-                                                x-text="link.host"></em></p>
+                                        <p x-show="link.host"><em x-text="link.host"></em></p>
                                     </td>
                                     <td class="agentDetails">
-                                        <p x-show="!link.pid"><em>n/a</em></p>
-                                        <p x-show="link.pid"><em
-                                                x-text="link.pid"></em></p>
+                                        <p x-show="!link.pid" class="mb-0"><em>n/a</em></p>
+                                        <p x-show="link.pid"><em x-text="link.pid"></em></p>
                                     </td>
 
                                     <!--COMMAND COLUMN-->
                                     <td class="commandDetails">
-                                        <template x-if="!isLinkEditable">
-                                            <div class="is-flex is-justify-content-center is-flex-direction-column">
+                                        <div class="is-flex is-justify-content-flex-start">
+                                            <template x-if="!isLinkEditable(link)">
                                                 <button class="button is-small"
                                                         x-on:click="getLink(link); openModal='showCommand'"
                                                         title="view output">View Command
                                                 </button>
-                                            </div>
-                                        </template>
-                                        <template x-if="isLinkEditable">
-                                            <div class="is-flex is-align-items-flex-start is-justify-content-flex-start is-flex-direction-column">
-                                                <label x-show="false" for="edit-command">Edit command</label>
-                                                <textarea id="edit-command"
-                                                          class="code mb-2"
-                                                          contenteditable
-                                                          x-model="editableCommand"
-                                                          spellcheck="false"></textarea>
-
-                                                <!-- BUTTONS TO MANUALLY EXECUTE (APPROVE/DISCARD) COMMAND-->
-                                                <div class="is-flex is-justify-content-space-between">
-                                                    <button type="button"
-                                                            class="button is-small mr-3"
-                                                            x-on:click="updateLink(-2)">
-                                                        Discard
-                                                    </button>
-                                                    <button type="button"
-                                                            class="button is-primary is-small"
-                                                            x-on:click="updateLink(-3, editableCommand)">
-                                                        Approve
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </template>
+                                            </template>
+                                            <template x-if="isLinkEditable(link)">
+                                                <button class="button is-small is-warning is-outlined"
+                                                        x-on:click="getLink(link); openModal='showCommand'"
+                                                        title="view output">
+                                                    <i class="fas fa-exclamation-triangle pr-2"></i>
+                                                    Review Command
+                                                </button>
+                                            </template>
+                                        </div>
                                     </td>
 
                                     <!--OUTPUT/FACTS COLUMN-->
@@ -291,7 +272,7 @@
                                     <td class="csv-exclude">
                                         <button x-show="selectedLink === link && isOperationRunning && !(link.status in LINK_STATUSES)"
                                                 type="button" title="delete link"
-                                                class="button is-primary is-small ml-2"
+                                                class="button is-danger is-outlined is-small ml-2"
                                                 x-on:click="openModal = 'deleteLinkModal'"><em
                                                 class="pr-1 fas fa-trash"></em>Discard Link
                                         </button>
@@ -417,7 +398,7 @@
                                                 <tr>
                                                     <th>Name</th>
                                                     <th>Value</th>
-                                                    <th>Trait</th>
+                                                    <th>Score</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -457,18 +438,46 @@
                             <p class="modal-card-title">Command</p>
                         </header>
                         <section class="modal-card-body">
-                            <div>
-                                <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
-                            </div>
+                            <template x-if="isLinkEditable(selectedLink)">
+                                <div>
+                                    <label x-show="false" htmlFor="edit-command">Edit command</label>
+                                    <textarea id="edit-command"
+                                              class="textarea is-small code"
+                                              contentEditable
+                                              x-model="editableCommand"
+                                              spellCheck="false"></textarea>
+                                </div>
+                            </template>
+                            <template x-if="!isLinkEditable(selectedLink)">
+                                <div>
+                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
+                                </div>
+                            </template>
                         </section>
                         <footer class="modal-card-foot">
                             <nav class="level">
                                 <div class="level-left">
+                                    <template x-if="isLinkEditable(selectedLink)">
+                                        <button type="button"
+                                                class="button is-danger is-outlined is-small"
+                                                x-on:click="updateLink(-2); openModal = null;">
+                                            Discard
+                                        </button>
+                                    </template>
                                 </div>
                                 <div class="level-right">
                                     <div class="level-item">
                                         <button class="button is-small" @click="openModal = null">Close</button>
                                     </div>
+                                    <template x-if="isLinkEditable(selectedLink)">
+                                        <div class="level-item">
+                                            <button type="button"
+                                                    class="button is-primary is-small"
+                                                    x-on:click="updateLink(-3, editableCommand); openModal = null;">
+                                                Approve
+                                            </button>
+                                        </div>
+                                    </template>
                                 </div>
                             </nav>
                         </footer>
@@ -1110,7 +1119,6 @@
             filteredAbilitiesList: [],
             schedule: '',
             editableCommand: null,
-            showOperationsMenuCaret: true,
             addNewRow: false,
             addedTechniquesIDs: new Set(),
 
@@ -1162,16 +1170,11 @@
                 return !(this.selectedOperation.state === 'finished' || this.selectedOperation.state === 'cleanup' || this.selectedOperation.state === 'out_of_time');
             },
 
-            get isLinkEditable() {
-                if (!this.selectedLink) return false;
+            isLinkEditable(currentLink) {
+                if (!currentLink) return false;
                 // Link can only be editable if operation is running, and if link is paused, queued, or completed
-                return this.isOperationRunning && ((this.selectedLink.status === -1 || !(this.selectedLink.status in this.LINK_STATUSES))
-                    && !(this.selectedLink.finish.length > 0 || this.selectedLink.output === 'True'));
-            },
-
-            getOperationsMenuCaretDisplay() {
-                const el = document.querySelector('.operation-menu-container');
-                if (el) this.showOperationsMenuCaret = el.scrollWidth > el.offsetWidth;
+                return this.isOperationRunning && ((currentLink.status === -1 || !(currentLink.status in this.LINK_STATUSES))
+                    && !(currentLink.finish.length > 0 || currentLink.output === 'True'));
             },
 
             getReadableTime(date) {
@@ -1219,8 +1222,6 @@
                     this.getOperation();
                     this.getFacts();
                     this.getFields();
-                    this.getOperationsMenuCaretDisplay(); // wait for UI changes to get accurate width calcs
-                    this.getAndCompareOperation();
                 }
             },
 
@@ -1255,13 +1256,12 @@
                     obfuscator: 'plain-text',
                     jitter: '2/8',
                     visibility: '51',
-                }
+                };
             },
 
             getOperations() {
                 apiV2('GET', this.ENDPOINT).then((res) => {
                     this.operations = res;
-                    this.selectedOperationID = this.selectedOperationID;
                 }).catch(() => {
                     toast('Error getting operations');
                 });
@@ -1284,24 +1284,6 @@
                 }).catch(() => {
                     toast('Error getting operation');
                 });
-            },
-
-            getAndCompareOperation() {
-                if (this.selectedOperationID) {
-                    apiV2('GET', `${this.ENDPOINT}/${this.selectedOperationID}`).then((res) => {
-                        if (this.selectedLink) {
-                            this.selectedOperation = {
-                                ...res,
-                                chain: res.chain.map(link => link.id === this.selectedLink.id ? this.selectedLink : link)
-                            };
-                        } else {
-                            this.selectedOperation = res;
-                        }
-                        this.generateAddedLinksList();
-                    }).catch(() => {
-                        console.error('Error getting operation');
-                    });
-                }
             },
 
             addOperation() {
@@ -1422,7 +1404,7 @@
                 if (!this.selectedPotentialLink.ability_id) return;
 
                 const executor = link.executors.find((e) => this.potentialLink.executor === e.name);
-                const fields = [...new Set( [...executor.command.matchAll(/#{(.*?)}/gm)].map((field) => field[1]) )]
+                const fields = [...new Set([...executor.command.matchAll(/#{(.*?)}/gm)].map((field) => field[1]))];
                 const opSource = this.selectedOperation.source;
                 const opSourceCollected = this.SOURCES.find((source) => source.name === this.selectedOperation.name);
                 const facts = opSource.facts.concat(opSourceCollected ? opSourceCollected.facts : []);
@@ -1436,8 +1418,8 @@
                             value: fact.value,
                             origin: fact.origin_type,
                             selected: false
-                        })
-                    })
+                        });
+                    });
                 });
 
                 this.setPotentialLinksToAdd();
@@ -1489,7 +1471,7 @@
                     factGroup.forEach((fact) => {
                         let split = fact.split('|');
                         command = command.replaceAll(`#{${split[0]}}`, split[1])
-                    })
+                    });
 
                     this.potentialLinksToAdd.push({
                         ability: this.selectedPotentialLink,
@@ -1498,8 +1480,8 @@
                             ...executor,
                             command: command
                         }
-                    })
-                })
+                    });
+                });
                 this.isAddingBlankPotentialLink = false;
             },
 
@@ -1678,8 +1660,8 @@
 
             isJitterValid() {
                 const jitterMin = parseInt(this.jitterMin, 10);
-                const jitterMax = parseInt(this.jitterMax, 10); 
-                return (jitterMin >= 0 && jitterMax >= 0 && jitterMin <= jitterMax) 
+                const jitterMax = parseInt(this.jitterMax, 10);
+                return (jitterMin >= 0 && jitterMax >= 0 && jitterMin <= jitterMax);
             },
 
             filterAbilities(abilities) {
@@ -1734,22 +1716,6 @@
     /*MODAL FORM STYLE*/
     #operationsPage .modal-form-fields.download-buttons-container button {
         width: fit-content;
-    }
-
-    #operationsPage .modal-results {
-        overflow-x: hidden;
-        overflow-y: scroll;
-        height: 50vh;
-    }
-
-    #operationsPage .modal-results li.abilities-list-item {
-        box-sizing: border-box;
-        padding: .5em;
-        list-style: none;
-    }
-
-    #operationsPage .modal-results li.abilities-list-item:hover {
-        background-color: rgba(255, 255, 255, 0.1);
     }
 
     /*END MODAL FORM STYLE*/

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <div class="control">
-                <button type="button" class="button is-primary is-small" @click="isCreatingProfile = true">+ New</button>
+                <button type="button" class="button is-primary is-small" @click="isCreatingProfile = true">+ New Adversary</button>
             </div>
         </div>
     </form>
@@ -61,12 +61,16 @@
             </form>
             <div class="control-buttons is-flex is-flex-direction-row">
                 <button class="button is-small" @click="selectedAbilityId = ''; showAbilityChoiceModal = true;">
-                    <span class="icon"><i class="fas fa-plus"></i></span>
+                    <span class="icon"><em class="fas fa-plus"></em></span>
                     <span>Add Ability</span>
                 </button>
                 <button class="button is-small" @click="showAddAdversaryModal = true">
-                    <span class="icon"><i class="fas fa-plus"></i></span>
+                    <span class="icon"><em class="fas fa-plus"></em></span>
                     <span>Add Adversary</span>
+                </button>
+                <button class="button is-small" @click="showFactBreakdownModal = true">
+                    <span class="icon"><em class="fas fa-unlock-alt"></em></span>
+                    <span>Fact breakdown</span>
                 </button>
                 <div class="vr"></div>
                 <span>Objective: <b x-text="getObjectiveName()"></b>&nbsp;&nbsp;&nbsp;</span>
@@ -102,28 +106,28 @@
                             <td>
                                 <template x-for="platform of getExecutorDetail('platforms', ability)">
                                     <span class="has-tooltip-arrow no-underline" x-bind:data-tooltip="platform">
-                                        <span class="icon is-small"><i class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></i></span>
+                                        <span class="icon is-small"><em class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
                                     </span>
                                 </template>
                             </td>
                             <td class="has-text-centered" x-bind:class="{ 'unlock': onHoverUnlocks.indexOf(ability.ability_id) > -1 }">
                                 <span class=" has-tooltip-arrow no-underline" x-show="getExecutorDetail('requirements', ability)" x-bind:data-tooltip="`This ability has requirements: (${abilityDependencies[ability.ability_id].requireTypes})`">
-                                    <span class="icon is-small"><i class="fas fa-lock"></i></span>
+                                    <span class="icon is-small"><em class="fas fa-lock"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered" x-bind:class="{ 'lock': onHoverLocks.indexOf(ability.ability_id) > -1 }">
                                 <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('parser', ability)" x-bind:data-tooltip="`This ability unlocks other abilities: (${abilityDependencies[ability.ability_id].enableTypes})`">
-                                    <span class="icon is-small"><i class="fas fa-key"></i></span>
+                                    <span class="icon is-small"><em class="fas fa-key"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered">
                                 <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('payload', ability)" data-tooltip="This ability uses a payload">
-                                    <span class="icon is-small"><i class="fas fa-weight-hanging"></i></span>
+                                    <span class="icon is-small"><em class="fas fa-weight-hanging"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered">
                                 <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('cleanup', ability)" data-tooltip="This ability can clean itself up">
-                                    <span class="icon is-small"><i class="fas fa-trash"></i></span>
+                                    <span class="icon is-small"><em class="fas fa-trash"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered"><button class="delete is-danger" @click.stop="removeAbility(index)"></button></td>
@@ -136,7 +140,7 @@
             </div>
             <div class="icon-text" x-show="needsParser.length">
                 <span class="icon has-text-warning">
-                    <i class="fas fa-exclamation-triangle"></i>
+                    <em class="fas fa-exclamation-triangle"></em>
                 </span>
                 <span>One or more of the abilities have unmet requirements, which may result in a failed operation if ran sequentially.</span>
             </div>
@@ -214,12 +218,12 @@
                                     <b x-text="ability.name"></b> |
                                     <span x-text="ability.tactic"></span> |
                                     <template x-for="platform of getExecutorDetail('platforms', ability)">
-                                        <span class="icon is-small"><i class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></i></span>
+                                        <span class="icon is-small"><em class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
                                     </template> |
-                                    <span class="icon is-small" x-show="getExecutorDetail('requirements', ability)"><i class="fas fa-lock"></i></span>
-                                    <span class="icon is-small" x-show="getExecutorDetail('cleanup', ability)"><i class="fas fa-trash"></i></span>
-                                    <span class="icon is-small" x-show="getExecutorDetail('parser', ability)"><i class="fas fa-key"></i></span>
-                                    <span class="icon is-small" x-show="getExecutorDetail('payload', ability)"><i class="fas fa-weight-hanging"></i></span>
+                                    <span class="icon is-small" x-show="getExecutorDetail('requirements', ability)"><em class="fas fa-lock"></em></span>
+                                    <span class="icon is-small" x-show="getExecutorDetail('cleanup', ability)"><em class="fas fa-trash"></em></span>
+                                    <span class="icon is-small" x-show="getExecutorDetail('parser', ability)"><em class="fas fa-key"></em></span>
+                                    <span class="icon is-small" x-show="getExecutorDetail('payload', ability)"><em class="fas fa-weight-hanging"></em></span>
                                 </span>
                             </label>
                         </div>
@@ -386,7 +390,7 @@
                                         </div>
                                         <div class="control">
                                             <a class="button is-small has-tooltip-left has-tooltip-arrow" data-tooltip="Generate New ID" @click="selectedAbility.ability_id = uuidv4()">
-                                                <span class="icon is-small"><i class="fas fa-sync"></i></span>
+                                                <span class="icon is-small"><em class="fas fa-sync"></em></span>
                                             </a>
                                         </div>
                                     </div>
@@ -618,7 +622,7 @@
                                                     </div>
                                                     <div class="control">
                                                         <a class="button is-small has-tooltip-bottom has-tooltip-arrow" data-tooltip="Remove cleanup command" @click="executor.cleanup.splice(index, 1)">
-                                                            <span class="icon is-small"><i class="fas fa-minus-square"></i></span>
+                                                            <span class="icon is-small"><em class="fas fa-minus-square"></em></span>
                                                         </a>
                                                     </div>
                                                 </div>
@@ -653,7 +657,7 @@
                     <div class="level-left">
                         <div class="level-item" x-show="selectedAbility">
                             <button class="button is-small" @click="saveAbility(false)" x-bind:disabled="!selectedAbilityId">
-                                <span class="icon"><i class="fas fa-save"></i></span>
+                                <span class="icon"><em class="fas fa-save"></em></span>
                                 <span>Save</span>
                             </button>
                         </div>
@@ -667,6 +671,47 @@
                                 <span class="icon"><em class="fas fa-plus"></em></span>
                                 <span>Save & Add</span>
                             </button>
+                        </div>
+                    </div>
+                </nav>
+            </footer>
+        </div>
+    </div>
+
+    <div class="modal" x-bind:class="{ 'is-active': showFactBreakdownModal }">
+        <div class="modal-background" @click="showFactBreakdownModal = false"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Fact Breakdown</p>
+            </header>
+            <section class="modal-card-body">
+                <p class="has-text-weight-bold">Facts Collected</p>
+                <div class="tags" x-show="factTotals.collected.length">
+                    <template x-for="(fact, index) of factTotals.collected.sort()" :key="index">
+                        <span class="tag is-small is-info" x-text="fact"></span>
+                    </template>
+                </div>
+                <p x-show="!factTotals.collected.length">No facts to show</p>
+                <p class="has-text-weight-bold mb-0">Facts Required</p>
+                <p class="help">
+                    Facts in yellow with a warning icon are facts that have not been met from the other abilities.
+                </p>
+                <div class="tags" x-show="factTotals.required.length">
+                    <template x-for="(fact, index) of factTotals.required.sort()" :key="index">
+                        <span class="tag is-small is-info" :class="{ 'is-warning': factTotals.collected.indexOf(fact) === -1 }">
+                            <span x-show="factTotals.collected.indexOf(fact) === -1" class="icon"><em class="fas fa-exclamation-triangle"></em></span>
+                            <span x-text="fact"></span>
+                        </span>
+                    </template>
+                </div>
+                <p x-show="!factTotals.required.length">No facts to show</p>
+            </section>
+            <footer class="modal-card-foot">
+                <nav class="level">
+                    <div class="level-left"></div>
+                    <div class="level-right">
+                        <div class="level-item">
+                            <button class="button is-small" @click="showFactBreakdownModal = false">Close</button>
                         </div>
                     </div>
                 </nav>
@@ -729,6 +774,10 @@
             selectedAbility: {},
             selectedPlatform: '',
             selectedExecutor: '',
+
+            // Fact breakdown modal
+            showFactBreakdownModal: false,
+            factTotals: { required: [], collected: [] },
 
             // Input validation
             requiredFieldsProfile: ['name', 'description'],
@@ -883,6 +932,8 @@
 
             findAbilityDependencies() {
                 const types = {};
+                this.factTotals.collected = [];
+                this.factTotals.required = [];
 
                 this.selectedProfileAbilities.forEach((ability, index) => {
                     let requireTypes = [];
@@ -944,7 +995,14 @@
                         // Same dimension as requireTypes, but true/false if requirement has been met
                         requireTypesMet: requireTypesMet,
                     };
+
+                     // Update fact totals for fact breakdown
+                    this.factTotals.collected = this.factTotals.collected.concat(types[ability.ability_id].enableTypes);
+                    this.factTotals.required = this.factTotals.required.concat(types[ability.ability_id].requireTypes);
                 });
+
+                this.factTotals.collected = [...new Set(this.factTotals.collected)];
+                this.factTotals.required = [...new Set(this.factTotals.required)];
 
                 this.hasMetAbilityDependencies();
             },


### PR DESCRIPTION
## Description

A fact breakdown has been added via a modal to the adversaries page which will show all unique facts that are collected or are required by other abilities in the profile. It will also flag certain facts with a warning sign if a fact is required but is not collected from another ability. 

There's future improvements to be made here like being able to create a fact source but we'll save that for later.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

<img width="782" alt="Screen Shot 2022-03-10 at 1 16 29 PM" src="https://user-images.githubusercontent.com/6034483/157728753-d7a7ef87-a762-43e7-9d5b-b3f74cc1d807.png">
<img width="713" alt="Screen Shot 2022-03-10 at 1 16 51 PM" src="https://user-images.githubusercontent.com/6034483/157728757-0324c127-dff1-4870-9d64-1b7fe28e09c6.png">
<img width="1918" alt="Screen Shot 2022-03-10 at 1 16 00 PM" src="https://user-images.githubusercontent.com/6034483/157728762-47b170ef-6b43-4f4c-afeb-6f605c9c8acb.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
