### PR TITLE
Fix asyncio.start_server call (unexpected keyword argument 'loop')

### DIFF
--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -21,7 +21,7 @@ class Contact(BaseWorld):
     async def start(self):
         loop = asyncio.get_event_loop()
         tcp = self.get_config('app.contact.tcp')
-        loop.create_task(asyncio.start_server(self.tcp_handler.accept, *tcp.split(':'), loop=loop))
+        loop.create_task(asyncio.start_server(self.tcp_handler.accept, *tcp.split(':')))
         loop.create_task(self.operation_loop())
 
     async def operation_loop(self):


### PR DESCRIPTION
## Description

The loop parameter [was not necessary and was removed in Python 3.10](https://stackoverflow.com/questions/60312374/what-are-all-these-deprecated-loop-parameters-in-asyncio/60315290#60315290). This was causing an error preventing the server from starting up at all in Python 3.10.

Fixes #2611.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Started up the server under both Python 3.10.5 and Python 3.7.5 and confirmed that the server started up without any related errors.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
