### PR TITLE
Patch Global vars in potential links

### DIFF
--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -95,7 +95,9 @@ class OperationApiManager(BaseApiManager):
         agent = await self.get_agent(operation, data)
         if data['executor']['name'] not in agent.executors:
             raise JsonHttpBadRequest(f'Agent {agent.paw} missing specified executor')
-        encoded_command = self._encode_string(data['executor']['command'])
+        encoded_command_temp = self._encode_string(data['executor']['command'])
+        command_with_globals = agent.replace(encoded_command_temp, file_svc=self.services['file_svc'])
+        encoded_command = self._encode_string(command_with_globals)
         executor = self.build_executor(data=data.pop('executor', {}), agent=agent)
         ability = self.build_ability(data=data.pop('ability', {}), executor=executor)
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, executor=executor,

--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -95,9 +95,8 @@ class OperationApiManager(BaseApiManager):
         agent = await self.get_agent(operation, data)
         if data['executor']['name'] not in agent.executors:
             raise JsonHttpBadRequest(f'Agent {agent.paw} missing specified executor')
-        encoded_command_temp = self._encode_string(data['executor']['command'])
-        command_with_globals = agent.replace(encoded_command_temp, file_svc=self.services['file_svc'])
-        encoded_command = self._encode_string(command_with_globals)
+        encoded_command = self._encode_string(agent.replace(self._encode_string(data['executor']['command']),
+                                              file_svc=self.services['file_svc']))
         executor = self.build_executor(data=data.pop('executor', {}), agent=agent)
         ability = self.build_ability(data=data.pop('ability', {}), executor=executor)
         link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, executor=executor,


### PR DESCRIPTION
## Description

A user recently pointed out that we don't properly handle "global" variables (server, paw, link id, etc.) when using potential links. This change adds globals support for potential links in v2 api.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested manually in a local environment, and with the battery of tests.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
