### PR TITLE
Keep cryptography dependency under 37.0.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ aiohttp-security==0.4.0
 aiohttp-apispec==2.2.3
 jinja2==3.0.3
 pyyaml>=5.1
-cryptography>=3.2,<37.0.0
+cryptography>=3.2,<37.0.0; python_version <= '3.7'
+cryptography>=3.2; python_version > '3.7'
 websockets==9.1
 Sphinx==3.0.4
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp-security==0.4.0
 aiohttp-apispec==2.2.3
 jinja2==3.0.3
 pyyaml>=5.1
-cryptography>=3.2
+cryptography>=3.2,<37.0.0
 websockets==9.1
 Sphinx==3.0.4
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115


### PR DESCRIPTION


## Description
Keep cryptography dependency under 37.0.0 because they recently deprecated blowfish, which the `asyncssh` dependency seems to use for Python 3.7. Once asyncssh fixes this, we can revert to latest versions of crytography. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ensured workflow checks passed


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
