### PR TITLE
Handle Undefined Ability in Adversary Profile

### DIFF
--- a/static/css/lib/custom-bulma.css
+++ b/static/css/lib/custom-bulma.css
@@ -2239,7 +2239,8 @@ div.icon-text {
   color: #fff;
 }
 .table td.is-warning,
-.table th.is-warning {
+.table th.is-warning,
+.table tr.is-warning {
   background-color: #ffdd57;
   border-color: #ffdd57;
   color: rgba(0, 0, 0, 0.7);

--- a/static/css/lib/custom-bulma.css
+++ b/static/css/lib/custom-bulma.css
@@ -2239,8 +2239,7 @@ div.icon-text {
   color: #fff;
 }
 .table td.is-warning,
-.table th.is-warning,
-.table tr.is-warning {
+.table th.is-warning {
   background-color: #ffdd57;
   border-color: #ffdd57;
   color: rgba(0, 0, 0, 0.7);

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -101,18 +101,18 @@
                 </thead>
                 <tbody>
                     <template x-for="(ability, index) of selectedProfileAbilities">
-                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1 , 'row-hover': ability.ability_id === abilityTableDragHoverId, 'grey-out-unclickable': undefinedAbilities.indexOf(ability.ability_id) > -1 }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id">
+                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1 , 'row-hover': ability.ability_id === abilityTableDragHoverId && abilityTableDragHoverId != undefined, 'grey-out-unclickable': undefinedAbilities.indexOf(ability.ability_id) > -1 }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id"> 
                             <td class="has-text-centered drag" @click.stop draggable="true" x-on:dragstart="startAbilitySwap"  x-on:dragover.prevent="swapAbilitiesHover" x-on:dragend="swapAbilities">&#9776;</td>
                             <td x-text="index + 1"></td>
-                            <td x-text="ability.name"></td>
+                            <td x-text="ability.ability_id ? ability.name : 'Undefined Ability'"></td>
                             <td>
                                 <span x-text="ability.tactic" x-bind:style="`border-bottom: 1px ridge ${hashStringToColor(ability.tactic)}`"></span>
                             </td>
                             <td x-text="ability.technique_name"></td>
                             <td>
                                 <template x-for="platform of getExecutorDetail('platforms', ability)">
-                                    <span class="has-tooltip-arrow no-underline" x-bind:data-tooltip="platform">
-                                        <span class="icon is-small"><em class="fab" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
+                                    <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:data-tooltip="platform">
+                                        <span class="icon is-small"><em class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
                                     </span>
                                 </template>
                             </td>
@@ -155,6 +155,7 @@
                     <em class="fas fa-exclamation-triangle"></em>
                 </span>
                 <span>One or more of the referenced abilities are not defined.</span>
+                <span x-text="index"></span>
             </div>
         </div>
     </template>
@@ -1341,12 +1342,12 @@
 
     .grey-out-unclickable {
         pointer-events: none;
-        color: grey;
-        border: 2px solid #ffdd57;
+        font-weight: bold;
+        border: 2px solid orange;
     }
 
     .red-row {
-        border: 2px solid #8B0000;
+        border: 3px solid #8B0000;
     }
 
     .row-hover {

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -101,38 +101,55 @@
                 </thead>
                 <tbody>
                     <template x-for="(ability, index) of selectedProfileAbilities">
-                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1 , 'row-hover': ability.ability_id === abilityTableDragHoverId && abilityTableDragHoverId != undefined, 'grey-out-unclickable': undefinedAbilities.indexOf(ability.ability_id) > -1 }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id"> 
+                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" 
+                            x-bind:class="{ 'orange-row': needsParser.indexOf(ability.name) > -1 ,
+                                            'row-hover': ability.ability_id === abilityTableDragHoverId && abilityTableDragHoverId != undefined, 
+                                            'red-row-unclickable': undefinedAbilities.indexOf(ability.ability_id) > -1 }" 
+                            x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id"> 
                             <td class="has-text-centered drag" @click.stop draggable="true" x-on:dragstart="startAbilitySwap"  x-on:dragover.prevent="swapAbilitiesHover" x-on:dragend="swapAbilities">&#9776;</td>
-                            <td x-text="index + 1"></td>
-                            <td x-text="ability.ability_id ? ability.name : 'Undefined Ability'"></td>
                             <td>
+                                <div class="icon-text">
+                                    <span x-text="index + 1"></span>
+                                    <span class="icon has-text-danger" x-show="!ability.ability_id">
+                                        <em class="fas fa-ban"></em>
+                                    </span>
+                                    <span class="icon has-text-warning" x-show="needsParser.indexOf(ability.name) > -1">
+                                        <em class="fas fa-exclamation-triangle"></em>
+                                    </span>
+                                </div>
+                            </td>
+                            <td x-text="ability.ability_id ? ability.name : 'Undefined Ability'"></td>
+                            <template x-if="!ability.ability_id">
+                                <td colspan="7" x-text="'ID - ' + abilityIDs[index]"></td>
+                            </template>
+                            <td x-show="undefinedAbilities.indexOf(ability.ability_id)">
                                 <span x-text="ability.tactic" x-bind:style="`border-bottom: 1px ridge ${hashStringToColor(ability.tactic)}`"></span>
                             </td>
-                            <td x-text="ability.technique_name"></td>
-                            <td>
+                            <td x-text="ability.technique_name" x-show="undefinedAbilities.indexOf(ability.ability_id)"></td>
+                            <td x-show="undefinedAbilities.indexOf(ability.ability_id)">
                                 <template x-for="platform of getExecutorDetail('platforms', ability)">
-                                    <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:data-tooltip="platform">
+                                    <span class="has-tooltip-arrow no-underline" x-bind:data-tooltip="platform">
                                         <span class="icon is-small"><em class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
                                     </span>
                                 </template>
                             </td>
-                            <td class="has-text-centered" x-bind:class="{ 'unlock': onHoverUnlocks.indexOf(ability.ability_id) > -1 }">
-                                <span class=" has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('requirements', ability)" x-bind:data-tooltip="`This ability has requirements: (${abilityDependencies[ability.ability_id].requireTypes})`">
+                            <td class="has-text-centered" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:class="{ 'unlock': onHoverUnlocks.indexOf(ability.ability_id) > -1 }">
+                                <span class=" has-tooltip-arrow no-underline" x-show="getExecutorDetail('requirements', ability)" x-bind:data-tooltip="`This ability has requirements: (${abilityDependencies[ability.ability_id].requireTypes})`">
                                     <span class="icon is-small"><em class="fas fa-lock"></em></span>
                                 </span>
                             </td>
-                            <td class="has-text-centered" x-bind:class="{ 'lock': onHoverLocks.indexOf(ability.ability_id) > -1 }">
-                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('parser', ability)" x-bind:data-tooltip="`This ability unlocks other abilities: (${abilityDependencies[ability.ability_id].enableTypes})`">
+                            <td class="has-text-centered" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:class="{ 'lock': onHoverLocks.indexOf(ability.ability_id) > -1 }">
+                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('parser', ability)" x-bind:data-tooltip="`This ability unlocks other abilities: (${abilityDependencies[ability.ability_id].enableTypes})`">
                                     <span class="icon is-small"><em class="fas fa-key"></em></span>
                                 </span>
                             </td>
-                            <td class="has-text-centered">
-                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('payload', ability)" data-tooltip="This ability uses a payload">
+                            <td class="has-text-centered" x-show="undefinedAbilities.indexOf(ability.ability_id)">
+                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('payload', ability)" data-tooltip="This ability uses a payload">
                                     <span class="icon is-small"><em class="fas fa-weight-hanging"></em></span>
                                 </span>
                             </td>
-                            <td class="has-text-centered">
-                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('cleanup', ability)" data-tooltip="This ability can clean itself up">
+                            <td class="has-text-centered" x-show="undefinedAbilities.indexOf(ability.ability_id)">
+                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('cleanup', ability)" data-tooltip="This ability can clean itself up">
                                     <span class="icon is-small"><em class="fas fa-trash"></em></span>
                                 </span>
                             </td>
@@ -151,11 +168,10 @@
                 <span>One or more of the abilities have unmet requirements, which may result in a failed operation if ran sequentially.</span>
             </div>
             <div class="icon-text mt-2" x-show="undefinedAbilities.length">
-                <span class="icon has-text-warning">
-                    <em class="fas fa-exclamation-triangle"></em>
+                <span class="icon has-text-danger">
+                    <em class="fas fa-ban"></em>
                 </span>
                 <span>One or more of the referenced abilities are not defined.</span>
-                <span x-text="index"></span>
             </div>
         </div>
     </template>
@@ -746,6 +762,7 @@
             // Global page variables
             adversaries: [],
             abilities: [],
+			abilityIDs: [],
             objectives: [],
             platforms: JSON.parse('{{ platforms | tojson }}'),
             payloads: JSON.parse('{{ payloads | tojson }}').sort(),
@@ -836,7 +853,7 @@
                 this.selectedProfileDescription = selectedAdversary.description;
                 this.selectedObjectiveId = this.objectives.find((objective) => objective.id === selectedAdversary.objective).id;
                 this.selectedProfileAbilities = selectedAdversary.atomic_ordering.map((ability_id) => ({ ...this.abilities.find((ability) => ability.ability_id === ability_id) }));
-
+                this.abilityIDs = selectedAdversary.atomic_ordering;
                 this.findAbilityDependencies();
             },
 
@@ -979,7 +996,7 @@
                 this.selectedProfileAbilities.forEach((ability, index) => {	
 					let requireTypes = [];
                     let enableTypes = [];
-						 
+
                     //skip building out enable types and require types if ability is unknown
                     if(ability.ability_id != undefined) {    
 
@@ -1340,14 +1357,14 @@
         cursor: pointer;
     }
 
-    .grey-out-unclickable {
+    .red-row-unclickable {
         pointer-events: none;
         font-weight: bold;
-        border: 2px solid orange;
+        border: 3px solid #8B0000;
     }
 
-    .red-row {
-        border: 3px solid #8B0000;
+    .orange-row {
+        border: 2px solid orange;
     }
 
     .row-hover {

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -101,7 +101,7 @@
                 </thead>
                 <tbody>
                     <template x-for="(ability, index) of selectedProfileAbilities">
-                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1, 'row-hover': ability.ability_id === abilityTableDragHoverId }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id">
+                        <tr @click="selectAbility(ability.ability_id)" class="ability-row" x-bind:class="{ 'red-row': needsParser.indexOf(ability.name) > -1 , 'row-hover': ability.ability_id === abilityTableDragHoverId, 'grey-out-unclickable': undefinedAbilities.indexOf(ability.ability_id) > -1 }" x-on:mouseenter="setAbilityHover(ability.ability_id)" x-on:mouseleave="clearAbilityHover()" x-on:dragenter="abilityTableDragHoverId = ability.ability_id">
                             <td class="has-text-centered drag" @click.stop draggable="true" x-on:dragstart="startAbilitySwap"  x-on:dragover.prevent="swapAbilitiesHover" x-on:dragend="swapAbilities">&#9776;</td>
                             <td x-text="index + 1"></td>
                             <td x-text="ability.name"></td>
@@ -112,27 +112,27 @@
                             <td>
                                 <template x-for="platform of getExecutorDetail('platforms', ability)">
                                     <span class="has-tooltip-arrow no-underline" x-bind:data-tooltip="platform">
-                                        <span class="icon is-small"><em class="fab" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
+                                        <span class="icon is-small"><em class="fab" x-show="undefinedAbilities.indexOf(ability.ability_id)" x-bind:class="if (platform.includes('windows')) return 'fa-windows'; else if (platform.includes('darwin')) return 'fa-apple'; else if (platform.includes('linux')) return 'fa-linux'"></em></span>
                                     </span>
                                 </template>
                             </td>
                             <td class="has-text-centered" x-bind:class="{ 'unlock': onHoverUnlocks.indexOf(ability.ability_id) > -1 }">
-                                <span class=" has-tooltip-arrow no-underline" x-show="getExecutorDetail('requirements', ability)" x-bind:data-tooltip="`This ability has requirements: (${abilityDependencies[ability.ability_id].requireTypes})`">
+                                <span class=" has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('requirements', ability)" x-bind:data-tooltip="`This ability has requirements: (${abilityDependencies[ability.ability_id].requireTypes})`">
                                     <span class="icon is-small"><em class="fas fa-lock"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered" x-bind:class="{ 'lock': onHoverLocks.indexOf(ability.ability_id) > -1 }">
-                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('parser', ability)" x-bind:data-tooltip="`This ability unlocks other abilities: (${abilityDependencies[ability.ability_id].enableTypes})`">
+                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('parser', ability)" x-bind:data-tooltip="`This ability unlocks other abilities: (${abilityDependencies[ability.ability_id].enableTypes})`">
                                     <span class="icon is-small"><em class="fas fa-key"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered">
-                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('payload', ability)" data-tooltip="This ability uses a payload">
+                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('payload', ability)" data-tooltip="This ability uses a payload">
                                     <span class="icon is-small"><em class="fas fa-weight-hanging"></em></span>
                                 </span>
                             </td>
                             <td class="has-text-centered">
-                                <span class="has-tooltip-arrow no-underline" x-show="getExecutorDetail('cleanup', ability)" data-tooltip="This ability can clean itself up">
+                                <span class="has-tooltip-arrow no-underline" x-show="undefinedAbilities.indexOf(ability.ability_id) && getExecutorDetail('cleanup', ability)" data-tooltip="This ability can clean itself up">
                                     <span class="icon is-small"><em class="fas fa-trash"></em></span>
                                 </span>
                             </td>
@@ -149,6 +149,12 @@
                     <em class="fas fa-exclamation-triangle"></em>
                 </span>
                 <span>One or more of the abilities have unmet requirements, which may result in a failed operation if ran sequentially.</span>
+            </div>
+            <div class="icon-text mt-2" x-show="undefinedAbilities.length">
+                <span class="icon has-text-warning">
+                    <em class="fas fa-exclamation-triangle"></em>
+                </span>
+                <span>One or more of the referenced abilities are not defined.</span>
             </div>
         </div>
     </template>
@@ -752,6 +758,7 @@
             // Ability dependencies & parsers
             abilityDependencies: {},
             needsParser: [],
+            undefinedAbilities: [],
             onHoverUnlocks: [],
             onHoverLocks: [],
             isTacticBreakdownActive: false,
@@ -966,25 +973,33 @@
                 const types = {};
                 let factsCollected = [];
                 let factsRequired = [];
+                this.undefinedAbilities = [];
 
-                this.selectedProfileAbilities.forEach((ability, index) => {
-                    let requireTypes = [];
+                this.selectedProfileAbilities.forEach((ability, index) => {	
+					let requireTypes = [];
                     let enableTypes = [];
+						 
+                    //skip building out enable types and require types if ability is unknown
+                    if(ability.ability_id != undefined) {    
 
-                    // Get all parser types from executors
-                    ability.executors.forEach((executor) => {
-                        executor.parsers.forEach((parser) => {
-                            enableTypes = enableTypes.concat(parser.parserconfigs.map((rel) => rel.source));
+                        // Get all parser types from executors
+                        ability.executors.forEach((executor) => {
+                            executor.parsers.forEach((parser) => {
+                                enableTypes = enableTypes.concat(parser.parserconfigs.map((rel) => rel.source));
+                            });
                         });
-                    });
 
-                    // Get all requirement types
-                    ability.requirements.forEach((requirement) => {
-                        requireTypes = requireTypes.concat(requirement.relationship_match.map((match) => match.source));
-                    });
+                        // Get all requirement types
+                        ability.requirements.forEach((requirement) => {
+                            requireTypes = requireTypes.concat(requirement.relationship_match.map((match) => match.source));
+                        });
+                    
+                    } else {
+                        this.undefinedAbilities.push(ability.ability_id);
+                    }
 
-                    types[ability.ability_id] = {
-                        enableTypes: [...new Set(enableTypes)],
+				    types[ability.ability_id] = {
+                	    enableTypes: [...new Set(enableTypes)],
                         requireTypes: [...new Set(requireTypes)]
                     };
                 });
@@ -1322,6 +1337,12 @@
 
     .pointer {
         cursor: pointer;
+    }
+
+    .grey-out-unclickable {
+        pointer-events: none;
+        color: grey;
+        border: 2px solid #ffdd57;
     }
 
     .red-row {

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -1038,8 +1038,9 @@
                 yaml += `description: ${this.selectedProfileDescription}\n`;
                 yaml += `objective: ${this.selectedObjectiveId}\n`;
                 yaml += `atomic_ordering:\n`;
-                this.selectedProfileAbilities.forEach((ability) => yaml += `- ${ability.ability_id}\n`);
-
+                this.selectedProfileAbilities.forEach((ability, index) => 
+                    ability.ability_id ? yaml += `- ${ability.ability_id}\n` : yaml += `- ${this.abilityIDs[index]}\n`);
+                console.log(this.selectedProfileAbilities)
                 const blob = new Blob([yaml], { type: 'application/x-yaml' })
                 const url = window.URL.createObjectURL(blob);
                 const a = document.createElement('a');
@@ -1050,6 +1051,7 @@
                 a.click();
                 window.URL.revokeObjectURL(url);
             },
+
 
             getAdversaryTactics() {
                 this.adversaries.forEach((adversary) => {

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -964,12 +964,15 @@
                 let hasPayload = false;
                 let hasParser = false;
 
-                ability.executors.forEach((executor) => {
-                    if (executor.cleanup.length > 0) hasCleanup = true;
-                    if (executor.parsers.length > 0) hasParser = true;
-                    if (executor.payloads.length > 0) hasPayload = true;
-                    plats.push(`${executor.platform} (${executorNameMap.get(executor.name) || executor.name})`);
-                });
+                if(ability.executors)
+                {
+                    ability.executors.forEach((executor) => {
+                        if (executor.cleanup.length > 0) hasCleanup = true;
+                        if (executor.parsers.length > 0) hasParser = true;
+                        if (executor.payloads.length > 0) hasPayload = true;
+                        plats.push(`${executor.platform} (${executorNameMap.get(executor.name) || executor.name})`);
+                    });
+                }
 
                 switch (detail) {
                 case 'cleanup':
@@ -979,7 +982,9 @@
                 case 'payload':
                     return hasPayload;
                 case 'requirements':
-                    return ability.requirements.length > 0;
+                    if(ability.requirements){
+                        return ability.requirements.length > 0;
+                    }
                 case 'platforms':
                     return plats;
                 default:
@@ -994,7 +999,7 @@
                 this.undefinedAbilities = [];
 
                 this.selectedProfileAbilities.forEach((ability, index) => {	
-					let requireTypes = [];
+                    let requireTypes = [];
                     let enableTypes = [];
 
                     //skip building out enable types and require types if ability is unknown
@@ -1016,8 +1021,8 @@
                         this.undefinedAbilities.push(ability.ability_id);
                     }
 
-				    types[ability.ability_id] = {
-                	    enableTypes: [...new Set(enableTypes)],
+                    types[ability.ability_id] = {
+                        enableTypes: [...new Set(enableTypes)],
                         requireTypes: [...new Set(requireTypes)]
                     };
                 });
@@ -1029,9 +1034,11 @@
 
                     // For each parser, look at and forward for any ability it unlocks
                     types[ability.ability_id].enableTypes.forEach((key) => {
-                        for (let i = index; i < this.selectedProfileAbilities.length; i++) {
-                            if (types[this.selectedProfileAbilities[i].ability_id].requireTypes.indexOf(key) > -1) {
-                                enablesAbilityIds.push(this.selectedProfileAbilities[i].ability_id);
+                        if(this.selectedProfileAbilities) {
+                            for (let i = index; i < this.selectedProfileAbilities.length; i++) {
+                                if (types[this.selectedProfileAbilities[i].ability_id].requireTypes.indexOf(key) > -1) {
+                                    enablesAbilityIds.push(this.selectedProfileAbilities[i].ability_id);
+                                }
                             }
                         }
                     });
@@ -1299,8 +1306,10 @@
 
             hashStringToColor(str) {
                 let hash = 5381;
-                for (let i = 0; i < str.length; i++) {
-                    hash = ((hash << 5) + hash) + str.charCodeAt(i);
+                if(str) {
+                    for (let i = 0; i < str.length; i++) {
+                        hash = ((hash << 5) + hash) + str.charCodeAt(i);
+                    }
                 }
 
                 let r = (hash & 0xFF0000) >> 16;

--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -1040,7 +1040,6 @@
                 yaml += `atomic_ordering:\n`;
                 this.selectedProfileAbilities.forEach((ability, index) => 
                     ability.ability_id ? yaml += `- ${ability.ability_id}\n` : yaml += `- ${this.abilityIDs[index]}\n`);
-                console.log(this.selectedProfileAbilities)
                 const blob = new Blob([yaml], { type: 'application/x-yaml' })
                 const url = window.URL.createObjectURL(blob);
                 const a = document.createElement('a');


### PR DESCRIPTION
## Description

Previously an "undefined ability" (An ability ID in the atomic ordering the .yml file that does not map to a known ability) would cause the UI to lock up and require a page reload. This PR resolves that lock up and adds a series of UI indicators to inform the user of the problem. Specifically a Icon and error message appears at the bottom of the Ability table. Also the undefined abilities are highlighted in red and call out the unknown Ability ID from the .yml file.  This change also involved changing the look of the "unmet requirements" call out from a red outline to a orange outline to better fit the icons in use. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I added multiple "bogus" Ability IDs in the .yml file (data/adversaries/ade13716-230a-48ea-a9b6-2446c83fe716.yml) and verified that they locked up the page before. After my fix I verified that they no longer lock up the page or cause any unexpected behavior to occur. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

### Screenshots of new callouts:

Undefined Ability and Unmet Requirements:
![Screen Shot 2022-05-10 at 8 37 45 AM](https://user-images.githubusercontent.com/17558505/167629956-b4c20479-8151-4951-b648-ffb711caf57e.png)

Undefined Ability:
![Screen Shot 2022-05-10 at 8 37 34 AM](https://user-images.githubusercontent.com/17558505/167629959-ddaf6f2a-a242-48a5-9db4-5446d0e45eef.png)

