### PR TITLE
Minor tweaks to operations page

### DIFF
--- a/templates/adversaries.html
+++ b/templates/adversaries.html
@@ -12,7 +12,7 @@
     <hr>
 
     <!-- ADVERSARY SELECTION -->
-    <form>
+    <form autocomplete="off">
         <div id="select-adversary" class="field has-addons">
             <label class="label" for="profile-search">Select a profile &nbsp;&nbsp;&nbsp;</label>
             <div class="control is-expanded auto-complete" x-data="{focusSearchResults: false}" @click.outside="focusSearchResults = false; searchResults = []">
@@ -113,7 +113,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <template x-for="(ability, index) of selectedProfileAbilities">
+                    <template x-for="(ability, index) of selectedProfileAbilities" :key="ability.ability_id">
                         <tr @click="selectAbility(ability.ability_id)" class="ability-row" 
                             x-bind:class="{ 'orange-row': needsParser.indexOf(ability.name) > -1 ,
                                             'row-hover': ability.ability_id === abilityTableDragHoverId && abilityTableDragHoverId != undefined, 
@@ -1067,6 +1067,7 @@
                     adversary.tactics = [...new Set(tactics)];
                 });
                 this.adversarySearchResults = this.adversaries;
+                this.searchForAdversary()
             },
 
             linkObjective() {
@@ -1400,14 +1401,14 @@
                 const children = Array.from(event.target.parentNode.parentNode.children);
 
                 if (children.indexOf(event.target.parentNode) > children.indexOf(this.abilityTableDragTarget)) {
-                    this.abilityTableDragEndIndex = parseInt(event.target.parentNode.children[1].innerHTML, 10);
+                    this.abilityTableDragEndIndex = parseInt(event.target.parentNode.children[1].children[0].children[0].innerHTML, 10);
                 } else {
-                    this.abilityTableDragEndIndex = parseInt(event.target.parentNode.children[1].innerHTML, 10);
+                    this.abilityTableDragEndIndex = parseInt(event.target.parentNode.children[1].children[0].children[0].innerHTML, 10);
                 }
             },
 
             swapAbilities(event) {
-                const fromIndex = parseInt(this.abilityTableDragTarget.children[1].innerHTML, 10) - 1;
+                const fromIndex = parseInt(this.abilityTableDragTarget.children[1].children[0].children[0].innerHTML, 10) - 1;
                 const toIndex = this.abilityTableDragEndIndex - 1;
                 const temp = this.selectedProfileAbilities[fromIndex];
                 this.selectedProfileAbilities[fromIndex] = this.selectedProfileAbilities[toIndex];

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -396,7 +396,7 @@
                 <div class="modal-background" @click="openModal = null; selectPotentialLink({})"></div>
 
                 <template x-if="openModal === 'showOutput'">
-                    <div class="modal-card">
+                    <div class="modal-card wide">
                         <header class="modal-card-head">
                             <p class="modal-card-title">Output</p>
                         </header>
@@ -445,7 +445,7 @@
                 </template>
 
                 <template x-if="openModal === 'showCommand'">
-                    <div class="modal-card">
+                    <div class="modal-card wide">
                         <header class="modal-card-head">
                             <p class="modal-card-title">Command</p>
                         </header>
@@ -753,7 +753,7 @@
                                             <div class="control">
                                                 <div class="select is-small is-fullwidth">
                                                     <select id="link-agent" x-model="selectedAgentIndex" x-on:change="getAgent(selectedAgent.paw); potentialLink.agent = selectedAgent">
-                                                        <option default value="">Choose an agent</option>
+                                                        <option default disabled value="">Choose an agent</option>
                                                         <template x-for="(agent, index) in selectedOperation.host_group" :key="agent.paw">
                                                             <option :value="index" x-bind:selected="index === 0" x-text="agent.display_name + '-' + agent.paw"></option>
                                                         </template>
@@ -772,7 +772,7 @@
                                             <div class="control">
                                                 <div class="select is-small is-fullwidth">
                                                     <select id="link-exec" x-model="potentialLink.executor" x-on:change="filterAbilities(abilities)">
-                                                        <option default value="" disabled>Select an executor</option>
+                                                        <option value="" disabled>Select an executor</option>
                                                         <template x-for="(exec, index) of selectedAgentExecutors" :key="exec.executor">
                                                             <option x-text="exec.display" :value="exec.executor"></option>
                                                         </template>
@@ -840,7 +840,7 @@
                                 <p x-text="`${filteredAbilitiesList.length} potential link${((filteredAbilitiesList.length === 1) ? '' : 's')}`"></p>
                             </div>
                             <template x-for="ability in filteredAbilitiesList" :key="ability.ability_id">
-                                <div class="box mb-2 mr-2 p-3 ability" @click="selectPotentialLink(ability)">
+                                <div class="box mb-2 mr-2 p-3 op-ability" @click="selectPotentialLink(ability)">
                                     <p style="width: 90%">
                                         <span class="has-text-weight-bold" x-text="ability.name"></span>
                                         <span x-text="`(${ability.technique_id})`"></span>
@@ -1273,6 +1273,11 @@
             },
 
             resetOperationToStart() {
+                let defaultSourceId = 'ed32b9c3-9593-4c33-b0db-e2007315096b'  // basic fact source
+                if (!this.SOURCES.find((s) => s.id === defaultSourceId) && this.SOURCES[0]) {
+                    defaultSourceId = this.SOURCES[0].id
+                }
+
                 this.operationToStart = {
                     name: '',
                     group: '',
@@ -1281,7 +1286,7 @@
                     state: 'running',
                     autonomous: 1,
                     planner: { id: this.PLANNERS[0] ? this.PLANNERS[0].id : 'aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a' },
-                    source: { id: this.SOURCES[0] ? this.SOURCES[0].id : 'ed32b9c3-9593-4c33-b0db-e2007315096b' },
+                    source: { id: defaultSourceId },
                     use_learning_parsers: 1,
                     obfuscator: 'plain-text',
                     jitter: '2/8',
@@ -1454,10 +1459,9 @@
 
                 const executor = link.executors.find((e) => this.potentialLink.executor === e.name);
                 const fields = [...new Set([...executor.command.matchAll(/#{(.*?)}/gm)].map((field) => field[1]))];
-                const opSource = this.selectedOperation.source;
+                const opSource = this.SOURCES.find((s) => s.id === this.selectedOperation.source.id);
                 const opSourceCollected = this.SOURCES.find((source) => source.name === this.selectedOperation.name);
                 const facts = (opSource.facts.concat(opSourceCollected ? opSourceCollected.facts : [])).concat(this.facts);
-
                 this.potentialLinkCommand = executor.command;
 
                 fields.filter((field) => facts.find((fact) => fact.name === field)).forEach((field) => {
@@ -1747,13 +1751,13 @@
         font-size: 1em !important;
     }
 
-    #operationsPage .box.ability {
+    #operationsPage .box.op-ability {
         position: relative;
         cursor: pointer;
         border: 1px solid transparent;
         background-color: #272727;
     }
-    #operationsPage .box.ability:hover {
+    #operationsPage .box.op-ability:hover {
         border: 1px solid #474747;
     }
     #operationsPage .ability-icon {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -845,7 +845,7 @@
                                         <span class="has-text-weight-bold" x-text="ability.name"></span>
                                         <span x-text="`(${ability.technique_id})`"></span>
                                     </p>
-                                    <p class="help mb-0" x-text="ability.description" style="width: 90%; word-wrap: anywhere;"></p>
+                                    <p class="help mb-0" x-text="ability.description" style="width: 90%; white-space: pre-line;"></p>
                                     <span class="icon is-large ability-icon"><em class="fas fa-lg fa-arrow-right"></em></span>
                                 </div>
                             </template>
@@ -854,7 +854,7 @@
                         <section class="modal-card-body " x-show="selectedPotentialLink.ability_id">
                             <strong x-text="selectedPotentialLink.name" class="mb-2 is-size-4"></strong>
                             <span x-text="`(${selectedPotentialLink.technique_id})`"></span>
-                            <p x-text="selectedPotentialLink.description" style="word-wrap: anywhere;"></p>
+                            <p x-text="selectedPotentialLink.description" style="white-space: pre-line;"></p>
                             <hr>
                             <p class="has-text-centered has-text-weight-bold">Fact Templates</p>
                             <p class="help" x-show="Object.keys(selectedPotentialLinkFacts).length">


### PR DESCRIPTION
## Description

* Fixed width of ability cards in potential link window when Abilities page was opened
* When adding a potential link, facts are pulled from the fact sources API instead of the operation object to get the most recent fact values
* Command and output modals for links have been widened 
* Operations default to the 'basic' source, if it still exists
* Potential link ability descriptions respect newlines
* Fixed adversary drag-and-drop ordering
* Fixed adversary profile search via input

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
