### PR TITLE
fix websockets stale async usage

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -10,17 +10,14 @@ class Contact(BaseWorld):
         self.name = 'websocket'
         self.description = 'Accept data through web sockets'
         self.log = self.create_logger('contact_websocket')
+        self.log.level = 100
         self.handler = Handler(services)
         self.stop_future = asyncio.Future()
 
     async def start(self):
         web_socket = self.get_config('app.contact.websocket')
         try:
-            async with websockets.serve(self.handler.handle, *web_socket.split(':')):
-                # as soon as we start serving from websockets, we need to suppress their excessive debug messages
-                self.log.manager.loggerDict['websockets.protocol'].level = 100
-                self.log.manager.loggerDict['websockets.server'].level = 100
-
+            async with websockets.serve(self.handler.handle, *web_socket.split(':'), logger=self.log):
                 await self.stop_future
 
         except OSError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2==3.0.3
 pyyaml>=5.1
 cryptography>=3.2,<37.0.0; python_version <= '3.7'
 cryptography>=3.2; python_version > '3.7'
-websockets==9.1
+websockets>=10.3
 Sphinx==3.0.4
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
## Description

Python 3.10 asyncio API and websockets 9.1 have breaking changes. Require update to websockets 10.3

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran Collection adversary on local sandcat agent on MacOS with python3.10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
