### PR TITLE
Sanitize inputs to toast function

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -192,9 +192,15 @@ function sortAlphabetically(list) {
     })
 }
 
+function sanitize(unsafeMsg) {
+    const parser = new DOMParser();
+    let doc = parser.parseFromString(unsafeMsg, 'text/html');
+    return doc.body.innerText;
+}
+
 function toast(message, success) {
     bulmaToast.toast({
-        message: `<span class="icon"><i class="fas fa-${success ? 'check' : 'exclamation'}"></i></span> ${message}`,
+        message: `<span class="icon"><i class="fas fa-${success ? 'check' : 'exclamation'}"></i></span> ${sanitize(message)}`,
         type: `toast ${success ? 'is-success' : 'is-danger'}`,
         position: 'bottom-right',
         duration: '3000',
@@ -250,41 +256,6 @@ function uuidv4() {
     });
 }
 
-// TODO: JQuery functions
-
-function showHide(show, hide) {
-    $(show).each(function () {
-        $(this).prop('disabled', false).css('opacity', 1.0)
-    });
-    $(hide).each(function () {
-        $(this).prop('disabled', true).css('opacity', 0.5)
-    });
-}
-
-function validateFormState(conditions, selector) {
-    (conditions) ?
-        updateButtonState(selector, 'valid') :
-        updateButtonState(selector, 'invalid');
-}
-
-function updateButtonState(selector, state) {
-    (state === 'valid') ?
-        $(selector).attr('class', 'button-success atomic-button') :
-        $(selector).attr('class', 'button-notready atomic-button');
-}
-
-function stream(msg, speak = false) {
-    let streamer = $('#streamer');
-    if (streamer.text() != msg) {
-        streamer.fadeOut(function () {
-            if (speak) {
-                window.speechSynthesis.speak(new SpeechSynthesisUtterance(msg));
-            }
-            $(this).text(msg).fadeIn(1000);
-        });
-    }
-}
-
 /* SECTIONS */
 
 // Alternative to JQuery parseHTML(keepScripts=true)
@@ -306,33 +277,6 @@ function setInnerHTML(elem, html) {
 // TODO: remove this from all individual plugins in future, as close (x) will be in the tab rather than inside the plugins itself
 function removeSection(identifier) {
     $('#' + identifier).remove();
-}
-
-/* AUTOMATIC functions for all pages */
-
-$(document).ready(function () {
-    $(document).find("select").each(function () {
-        if (!$(this).hasClass('avoid-alphabetizing')) {
-            alphabetize_dropdown($(this));
-            let observer = new MutationObserver(function (mutations, obs) {
-                obs.disconnect();
-                alphabetize_dropdown($(mutations[0].target));
-                obs.observe(mutations[0].target, {childList: true});
-            });
-            observer.observe(this, {childList: true});
-        }
-    });
-});
-
-function alphabetize_dropdown(obj) {
-    let selected_val = $(obj).children("option:selected").val();
-    let disabled = $(obj).find('option:disabled');
-    let opts_list = $(obj).find('option:enabled').clone(true);
-    opts_list.sort(function (a, b) {
-        return a.text.toLowerCase() == b.text.toLowerCase() ? 0 : a.text.toLowerCase() < b.text.toLowerCase() ? -1 : 1;
-    });
-    $(obj).empty().append(opts_list).prepend(disabled);
-    obj.val(selected_val);
 }
 
 function b64DecodeUnicode(str) { //https://stackoverflow.com/a/30106551

--- a/templates/configurations.html
+++ b/templates/configurations.html
@@ -114,6 +114,7 @@
             },
 
             enablePlugin(pluginName) {
+                pluginName = sanitize(pluginName);
                 let requestBody = {
                     value: pluginName,
                     prop: 'plugin'

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1435,6 +1435,7 @@
                 } else if (!this.isJitterValid()) {
                     toast('Jitter values are invalid', false);
                 } else {
+                    this.operationToStart.name = sanitize(this.operationToStart.name);
                     this.operationToStart.autonomous = Number(this.operationToStart.autonomous);
                     this.operationToStart.use_learning_parsers = parseInt(this.operationToStart.use_learning_parsers, 10) === 1;
                     this.operationToStart.auto_close = parseInt(this.operationToStart.auto_close, 10) === 1;
@@ -1458,7 +1459,8 @@
                 let stringToReplace = (dateMatches && dateMatches.length) ? dateMatches[dateMatches.length - 1] : '';
                 let date = `(${new Date().toLocaleString()})`;
                 newOp.name = stringToReplace ? (newOp.name.replace(stringToReplace, date)) : (`${newOp.name} ${date}`);
-                
+                newOp.name = sanitize(newOp.name);
+
                 apiV2('POST', this.ENDPOINT, newOp).then((newOperation) => {
                     toast(`Started operation ${newOperation.name}!`, true);
                     this.operations.push(newOperation);


### PR DESCRIPTION
## Description

String messages to the `toast()` function were not sanitized, allowing for malicious HTML to be passed to it. In particular, the operation name input in the operations page allowed a user to enter a XSS string such as `<img src="http://url.to.file.which/not.exist" onerror=alert(document.cookie);>`, which would fire the onerror handler once created.

A `sanitize()` method has been added so it can be used anywhere in Caldera's UI. It will completely remove any HTML content and return the remaining text, if any. The toast method now uses this, along with a couple of other sections in the operations page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

After inputing malicious strings to the operation name input, the scripts never fire like they did before.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
