### PR TITLE
Displaying un-encoded commands when using obfuscation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ calderaenv/
 conf/*.yml
 !conf/default.yml
 data/object_store
+data/fact_store
 data/results/*
 !data/results/.gitkeep
 data/payloads/*

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -292,10 +292,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           facts=[f.display for f in await self.all_facts()])
             agents_steps = {a.paw: {'steps': []} for a in self.agents}
             for step in self.chain:
-                plainTextCommand = "N/a"
+                plainTextCommand = ''
                 if(step.plaintext_command):
                     plainTextCommand = b64decode(step.plaintext_command).decode('utf-8')
-                
                 step_report = dict(link_id=step.id,
                                    ability_id=step.ability.ability_id,
                                    command=step.command,
@@ -363,10 +362,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.objective = deepcopy(obj[0])
 
     async def _convert_link_to_event_log(self, link, file_svc, data_svc, output=False):
-        plainTextCommand = "N/a"
+        plainTextCommand = ''
         if(link.plaintext_command):
             plainTextCommand = b64decode(link.plaintext_command).decode('utf-8')
-
         event_dict = dict(command=link.command,
                           plaintext_command=plainTextCommand,
                           delegated_timestamp=link.decide.strftime(self.TIME_FORMAT),

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
 from importlib import import_module
-from base64 import b64decode
 
 import marshmallow as ma
 

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -295,13 +295,10 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           facts=[f.display for f in await self.all_facts()])
             agents_steps = {a.paw: {'steps': []} for a in self.agents}
             for step in self.chain:
-                plainTextCommand = ''
-                if(step.plaintext_command):
-                    plainTextCommand = b64decode(step.plaintext_command).decode('utf-8')
                 step_report = dict(link_id=step.id,
                                    ability_id=step.ability.ability_id,
                                    command=step.command,
-                                   plaintext_command=plainTextCommand,
+                                   plaintext_command=step.plaintext_command,
                                    delegated=step.decide.strftime(self.TIME_FORMAT),
                                    run=step.finish,
                                    status=step.status,
@@ -365,11 +362,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.objective = deepcopy(obj[0])
 
     async def _convert_link_to_event_log(self, link, file_svc, data_svc, output=False):
-        plainTextCommand = ''
-        if(link.plaintext_command):
-            plainTextCommand = b64decode(link.plaintext_command).decode('utf-8')
         event_dict = dict(command=link.command,
-                          plaintext_command=plainTextCommand,
+                          plaintext_command=link.plaintext_command,
                           delegated_timestamp=link.decide.strftime(self.TIME_FORMAT),
                           collected_timestamp=link.collect.strftime(self.TIME_FORMAT) if link.collect else None,
                           finished_timestamp=link.finish,

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
 from importlib import import_module
+from base64 import b64decode
 
 import marshmallow as ma
 
@@ -291,9 +292,14 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           facts=[f.display for f in await self.all_facts()])
             agents_steps = {a.paw: {'steps': []} for a in self.agents}
             for step in self.chain:
+                plainTextCommand = "N/a"
+                if(step.plaintext_command):
+                    plainTextCommand = b64decode(step.plaintext_command).decode('utf-8')
+                
                 step_report = dict(link_id=step.id,
                                    ability_id=step.ability.ability_id,
                                    command=step.command,
+                                   plaintext_command=plainTextCommand,
                                    delegated=step.decide.strftime(self.TIME_FORMAT),
                                    run=step.finish,
                                    status=step.status,
@@ -357,7 +363,12 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.objective = deepcopy(obj[0])
 
     async def _convert_link_to_event_log(self, link, file_svc, data_svc, output=False):
+        plainTextCommand = "N/a"
+        if(link.plaintext_command):
+            plainTextCommand = b64decode(link.plaintext_command).decode('utf-8')
+
         event_dict = dict(command=link.command,
+                          plaintext_command=plainTextCommand,
                           delegated_timestamp=link.decide.strftime(self.TIME_FORMAT),
                           collected_timestamp=link.collect.strftime(self.TIME_FORMAT) if link.collect else None,
                           finished_timestamp=link.finish,

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -152,12 +152,12 @@ class Link(BaseObject):
     def is_global_variable(cls, variable):
         return variable in cls.RESERVED
 
-    def __init__(self, command='', paw='', ability=None, executor=None, status=-3, score=0, jitter=0, cleanup=0, id='',
+    def __init__(self, command='', plaintext_command=None, paw='', ability=None, executor=None, status=-3, score=0, jitter=0, cleanup=0, id='',
                  pin=0, host=None, deadman=False, used=None, relationships=None, agent_reported_time=None):
         super().__init__()
         self.id = str(id)
         self.command = command
-        self.plaintext_command = None
+        self.plaintext_command = plaintext_command
         self.command_hash = None
         self.paw = paw
         self.host = host

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -152,7 +152,7 @@ class Link(BaseObject):
     def is_global_variable(cls, variable):
         return variable in cls.RESERVED
 
-    def __init__(self, command='', plaintext_command=None, paw='', ability=None, executor=None, status=-3, score=0, jitter=0, cleanup=0, id='',
+    def __init__(self, command='', plaintext_command='', paw='', ability=None, executor=None, status=-3, score=0, jitter=0, cleanup=0, id='',
                  pin=0, host=None, deadman=False, used=None, relationships=None, agent_reported_time=None):
         super().__init__()
         self.id = str(id)

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -28,6 +28,7 @@ class LinkSchema(ma.Schema):
     id = ma.fields.String(missing='')
     paw = ma.fields.String()
     command = ma.fields.String()
+    plaintext_command = ma.fields.String()
     status = ma.fields.Integer(missing=-3)
     score = ma.fields.Integer(missing=0)
     jitter = ma.fields.Integer(missing=0)
@@ -156,6 +157,7 @@ class Link(BaseObject):
         super().__init__()
         self.id = str(id)
         self.command = command
+        self.plaintext_command = None
         self.command_hash = None
         self.paw = paw
         self.host = host
@@ -222,6 +224,7 @@ class Link(BaseObject):
     def replace_origin_link_id(self):
         decoded_cmd = self.decode_bytes(self.command)
         self.command = self.encode_string(decoded_cmd.replace(self.RESERVED['origin_link_id'], self.id))
+        self.plaintext_command = None
 
     def _emit_status_change_event(self, from_status, to_status):
         event_svc = BaseService.get_service('event_svc')

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -224,7 +224,7 @@ class Link(BaseObject):
     def replace_origin_link_id(self):
         decoded_cmd = self.decode_bytes(self.command)
         self.command = self.encode_string(decoded_cmd.replace(self.RESERVED['origin_link_id'], self.id))
-        self.plaintext_command = None
+        self.plaintext_command = decoded_cmd
 
     def _emit_status_change_event(self, from_status, to_status):
         event_svc = BaseService.get_service('event_svc')

--- a/app/utility/base_planning_svc.py
+++ b/app/utility/base_planning_svc.py
@@ -186,6 +186,7 @@ class BasePlanningService(BaseService):
         o = (await self.get_service('data_svc').locate('obfuscators', match=dict(name=obfuscator)))[0]
         mod = o.load(agent)
         for s_link in links:
+            s_link.plaintext_command = s_link.command
             s_link.command = self.encode_string(mod.run(s_link))
         return links
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,4 +17,4 @@ sonar.python.coverage.reportPaths=coverage.xml
 # Make an exception to Link's constructor, since it requires a refactor to pass
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
-sonar.issue.ignore.multicriteria.e1.resourceKey=./app/objects/secondclass/c_link.py
+sonar.issue.ignore.multicriteria.e1.resourceKey=app/objects/secondclass/c_link.py

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,3 +13,8 @@ sonar.sources=./app
 
 sonar.python.version=3.7,3.8,3.9,3.10
 sonar.python.coverage.reportPaths=coverage.xml
+
+# Make an exception to Link's constructor, since it requires a refactor to pass
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.e1.resourceKey=./app/objects/secondclass/c_link.py

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -463,7 +463,9 @@
                             <template x-if="!isLinkEditable(selectedLink)">
                                 <div>
                                     <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
-                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkPlaintextCommand"></pre>
+                                    <template x-if="selectedLinkPlaintextCommand">
+                                        <pre class="has-text-left white-space-pre-line" x-text="'Plaintext: ' + selectedLinkPlaintextCommand"></pre>
+                                    </template>
                                 </div>
                             </template>
                         </section>

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1680,7 +1680,14 @@
                             if (link.pid) agentDetails += `\nPid: ${link.pid}`;
                             rowItems.push(`"${agentDetails}"`);
                         } else if (col.className.includes('commandDetails')) {
-                            rowItems.push(`"${b64DecodeUnicode(link.command)}"`);
+                            if(link.plaintext_command && (link.command !== link.plaintext_command)) {
+                                rowItems.push(`Obfuscated: "${b64DecodeUnicode(link.command)}" | Plaintext: "${b64DecodeUnicode(link.plaintext_command)}"`);
+                            } else { 
+                                rowItems.push(`"${b64DecodeUnicode(link.command)}"`);
+                            }
+
+
+
                         } else if (col.className.includes('outputDetails')) {
                             rowItems.push(`"${link.facts}"`);
                         } else {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -463,6 +463,7 @@
                             <template x-if="!isLinkEditable(selectedLink)">
                                 <div>
                                     <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
+                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkPlaintextCommand"></pre>
                                 </div>
                             </template>
                         </section>
@@ -1566,6 +1567,7 @@
                             this.selectedLinkFacts = Array.from(new Set(res.facts)).sort((a, b) => b.score - a.score);
                         }
                         this.selectedLinkCommand = b64DecodeUnicode(res.command);
+                        this.selectedLinkPlaintextCommand = b64DecodeUnicode(res.plaintext_command);
                         this.editableCommand = b64DecodeUnicode(res.command);
                     })
                     .catch(() => {

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1773,31 +1773,17 @@
             },
 
             downloadCSV() {
-                const csv = [];
-                const rows = document.querySelector('#operationsPage').querySelectorAll('table tr:not(.csv-exclude)');
+                let csv = [ 'Decide,Link/Ability Name,Agent #paw,Host,pid,Command,Plaintext Command' ];
 
-                rows.forEach((row, i) => {
-                    const cols = row.querySelectorAll('td:not(.csv-exclude), th:not(.csv-exclude)');
+                this.selectedOperation.chain.forEach(async (link) => {
                     const rowItems = [];
-                    cols.forEach((col) => {
-                        const link = this.selectedOperation.chain[i - 1];
-                        if (col.className.includes('agentDetails')) {
-                            let agentDetails = `Agent #${link.paw}`;
-                            if (link.host) agentDetails += `\nHost: ${link.host}`;
-                            if (link.pid) agentDetails += `\nPid: ${link.pid}`;
-                            rowItems.push(`"${agentDetails}"`);
-                        } else if (col.className.includes('commandDetails')) {
-                            if(link.plaintext_command && (link.command !== link.plaintext_command)) {
-                                rowItems.push(`Obfuscated: "${b64DecodeUnicode(link.command)}" | Plaintext: "${b64DecodeUnicode(link.plaintext_command)}"`);
-                            } else { 
-                                rowItems.push(`"${b64DecodeUnicode(link.command)}"`);
-                            }
-                        } else if (col.className.includes('outputDetails')) {
-                            rowItems.push(`"${link.facts}"`);
-                        } else {
-                            rowItems.push(`"${col.innerText}"`);
-                        }
-                    });
+                    rowItems.push(link.decide);
+                    rowItems.push(link.ability.name);
+                    rowItems.push(link.paw);
+                    rowItems.push(link.host);
+                    rowItems.push(link.pid);
+                    rowItems.push(b64DecodeUnicode(link.command));
+                    rowItems.push(b64DecodeUnicode(link.plaintext_command));
                     csv.push(rowItems.join(','));
                 });
                 this.createDownloadReport(new Blob([csv.join('\n')], { type: 'text/csv' }), this.selectedOperation.name, true);

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1109,6 +1109,7 @@
             selectedLink: null,
             selectedLinkResults: null,
             selectedLinkFacts: null,
+            selectedLinkPlaintextCommand: null,
             selectedLinkCommand: null,
             selectedReportType: 'full-report',
             isAgentOutputSelected: false,
@@ -1585,6 +1586,7 @@
                         this.selectedLinkResults = null;
                         this.selectedLinkFacts = null;
                         this.selectedLinkCommand = null;
+                        this.selectedLinkPlaintextCommand = null;
                         toast('Error getting link results.');
                     });
             },

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -462,10 +462,19 @@
                             </template>
                             <template x-if="!isLinkEditable(selectedLink)">
                                 <div>
-                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
-                                    <template x-if="selectedLinkPlaintextCommand">
-                                        <pre class="has-text-left white-space-pre-line" x-text="'Plaintext: ' + selectedLinkPlaintextCommand"></pre>
-                                    </template>
+                                <template x-if="!selectedLinkPlaintextCommand || selectedLinkPlaintextCommand == selectedLinkCommand">      
+                                    <div>
+                                        <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
+                                    </div>
+                                </template>
+                                <template x-if="selectedLinkPlaintextCommand && selectedLinkPlaintextCommand !== selectedLinkCommand">
+                                    <div>
+                                        <p class="mt-3 mb-2">Obfuscated:</p>
+                                        <pre class="has-text-left white-space-pre-line" x-text="selectedLinkCommand"></pre>
+                                        <p class="mt-3 mb-2">Plaintext:</p>
+                                        <pre class="has-text-left white-space-pre-line" x-text="selectedLinkPlaintextCommand"></pre>
+                                    </div>
+                                </template>
                                 </div>
                             </template>
                         </section>

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1685,9 +1685,6 @@
                             } else { 
                                 rowItems.push(`"${b64DecodeUnicode(link.command)}"`);
                             }
-
-
-
                         } else if (col.className.includes('outputDetails')) {
                             rowItems.push(`"${link.facts}"`);
                         } else {

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -54,8 +54,8 @@ def operation_adversary(adversary):
 
 @pytest.fixture
 def operation_link():
-    def _generate_link(command, paw, ability, executor, pid=0, decide=None, collect=None, finish=None, **kwargs):
-        generated_link = Link(command, paw, ability, executor, **kwargs)
+    def _generate_link(command, plaintext_command, paw, ability, executor, pid=0, decide=None, collect=None, finish=None, **kwargs):
+        generated_link = Link(command, plaintext_command, paw, ability, executor, **kwargs)
         generated_link.pid = pid
         if decide:
             generated_link.decide = decide
@@ -88,17 +88,17 @@ def op_for_event_logs(operation_agent, operation_adversary, executor, ability, o
     ability_2 = ability(ability_id='456', tactic='test tactic', technique_id='T0000', technique_name='test technique',
                         name='test ability 2', description='test ability 2 desc', executors=[executor_2])
     link_1 = operation_link(ability=ability_1, paw=operation_agent.paw, executor=executor_1,
-                            command=encoded_command(command_1), status=0, host=operation_agent.host, pid=789,
+                            command=encoded_command(command_1), plaintext_command=encoded_command(command_1), status=0, host=operation_agent.host, pid=789,
                             decide=parse_datestring(LINK1_DECIDE_TIME),
                             collect=parse_datestring(LINK1_COLLECT_TIME),
                             finish=LINK1_FINISH_TIME)
     link_2 = operation_link(ability=ability_2, paw=operation_agent.paw, executor=executor_2,
-                            command=encoded_command(command_2), status=0, host=operation_agent.host, pid=7890,
+                            command=encoded_command(command_2), plaintext_command=encoded_command(command_2), status=0, host=operation_agent.host, pid=7890,
                             decide=parse_datestring(LINK2_DECIDE_TIME),
                             collect=parse_datestring(LINK2_COLLECT_TIME),
                             finish=LINK2_FINISH_TIME)
     discarded_link = operation_link(ability=ability_2, paw=operation_agent.paw, executor=executor_2,
-                                    command=encoded_command(command_2), status=-2, host=operation_agent.host, pid=7891,
+                                    command=encoded_command(command_2), plaintext_command=encoded_command(command_2), status=-2, host=operation_agent.host, pid=7891,
                                     decide=parse_datestring('2021-01-01T10:00:00Z'))
     op.chain = [link_1, link_2, discarded_link]
     return op

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -223,6 +223,7 @@ class TestOperation:
         want = [
             dict(
                 command='d2hvYW1p',
+                plaintext_command='d2hvYW1p',
                 delegated_timestamp=LINK1_DECIDE_TIME,
                 collected_timestamp=LINK1_COLLECT_TIME,
                 finished_timestamp=LINK1_FINISH_TIME,
@@ -241,6 +242,7 @@ class TestOperation:
             ),
             dict(
                 command='aG9zdG5hbWU=',
+                plaintext_command='aG9zdG5hbWU=',
                 delegated_timestamp=LINK2_DECIDE_TIME,
                 collected_timestamp=LINK2_COLLECT_TIME,
                 finished_timestamp=LINK2_FINISH_TIME,
@@ -292,6 +294,7 @@ class TestOperation:
         want = [
             dict(
                 command='d2hvYW1p',
+                plaintext_command='d2hvYW1p',
                 delegated_timestamp=LINK1_DECIDE_TIME,
                 collected_timestamp=LINK1_COLLECT_TIME,
                 finished_timestamp=LINK1_FINISH_TIME,
@@ -310,6 +313,7 @@ class TestOperation:
             ),
             dict(
                 command='aG9zdG5hbWU=',
+                plaintext_command='aG9zdG5hbWU=',
                 delegated_timestamp=LINK2_DECIDE_TIME,
                 collected_timestamp=LINK2_COLLECT_TIME,
                 finished_timestamp=LINK2_FINISH_TIME,


### PR DESCRIPTION
## Description

When using obfuscation for commands (e.g., Base64), the operations timeline now also contains the plaintext command to decode the actual command (e.g. `eval "$(echo d2hvYW1p | base64 --decode)"`).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works



<img width="1550" alt="image" src="https://user-images.githubusercontent.com/75180384/176259330-cfc4cbca-5872-4079-9796-ad1569d2bd3e.png">
<img width="1563" alt="image" src="https://user-images.githubusercontent.com/75180384/176259449-c1c444a7-020d-408f-9587-8c9a384f9f65.png">