### PR TITLE
VIRTS-3370 Exfiltration Operations Subdirectory 

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -128,9 +128,11 @@ class RestApi(BaseWorld):
         dir_name = request.headers.get('Directory', None)
         if dir_name:
             return await self.file_svc.save_multipart_file_upload(request, 'data/payloads/')
-        created_dir = os.path.normpath('/' + request.headers.get('X-Request-ID', str(uuid.uuid4()))).lstrip('/')
+        agent = request.headers.get('X-Request-ID', str(uuid.uuid4()))
+        created_dir = os.path.normpath('/' + agent).lstrip('/')
         saveto_dir = await self.file_svc.create_exfil_sub_directory(dir_name=created_dir)
-        return await self.file_svc.save_multipart_file_upload(request, saveto_dir)
+        operation_dir = await self.file_svc.create_exfil_operation_directory(dir_name=saveto_dir, agent_name=agent[-6:])
+        return await self.file_svc.save_multipart_file_upload(request, operation_dir)
 
     async def download_file(self, request):
         try:

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -70,6 +70,17 @@ class FileSvc(FileServiceInterface, BaseService):
             os.makedirs(path)
         return path
 
+    async def create_exfil_operation_directory(self, dir_name, agent_name):
+        op_list = self.data_svc.ram['operations']
+        op_list_filtered = [x for x in op_list if x.state not in x.get_finished_states()]
+        special_chars = {ord(c): '_' for c in r':<>"/\|?*'}
+        agent_opid = [(x.name.translate(special_chars), '_', x.start.strftime("%Y-%m-%d_%H%M%SZ"))
+                      for x in op_list_filtered if agent_name in [y.paw for y in x.agents]]
+        path = os.path.join((dir_name), ''.join(agent_opid[0]))
+        if not os.path.exists(path):
+            os.makedirs(path)
+        return path
+
     async def save_multipart_file_upload(self, request, target_dir, encrypt=True):
         try:
             reader = await request.multipart()
@@ -165,14 +176,19 @@ class FileSvc(FileServiceInterface, BaseService):
             startdir = self.get_config('exfil_dir')
         if not os.path.exists(startdir):
             return dict()
-
         exfil_files = dict()
-        exfil_folders = [f.path for f in os.scandir(startdir) if f.is_dir()]
-        for d in exfil_folders:
-            exfil_key = d.split(os.sep)[-1]
-            exfil_files[exfil_key] = {}
-            for file in [f.path for f in os.scandir(d) if f.is_file()]:
-                exfil_files[exfil_key][file.split(os.sep)[-1]] = file
+        exfil_list = [x for x in os.walk(startdir) if x[2]]
+        for d in exfil_list:
+            agent_path = d[0]
+            exfil_agent_key = d[0].split(os.sep)[-2]
+            exfil_subdir = d[0].split(os.sep)[-1]
+            if exfil_agent_key not in exfil_files:
+                exfil_files[exfil_agent_key] = dict()
+            for file in d[-1]:
+                if exfil_subdir not in exfil_files[exfil_agent_key]:
+                    exfil_files[exfil_agent_key][exfil_subdir] = dict()
+                if file not in exfil_files[exfil_agent_key][exfil_subdir]:
+                    exfil_files[exfil_agent_key][exfil_subdir][file] = os.path.join(agent_path, file)
         return exfil_files
 
     @staticmethod

--- a/templates/exfilled_files.html
+++ b/templates/exfilled_files.html
@@ -30,20 +30,28 @@
                 <li class="root-child">
                     <span class="icon is-small"><i class="far fa-folder-open"></i></span>
                     <span x-text="agentName"></span>
-                    <ul class="tree">
-                        <template x-for="filename of Object.keys(files[agentName])" :key="filename">
-                            <li class="agent-child">
-                                <label class="checkbox">
-                                    <input type="checkbox" class="file-checkbox" x-bind:value="files[agentName][filename]" @click="toggleFile($el, files[agentName][filename])">
-                                    <span class="icon is-small"><i class="far fa-file-alt"></i></span>
-                                    <span x-text="filename"></span>
-                                </label>
-                            </li>
+                        <template x-for="operation of Object.keys(files[agentName])" :key="operation">
+                            <ul class="tree">
+                                <li class="agentName-child">
+                                    <span class="icon is-small"><i class="fas fa-dragon"></i></span>
+                                    <span x-text="operation"></span>
+                                    <ul class="tree">
+                                        <template x-for="filename of Object.keys(files[agentName][operation])" :key="filename">
+                                            <li class="agent-child">
+                                                <label class="checkbox">
+                                                    <input type="checkbox" class="file-checkbox" x-bind:value="files[agentName][operation][filename]" @click="toggleFile($el, files[agentName][operation][filename])">
+                                                    <span class="icon is-small"><i class="far fa-file-alt"></i></span>
+                                                    <span x-text="filename"></span>
+                                                </label>
+                                            </li>
+                                        </template>
+                                        <li class="agent-child" x-show="!Object.keys(files[agentName][operation]).length">
+                                            (none)
+                                        </li>
+                                    </ul>     
+                                </li>
+                            </ul>    
                         </template>
-                        <li class="agent-child" x-show="!Object.keys(files[agentName]).length">
-                            (none)
-                        </li>
-                    </ul>
                 </li>
             </template>
         </ul>  
@@ -194,6 +202,9 @@
         display: none;
     }
     ul.tree li.root-child:last-child:after {
+        display: none;
+    }
+    ul.tree li.agentName-child:after{
         display: none;
     }
     ul.tree li.agent-child:nth-last-child(2):after {


### PR DESCRIPTION
## Description

Caldera currently only goes one layer deep from the default directory when saving files. Each exfiltrated file is saved under the agent name. As such, if the same operation is run repeatedly, exfiltrated files with the same name will be overwritten.

This change creates an additional layer by adding a subdirectory using the operation's name and timestamp. The corresponding files are saved in a directory within the agent using a "YearMonthDay_HourMinuteSecond" format. This allows for the repeated running of an exfiltration adversary while preserving the exfiltrated files for each run. This change also provides visual feedback for which operation the file originated from. 

The html page was also updated to show the new tree structure.

Old structure:

- Exfiltration root folder (default: /tmp/caldera)
  - Agent Name Folder
    - Exfil File

New structure:

- Exfiltration Root Folder (default: /tmp/caldera)
  - Agent Name Folder
    - Operation Name/Time Folder
      - Exfil File

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Looked at Caldera logs to see if any additional bugs were generated when starting the server.

Used range to setup a single host-client environment. Ran a file exfiltration operation (i.e. Thief adversary) multiple times to test that exfiltrated file was preserved under the appropriate agent and folder.

Tested updated exfiltration page by navigating to and refreshing the page. Ensured that files were downloadable and correct by downloading and hashing said files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code