### PR TITLE
Switch recommonmark to MyST-Parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,10 @@ pyyaml>=5.1
 cryptography>=3.2,<37.0.0; python_version <= '3.7'
 cryptography>=3.2; python_version > '3.7'
 websockets>=10.3
-Sphinx==3.0.4
+Sphinx==5.1.1
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 sphinx_rtd_theme==0.4.3
-recommonmark==0.6.0
+myst-parser==0.18.0
 marshmallow==3.5.1
 dirhash==0.2.0
 docker==4.2.0

--- a/server.py
+++ b/server.py
@@ -40,6 +40,7 @@ def setup_logger(level=logging.DEBUG):
             continue
         else:
             logging.getLogger(logger_name).setLevel(100)
+    logging.getLogger("markdown_it").setLevel(logging.WARNING)
     logging.captureWarnings(True)
 
 


### PR DESCRIPTION
## Description

Recommonmark is what we use to parse our markdown documentation for Sphinx, but it is no longer maintained. The [recommendation is to use MyST-Parser instead](https://github.com/readthedocs/recommonmark/issues/221). This PR should only be merged in tandem with https://github.com/mitre/fieldmanual/pull/104.

MyST-Parser is very noisy with `--log-level DEBUG`, so I set it to only emit warnings and errors.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Built the docs after the changes, verified that pages still displayed correctly and links work, and that extraneous debug messages are not emitted with `--log-level DEBUG`.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
