### PR TITLE
Prevent payload config file overwrite

### DIFF
--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -357,7 +357,7 @@ class DataService(DataServiceInterface, BaseService):
         overlap = set(old_dict).intersection(new_dict)
         for payload in overlap:
             self.log.warning('Config for %s already exists in the %s section of the payloads config and will be '
-                          'overridden by plugin %s', payload, config_section_name, curr_plugin_name)
+                             'overridden by plugin %s', payload, config_section_name, curr_plugin_name)
 
     async def _load_planners(self, plugin):
         for filename in glob.iglob('%s/planners/*.yml' % plugin.data_dir, recursive=False):

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -356,7 +356,7 @@ class DataService(DataServiceInterface, BaseService):
     def _check_payload_overlaps(self, old_dict, new_dict, config_section_name, curr_plugin_name):
         overlap = set(old_dict).intersection(new_dict)
         for payload in overlap:
-            self.log.warn('Config for %s already exists in the %s section of the payloads config and will be '
+            self.log.warning('Config for %s already exists in the %s section of the payloads config and will be '
                           'overridden by plugin %s', payload, config_section_name, curr_plugin_name)
 
     async def _load_planners(self, plugin):

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -1,4 +1,3 @@
-import asyncio
 import glob
 import json
 import yaml
@@ -165,7 +164,7 @@ class TestDataService:
     @mock.patch.object(BaseWorld, 'strip_yml', wraps=strip_payload_yaml)
     @mock.patch('app.service.data_svc.DataService._apply_special_payload_hooks')
     @mock.patch('app.service.data_svc.DataService._apply_special_extension_hooks')
-    async def test_load_payloads(self, mock_ext_hooks, mock_payload_hooks, mock_strip_yml, data_svc):
+    def test_load_payloads(self, mock_ext_hooks, mock_payload_hooks, mock_strip_yml, event_loop, data_svc):
         def _mock_apply_payload_config(config=None, **_):
             TestDataService.mock_payload_config = config
 
@@ -174,7 +173,7 @@ class TestDataService:
         with patch.object(glob, 'iglob', return_value=['path1', 'path2']) as mock_iglob:
             with patch.object(BaseWorld, 'apply_config', wraps=_mock_apply_payload_config) as mock_apply_config:
                 with patch.object(DataService, 'get_config', return_value=self.mock_payload_config):
-                    await data_svc._load_payloads(test_plugin)
+                    event_loop.run_until_complete(data_svc._load_payloads(test_plugin))
         mock_iglob.assert_called_once_with('test_plugin/data/payloads/*.yml', recursive=False)
         mock_strip_yml.assert_has_calls([call('path1'), call('path2')])
         mock_payload_hooks.assert_has_calls([
@@ -206,7 +205,7 @@ class TestDataService:
         with patch.object(glob, 'iglob', return_value=['path3']) as mock_iglob2:
             with patch.object(BaseWorld, 'apply_config', wraps=_mock_apply_payload_config) as mock_apply_config2:
                 with patch.object(DataService, 'get_config', return_value=self.mock_payload_config):
-                    await data_svc._load_payloads(test_plugin2)
+                    event_loop.run_until_complete(data_svc._load_payloads(test_plugin2))
         mock_iglob2.assert_called_once_with('test_plugin2/data/payloads/*.yml', recursive=False)
         mock_strip_yml.assert_called_with('path3')
         mock_payload_hooks.assert_called_with(PAYLOAD_CONFIG_YAMLS['path3'][0]['special_payloads'])

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -1,14 +1,82 @@
+import glob
 import json
+import yaml
+
+from unittest import mock
+from unittest.mock import patch, call
 
 from app.objects.c_ability import Ability
 from app.objects.c_adversary import Adversary
 from app.objects.c_agent import Agent
 from app.objects.c_operation import Operation
 from app.objects.c_planner import Planner
+from app.objects.c_plugin import Plugin
 from app.objects.secondclass.c_executor import Executor
+from app.service.data_svc import DataService
+from app.utility.base_world import BaseWorld
+
+
+PAYLOAD_CONFIG_YAMLS = {
+    'path1': [yaml.safe_load('''
+---
+id: testid1
+name: Plugin1 Payloads
+standard_payloads:
+  file.exe:
+    description: file desc
+    id: fileid1
+  file.ps1:
+    description: file desc
+    id: fileid2
+special_payloads:
+  file.go:
+    description: file desc
+    id: specialid1
+    service: stockpile_svc
+    function: funcname
+extensions:
+  .donut: plugins.stockpile.app.donut.donut_handler
+''')],
+    'path2': [yaml.safe_load('''
+---
+id: testid2
+name: Plugin1 Payloads 2
+standard_payloads:
+  file.py:
+    description: file desc
+    id: fileid3
+  file.txt:
+    description: file desc
+    id: fileid4
+special_payloads:
+  file.cpp:
+    description: file desc
+    id: specialid2
+    service: stockpile_svc
+    function: funcname
+''')],
+    'path3': [yaml.safe_load('''
+---
+id: testid3
+name: Plugin2 Payloads
+special_payloads:
+  special.py:
+    description: file desc
+    id: specialid3
+    service: stockpile_svc
+    function: funcname
+extensions:
+  .testext: handler
+''')],
+}
+
+
+def strip_payload_yaml(path):
+    return PAYLOAD_CONFIG_YAMLS.get(path, [])
 
 
 class TestDataService:
+    mock_payload_config = dict()
 
     def test_no_duplicate_adversary(self, event_loop, data_svc):
         event_loop.run_until_complete(data_svc.store(
@@ -92,3 +160,72 @@ class TestDataService:
         for ability in abilities:
             for executor in ability.executors:
                 assert not executor.cleanup
+
+    @mock.patch.object(BaseWorld, 'strip_yml', wraps=strip_payload_yaml)
+    @mock.patch('app.service.data_svc.DataService._apply_special_payload_hooks')
+    @mock.patch('app.service.data_svc.DataService._apply_special_extension_hooks')
+    async def test_load_payloads(self, mock_ext_hooks, mock_payload_hooks, mock_strip_yml, data_svc):
+        def _mock_apply_payload_config(config=None, **_):
+            TestDataService.mock_payload_config = config
+
+        test_plugin = Plugin(data_dir='test_plugin/data')
+        test_plugin2 = Plugin(data_dir='test_plugin2/data')
+        with patch.object(glob, 'iglob', return_value=['path1', 'path2']) as mock_iglob:
+            with patch.object(BaseWorld, 'apply_config', wraps=_mock_apply_payload_config) as mock_apply_config:
+                with patch.object(DataService, 'get_config', return_value=self.mock_payload_config):
+                    await data_svc._load_payloads(test_plugin)
+        mock_iglob.assert_called_once_with('test_plugin/data/payloads/*.yml', recursive=False)
+        mock_strip_yml.assert_has_calls([call('path1'), call('path2')])
+        mock_payload_hooks.assert_has_calls([
+            call(PAYLOAD_CONFIG_YAMLS['path1'][0]['special_payloads']),
+            call(PAYLOAD_CONFIG_YAMLS['path2'][0]['special_payloads']),
+        ], any_order=True)
+        mock_ext_hooks.assert_has_calls([
+            call(dict()),
+            call(PAYLOAD_CONFIG_YAMLS['path1'][0]['extensions']),
+        ], any_order=True)
+
+        expected_config_part1 = {
+            'standard_payloads': {
+                'file.exe': PAYLOAD_CONFIG_YAMLS['path1'][0]['standard_payloads']['file.exe'],
+                'file.ps1': PAYLOAD_CONFIG_YAMLS['path1'][0]['standard_payloads']['file.ps1'],
+                'file.py': PAYLOAD_CONFIG_YAMLS['path2'][0]['standard_payloads']['file.py'],
+                'file.txt': PAYLOAD_CONFIG_YAMLS['path2'][0]['standard_payloads']['file.txt'],
+            },
+            'special_payloads': {
+                'file.go': PAYLOAD_CONFIG_YAMLS['path1'][0]['special_payloads']['file.go'],
+                'file.cpp': PAYLOAD_CONFIG_YAMLS['path2'][0]['special_payloads']['file.cpp'],
+            },
+            'extensions': {
+                '.donut': PAYLOAD_CONFIG_YAMLS['path1'][0]['extensions']['.donut'],
+            }
+        }
+        mock_apply_config.assert_called_once_with(name='payloads', config=expected_config_part1)
+
+        with patch.object(glob, 'iglob', return_value=['path3']) as mock_iglob2:
+            with patch.object(BaseWorld, 'apply_config', wraps=_mock_apply_payload_config) as mock_apply_config2:
+                with patch.object(DataService, 'get_config', return_value=self.mock_payload_config):
+                    await data_svc._load_payloads(test_plugin2)
+        mock_iglob2.assert_called_once_with('test_plugin2/data/payloads/*.yml', recursive=False)
+        mock_strip_yml.assert_called_with('path3')
+        mock_payload_hooks.assert_called_with(PAYLOAD_CONFIG_YAMLS['path3'][0]['special_payloads'])
+        mock_ext_hooks.assert_called_with(PAYLOAD_CONFIG_YAMLS['path3'][0]['extensions'])
+
+        expected_config_part2 = {
+            'standard_payloads': {
+                'file.exe': PAYLOAD_CONFIG_YAMLS['path1'][0]['standard_payloads']['file.exe'],
+                'file.ps1': PAYLOAD_CONFIG_YAMLS['path1'][0]['standard_payloads']['file.ps1'],
+                'file.py': PAYLOAD_CONFIG_YAMLS['path2'][0]['standard_payloads']['file.py'],
+                'file.txt': PAYLOAD_CONFIG_YAMLS['path2'][0]['standard_payloads']['file.txt'],
+            },
+            'special_payloads': {
+                'file.go': PAYLOAD_CONFIG_YAMLS['path1'][0]['special_payloads']['file.go'],
+                'file.cpp': PAYLOAD_CONFIG_YAMLS['path2'][0]['special_payloads']['file.cpp'],
+                'special.py': PAYLOAD_CONFIG_YAMLS['path3'][0]['special_payloads']['special.py'],
+            },
+            'extensions': {
+                '.donut': PAYLOAD_CONFIG_YAMLS['path1'][0]['extensions']['.donut'],
+                '.testext': PAYLOAD_CONFIG_YAMLS['path3'][0]['extensions']['.testext'],
+            }
+        }
+        mock_apply_config2.assert_called_once_with(name='payloads', config=expected_config_part2)

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -66,6 +66,11 @@ special_payloads:
     id: specialid3
     service: stockpile_svc
     function: funcname
+  file.cpp:
+    description: overridden desc
+    id: overridden
+    service: stockpile_svc
+    function: overridden
 extensions:
   .testext: handler
 ''')],
@@ -188,7 +193,6 @@ class TestDataService:
             call(PAYLOAD_CONFIG_YAMLS['path2'][0]['special_payloads']),
         ], any_order=True)
         mock_ext_hooks.assert_has_calls([
-            call(dict()),
             call(PAYLOAD_CONFIG_YAMLS['path1'][0]['extensions']),
         ], any_order=True)
 
@@ -227,7 +231,8 @@ class TestDataService:
             },
             'special_payloads': {
                 'file.go': PAYLOAD_CONFIG_YAMLS['path1'][0]['special_payloads']['file.go'],
-                'file.cpp': PAYLOAD_CONFIG_YAMLS['path2'][0]['special_payloads']['file.cpp'],
+                # test override
+                'file.cpp': PAYLOAD_CONFIG_YAMLS['path3'][0]['special_payloads']['file.cpp'],
                 'special.py': PAYLOAD_CONFIG_YAMLS['path3'][0]['special_payloads']['special.py'],
             },
             'extensions': {

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -1,3 +1,4 @@
+import asyncio
 import glob
 import json
 import yaml
@@ -73,6 +74,12 @@ extensions:
 
 def strip_payload_yaml(path):
     return PAYLOAD_CONFIG_YAMLS.get(path, [])
+
+
+def async_mock_return(to_return):
+    mock_future = asyncio.Future()
+    mock_future.set_result(to_return)
+    return mock_future
 
 
 class TestDataService:
@@ -162,8 +169,10 @@ class TestDataService:
                 assert not executor.cleanup
 
     @mock.patch.object(BaseWorld, 'strip_yml', wraps=strip_payload_yaml)
-    @mock.patch('app.service.data_svc.DataService._apply_special_payload_hooks')
-    @mock.patch('app.service.data_svc.DataService._apply_special_extension_hooks')
+    # @mock.patch('app.service.data_svc.DataService._apply_special_payload_hooks', return_value=)
+    # @mock.patch('app.service.data_svc.DataService._apply_special_extension_hooks')
+    @mock.patch.object(DataService, '_apply_special_payload_hooks', return_value=async_mock_return(None))
+    @mock.patch.object(DataService, '_apply_special_extension_hooks', return_value=async_mock_return(None))
     def test_load_payloads(self, mock_ext_hooks, mock_payload_hooks, mock_strip_yml, event_loop, data_svc):
         def _mock_apply_payload_config(config=None, **_):
             TestDataService.mock_payload_config = config

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -169,8 +169,6 @@ class TestDataService:
                 assert not executor.cleanup
 
     @mock.patch.object(BaseWorld, 'strip_yml', wraps=strip_payload_yaml)
-    # @mock.patch('app.service.data_svc.DataService._apply_special_payload_hooks', return_value=)
-    # @mock.patch('app.service.data_svc.DataService._apply_special_extension_hooks')
     @mock.patch.object(DataService, '_apply_special_payload_hooks', return_value=async_mock_return(None))
     @mock.patch.object(DataService, '_apply_special_extension_hooks', return_value=async_mock_return(None))
     def test_load_payloads(self, mock_ext_hooks, mock_payload_hooks, mock_strip_yml, event_loop, data_svc):

--- a/tests/services/test_data_svc.py
+++ b/tests/services/test_data_svc.py
@@ -1,3 +1,4 @@
+import asyncio
 import glob
 import json
 import yaml


### PR DESCRIPTION
## Description
Previously, when loading payload config files from `plugins/[plugin_name]/data/payloads/*.yml`, the data service would overwrite the existing payload config each time it loads a new config yaml, so that only the last seen yaml gets saved. This PR addresses this bug by making sure all loaded yamls get combined into one since config yaml.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Wrote unit test to address the changes. Also tested with actual config yamls in two different plugins and confirmed that both configurations were combined and that the second one didn't overwrite the first. The test will also override the payload config from the first plugin, and I confirmed that the override occurred and that the logger produces the expected warning output (checked via `python3 -m pytest tests/services --log-cli-level=WARN`):
```
------------------------------------------------------------- live log call -------------------------------------------------------------
WARNING  data_svc:data_svc.py:359 Config for file.cpp already exists in the special_payloads section of the payloads config and will be overridden by plugin virtual
```




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
