### PR TITLE
Don't count abstractmethods in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,9 @@
 [run]
 source =
     ./app
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
 [html]
 directory = _htmlcov

--- a/app/api/v2/handlers/base_api.py
+++ b/app/api/v2/handlers/base_api.py
@@ -21,7 +21,7 @@ class BaseApi(abc.ABC):
 
     @abc.abstractmethod
     def add_routes(self, app: web.Application):
-        pass
+        raise NotImplementedError
 
     async def get_request_permissions(self, request: web.Request):
         return dict(access=tuple(await self._auth_svc.get_permissions(request)))

--- a/app/api/v2/handlers/base_object_api.py
+++ b/app/api/v2/handlers/base_object_api.py
@@ -21,7 +21,7 @@ class BaseObjectApi(BaseApi):
 
     @abc.abstractmethod
     def add_routes(self, app: web.Application):
-        pass
+        raise NotImplementedError
 
     async def get_all_objects(self, request: web.Request):
         access = await self.get_request_permissions(request)

--- a/app/objects/c_data_encoder.py
+++ b/app/objects/c_data_encoder.py
@@ -34,8 +34,8 @@ class DataEncoder(FirstClassObjectInterface, BaseObject):
 
     @abstractmethod
     def encode(self, data, **_):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def decode(self, data, **_):
-        pass
+        raise NotImplementedError

--- a/app/objects/interfaces/i_object.py
+++ b/app/objects/interfaces/i_object.py
@@ -6,8 +6,8 @@ class FirstClassObjectInterface(abc.ABC):
     @property
     @abc.abstractmethod
     def unique(self):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def store(self, ram):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_app_svc.py
+++ b/app/service/interfaces/i_app_svc.py
@@ -9,7 +9,7 @@ class AppServiceInterface(abc.ABC):
         Cyclic function that repeatedly checks if there are agents to be marked as untrusted
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def find_link(self, unique):
@@ -18,7 +18,7 @@ class AppServiceInterface(abc.ABC):
         :param unique:
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def find_op_with_link(self, link_id):
@@ -27,6 +27,7 @@ class AppServiceInterface(abc.ABC):
         :param link_id:
         :return: Operation or None
         """
+        raise NotImplementedError
 
     @abc.abstractmethod
     def run_scheduler(self):
@@ -34,7 +35,7 @@ class AppServiceInterface(abc.ABC):
         Kick off all scheduled jobs, as their schedule determines
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def resume_operations(self):
@@ -42,7 +43,7 @@ class AppServiceInterface(abc.ABC):
         Resume all unfinished operations
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def load_plugins(self, plugins):
@@ -50,20 +51,20 @@ class AppServiceInterface(abc.ABC):
         Store all plugins in the data store
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def retrieve_compiled_file(self, name, platform, location=''):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def teardown(self):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def register_contacts(self):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def load_plugin_expansions(self, plugins):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_auth_svc.py
+++ b/app/service/interfaces/i_auth_svc.py
@@ -11,7 +11,7 @@ class AuthServiceInterface(abc.ABC):
         :param users:
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
@@ -21,7 +21,7 @@ class AuthServiceInterface(abc.ABC):
         :param request:
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def login_user(self, request):
@@ -29,7 +29,7 @@ class AuthServiceInterface(abc.ABC):
         Kick off all scheduled jobs, as their schedule determines
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def check_permissions(self, group, request):
@@ -39,8 +39,8 @@ class AuthServiceInterface(abc.ABC):
         :param request:
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_permissions(self, request):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_contact_svc.py
+++ b/app/service/interfaces/i_contact_svc.py
@@ -5,11 +5,11 @@ class ContactServiceInterface(abc.ABC):
 
     @abc.abstractmethod
     def register_contact(self, contact):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def register_tunnel(self, tunnel):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def handle_heartbeat(self):
@@ -17,8 +17,8 @@ class ContactServiceInterface(abc.ABC):
         Accept all components of an agent profile and save a new agent or register an updated heartbeat.
         :return: the agent object, instructions to execute
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def build_filename(self):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_data_svc.py
+++ b/app/service/interfaces/i_data_svc.py
@@ -12,7 +12,7 @@ class DataServiceInterface(ObjectServiceInterface):
         :param collection:
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def load_data(self, plugins):
@@ -21,7 +21,7 @@ class DataServiceInterface(ObjectServiceInterface):
 
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def reload_data(self, plugins):
@@ -30,7 +30,7 @@ class DataServiceInterface(ObjectServiceInterface):
 
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def store(self, c_object):
@@ -40,7 +40,7 @@ class DataServiceInterface(ObjectServiceInterface):
         :param c_object:
         :return: a single c_object
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def locate(self, object_name, match):
@@ -51,7 +51,7 @@ class DataServiceInterface(ObjectServiceInterface):
         :param match: dict()
         :return: a list of c_object types
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def remove(self, object_name, match):
@@ -62,4 +62,4 @@ class DataServiceInterface(ObjectServiceInterface):
         :param match: dict()
         :return:
         """
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_event_svc.py
+++ b/app/service/interfaces/i_event_svc.py
@@ -12,7 +12,7 @@ class EventServiceInterface(abc.ABC):
         :param callback: The function that will handle the event
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def fire_event(self, event, **callback_kwargs):
@@ -22,4 +22,4 @@ class EventServiceInterface(abc.ABC):
         :param callback_kwargs: Any additional parameters to pass to the event handler
         :return: None
         """
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_file_svc.py
+++ b/app/service/interfaces/i_file_svc.py
@@ -12,15 +12,15 @@ class FileServiceInterface(abc.ABC):
         :return: File contents and optionally a display_name if the payload is a special payload
         :raises: KeyError if file key is not provided, FileNotFoundError if file cannot be found
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def save_file(self, filename, payload, target_dir):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def create_exfil_sub_directory(self, dir_name):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def save_multipart_file_upload(self, request, target_dir):
@@ -29,7 +29,7 @@ class FileServiceInterface(abc.ABC):
         :param request:
         :param target_dir: The path of the directory to save the uploaded file to.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def find_file_path(self, name, location):
@@ -39,7 +39,7 @@ class FileServiceInterface(abc.ABC):
         :param location:
         :return: a tuple: the plugin the file is found in & the relative file path
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read_file(self, name, location):
@@ -49,7 +49,7 @@ class FileServiceInterface(abc.ABC):
         :param location:
         :return: a tuple (file_path, contents)
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read_result_file(self, link_id, location):
@@ -60,7 +60,7 @@ class FileServiceInterface(abc.ABC):
         :param location: The path to results directory.
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def write_result_file(self, link_id, output, location):
@@ -72,7 +72,7 @@ class FileServiceInterface(abc.ABC):
         :param location: The path to the results directory.
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def add_special_payload(self, name, func):
@@ -82,7 +82,7 @@ class FileServiceInterface(abc.ABC):
         :param func:
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def compile_go(self, platform, output, src_fle, arch, ldflags, cflags, buildmode, build_dir, loop):
@@ -98,8 +98,8 @@ class FileServiceInterface(abc.ABC):
         :param build_dir: The path to build should take place in
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_payload_name_from_uuid(self, payload):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_knowledge_svc.py
+++ b/app/service/interfaces/i_knowledge_svc.py
@@ -12,7 +12,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param fact: Fact to add
         :param constraints: any potential constraints
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def update_fact(self, criteria, updates):
@@ -22,7 +22,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param criteria: dictionary containing fields to match on
         :param updates: dictionary containing fields to replace
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def get_facts(self, criteria, restrictions=None):
@@ -32,7 +32,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param criteria: dictionary containing fields to match on
         :return: list of facts matching the criteria
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def delete_fact(self, criteria):
@@ -41,12 +41,12 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
 
         :param criteria: dictionary containing fields to match on
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def get_meta_facts(self, meta_fact=None, agent=None, group=None):
         """Returns the complete set of facts associated with a meta-fact construct [In Development]"""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def get_fact_origin(self, fact):
@@ -55,7 +55,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
 
         :param fact: Fact to get origin for (can be either a trait string or a full blown fact)
         :return: tuple - (String of either origin source id or origin link id, fact origin type)"""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def check_fact_exists(self, fact, listing=None):
@@ -66,7 +66,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param listing: Optional specific listing to examine
         :return: Bool indicating whether or not the fact is already present
         """
-        pass
+        raise NotImplementedError
 
     # -- Relationships API --
     @abc.abstractmethod
@@ -77,7 +77,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param criteria: dictionary containing fields to match on
         :return: list of matching relationships
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def add_relationship(self, relationship, constraints=None):
@@ -87,7 +87,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param relationship: Relationship object to add
         :param constraints: optional constraints on the use of the relationship
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def update_relationship(self, criteria, updates):
@@ -97,7 +97,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param criteria: dictionary containing fields to match on
         :param updates: dictionary containing fields to modify
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def delete_relationship(self, criteria):
@@ -106,7 +106,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
 
         :param criteria: dictionary containing fields to match on
         """
-        pass
+        raise NotImplementedError
 
     # --- Rule API ---
     @abc.abstractmethod
@@ -117,7 +117,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param rule: Rule object to add
         :param constraints: dictionary containing fields to match on
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def get_rules(self, criteria, restrictions=None):
@@ -127,7 +127,7 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
         :param criteria: dictionary containing fields to match on
         :return: list of matching rules
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def delete_rule(self, criteria):
@@ -136,4 +136,4 @@ class KnowledgeServiceInterface(ObjectServiceInterface):
 
         :param criteria: dictionary containing fields to match on
         """
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_learning_svc.py
+++ b/app/service/interfaces/i_learning_svc.py
@@ -6,7 +6,7 @@ class LearningServiceInterface(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def add_parsers(directory):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def build_model(self):
@@ -15,8 +15,8 @@ class LearningServiceInterface(abc.ABC):
         This can be used to determine which facts - when found together - are more likely to be used together
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def learn(self, facts, link, blob):
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_login_handler.py
+++ b/app/service/interfaces/i_login_handler.py
@@ -16,7 +16,7 @@ class LoginHandlerInterface(abc.ABC, BaseObject):
         :return: the response/location of where the user is trying to navigate
         :raises: HTTP exception, such as HTTPFound for redirect, or HTTPUnauthorized
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def handle_login_redirect(self, request, **kwargs):
@@ -26,7 +26,7 @@ class LoginHandlerInterface(abc.ABC, BaseObject):
         :return: the response/location of where the user is trying to navigate
         :raises: HTTP exception, such as HTTPFound for redirect, or HTTPUnauthorized
         """
-        pass
+        raise NotImplementedError
 
     @property
     def name(self):

--- a/app/service/interfaces/i_object_svc.py
+++ b/app/service/interfaces/i_object_svc.py
@@ -10,7 +10,7 @@ class ObjectServiceInterface(abc.ABC):
         Clear out all data
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def save_state(self):
@@ -18,7 +18,7 @@ class ObjectServiceInterface(abc.ABC):
         Save stored data to disk
         :return:
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def restore_state(self):
@@ -26,4 +26,4 @@ class ObjectServiceInterface(abc.ABC):
         Load data from disk
         :return:
         """
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_planning_svc.py
+++ b/app/service/interfaces/i_planning_svc.py
@@ -14,7 +14,7 @@ class PlanningServiceInterface(abc.ABC):
         :param trim: call trim_links() on list of links before returning
         :return: a list of links
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_cleanup_links(self, operation, agent):
@@ -25,11 +25,11 @@ class PlanningServiceInterface(abc.ABC):
         :param agent:
         :return: None
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def generate_and_trim_links(self, agent, operation, abilities, trim):
-        pass
+        raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
@@ -37,4 +37,4 @@ class PlanningServiceInterface(abc.ABC):
         """
         Sort links by their score then by the order they are defined in an adversary profile
         """
-        pass
+        raise NotImplementedError

--- a/app/service/interfaces/i_rest_svc.py
+++ b/app/service/interfaces/i_rest_svc.py
@@ -11,7 +11,7 @@ class RestServiceInterface(abc.ABC):
         :param data:
         :return: the ID of the created adversary
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def update_planner(self, data):
@@ -21,96 +21,96 @@ class RestServiceInterface(abc.ABC):
         :param data:
         :return: the ID of the created adversary
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def persist_ability(self, access, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def persist_source(self, access, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def delete_agent(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def delete_ability(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def delete_adversary(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def delete_operation(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def display_objects(self, object_name, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def display_result(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def display_operation_report(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def download_contact_report(self, contact):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def update_agent_data(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def update_chain_data(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def create_operation(self, access, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def create_schedule(self, access, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def list_payloads(self):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def find_abilities(self, paw):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_potential_links(self, op_id, paw):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def apply_potential_link(self, link):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def task_agent_with_ability(self, paw, ability_id, obfuscator, facts):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_link_pin(self, json_data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def construct_agents_for_group(self, group):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def update_config(self, data):
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def update_operation(self, op_id, state, autonomous):
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
## Description

Configure the coverage tool to ignore @abstractmethods. Not a bugfix; just improves our coverage reports.

## How Has This Been Tested?

Ran tox and checked coverage report both before and after the change.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
