### PR TITLE
update jinja2 and aiohttp-apispec to fix dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp-jinja2==1.2.0
+aiohttp-jinja2==1.5.0
 aiohttp==3.8.1
 aiohttp_session==2.9.0
 aiohttp-security==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-MarkupSafe==2.0.1
 aiohttp-jinja2==1.2.0
 aiohttp==3.8.1
 aiohttp_session==2.9.0
 aiohttp-security==0.4.0
-aiohttp-apispec==2.2.1
-jinja2==2.11.3
+aiohttp-apispec==2.2.3
+jinja2==3.0.3
 pyyaml>=5.1
 cryptography>=3.2
 websockets==9.1


### PR DESCRIPTION
## Description

Resolving #2505 with new dependency versions.

https://github.com/maximdanilchenko/aiohttp-apispec/releases/tag/v2.2.3 removes upper bound for jinja2 and allows us to update `jinja2` to v3.0.3 resolving the MarkupSafe import issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

