### PR TITLE
Link Host Restoration Patch

### DIFF
--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -96,6 +96,9 @@ class BasePlanningService(BaseService):
             decoded_test = agent.replace(link.command, file_svc=self.get_service('file_svc'))
             variables = set(x for x in re.findall(self.re_variable, decoded_test) if not self.is_global_variable(x))
 
+            if not link.host:
+                link.host = agent.host  # Required to allow host specific parsers to work
+
             if not variables:
                 # apply_id() modifies link.command so the order of these operations matter
                 link.command = self.encode_string(decoded_test)

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -547,3 +547,18 @@ class TestPlanningService:
 
         await planning_svc.remove_links_with_unset_variables(links)
         assert len(links) == 0
+
+    async def test_link_host_presence(self, setup_planning_test, planning_svc):
+        _, agent, operation, ability = setup_planning_test
+        link = Link.load(dict(command=BaseWorld.encode_string(test_string), paw=agent.paw, ability=ability,
+                              executor=next(ability.executors), status=0))
+
+        f0 = Fact(trait='1_2_3', value='a')
+        f1 = Fact(trait='a.b.c', value='b')
+        f2 = Fact(trait='a.b.d', value='c')
+        f3 = Fact(trait='a.b.e', value='d')
+
+        handle = [link]
+        gen = await planning_svc.add_test_variants(handle, agent, facts=[f0, f1, f2, f3])
+
+        assert gen[0].host == handle[0].host


### PR DESCRIPTION
## Description

When we simplified `base_planning_svc` and `add_test_variants`, we ended up in a situation where checking for requirements occurs prior to assigning a host to a link. As some requirements literally depend on this, this caused some issues. This change is a fix to allow requirements that rely on link/agent host information to work again

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested locally with the Alice 2.0 adversary (the `reachable` requirement is what initially revealed this issue), and with the test battery.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
