### PR TITLE
Make getattr safe for missing keys

### DIFF
--- a/app/objects/c_ability.py
+++ b/app/objects/c_ability.py
@@ -83,10 +83,7 @@ class Ability(FirstClassObjectInterface, BaseObject):
         self.plugin = plugin
 
     def __getattr__(self, item):
-        try:
-            return super().__getattribute__('additional_info')[item]
-        except KeyError:
-            raise AttributeError(item)
+        return super().__getattribute__('additional_info').get('item')
 
     def store(self, ram):
         existing = self.retrieve(ram['abilities'], self.unique)


### PR DESCRIPTION
Changed __getattr__ in c_ability.py to use the dictionary .get('value') instead of [value] to prevent raising errors on missing keys. Will now return either the value or None.

## Description

This is the core Caldera change along with a Mock repo PR. Previous behavior with the Mock plugin was on a missing 'parsers' attribute for abilities, the server would throw a KeyError and the mock operation would halt. Closes #2476 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran through Caldera mock operations to see success while also watching the error log for any other attribute access issues.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
