### PR TITLE
add fact add/update events to knowledge service

### DIFF
--- a/app/service/knowledge_svc.py
+++ b/app/service/knowledge_svc.py
@@ -21,9 +21,11 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
 
     async def add_fact(self, fact, constraints=None):
         if isinstance(fact, Fact):
+            await self.get_service('event_svc').fire_event(exchange='fact', queue='added', fact=fact.display, constraints=constraints)
             return await self.__loaded_knowledge_module._add_fact(fact, constraints)
 
     async def update_fact(self, criteria, updates):
+        await self.get_service('event_svc').fire_event(exchange='fact', queue='updated', criteria=criteria, updates=updates)
         return await self.__loaded_knowledge_module._update_fact(criteria, updates)
 
     async def get_facts(self, criteria, restrictions=None):


### PR DESCRIPTION
Plugins can use the event_svc to subscribe to events. If a plugin wants to react if a fact is added or updated there is currently no event fired to subscribe to. This commit adds those events.

## Description

Adds events to subscribe to in knowledge_svc

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

It was tested via usage in a custom plugin which subscribes to these events and simply outputs the data passed via the sock.recv()


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (there is no documentation yet)
- [ ] I have added tests that prove my fix is effective or that my feature works
