### PR TITLE
Remove history list of "select a profile" input

### DIFF
--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -12,7 +12,7 @@
     <hr>
 
     <!-- ADVERSARY SELECTION -->
-    <form>
+    <form autocomplete="off">
         <div id="select-adversary" class="field has-addons">
             <label class="label" for="profile-search">Select a profile &nbsp;&nbsp;&nbsp;</label>
             <div class="control is-expanded auto-complete" x-data="{focusSearchResults: false}">


### PR DESCRIPTION
## Description

Change on the adversary page to correct a bug that show the list of previous search of adversary in front of the real list.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
