### PR TITLE
Bump lxml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ docker==4.2.0
 donut-shellcode==0.9.2
 marshmallow-enum==1.5.1
 ldap3==2.8.1
-lxml~=4.6.2  # debrief
+lxml~=4.9.1  # debrief
 reportlab==3.5.67  # debrief
 svglib==1.0.1  # debrief
 Markdown==3.3.3  # training


### PR DESCRIPTION
## Description

Bumps lxml version to mitigate CVE.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Debrief runs as normal and can still export reports with the new version.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
