### PR TITLE
[VIRTS-4149] Have server handle both stdout and stderr in link results

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import json
 import logging
 import re
@@ -311,11 +310,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
                                                technique_name=step.ability.technique_name,
                                                technique_id=step.ability.technique_id))
                 if output and step.output:
-                    results_dict = self.decode_bytes(file_svc.read_result_file(step.unique, return_dict=True))
-                    try:
-                        step_report['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
-                    except:  # old result files / incorrectly formatted json
-                        step_report['output'] = results_dict
+                    results_dict = self.decode_bytes(file_svc.read_result_file(step.unique))
+                    step_report['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
                 if step.agent_reported_time:
                     step_report['agent_reported_time'] = step.agent_reported_time.strftime(self.TIME_FORMAT)
                 agents_steps[step.paw]['steps'].append(step_report)
@@ -379,11 +375,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           operation_metadata=self._get_operation_metadata_for_event_log(),
                           attack_metadata=self._get_attack_metadata_for_event_log(link.ability))
         if output and link.output:
-            results_dict = self.decode_bytes(file_svc.read_result_file(link.unique, return_dict=True))
-            try:
-                event_dict['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
-            except:  # old result files / incorrectly formatted json
-                event_dict['output'] = results_dict
+            results_dict = self.decode_bytes(file_svc.read_result_file(link.unique))
+            event_dict['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
         if link.agent_reported_time:
             event_dict['agent_reported_time'] = link.agent_reported_time.strftime(self.TIME_FORMAT)
         return event_dict

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import logging
 import re
@@ -310,7 +311,11 @@ class Operation(FirstClassObjectInterface, BaseObject):
                                                technique_name=step.ability.technique_name,
                                                technique_id=step.ability.technique_id))
                 if output and step.output:
-                    step_report['output'] = self.decode_bytes(file_svc.read_result_file(step.unique))
+                    results_dict = self.decode_bytes(file_svc.read_result_file(step.unique, return_dict=True))
+                    try:  # Added for backwards compatibility (old result files)
+                        step_report['output'] = json.loads(results_dict)
+                    except: # old result files / incorrectly formatted json
+                        step_report['output'] = results_dict
                 if step.agent_reported_time:
                     step_report['agent_reported_time'] = step.agent_reported_time.strftime(self.TIME_FORMAT)
                 agents_steps[step.paw]['steps'].append(step_report)
@@ -375,7 +380,11 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           operation_metadata=self._get_operation_metadata_for_event_log(),
                           attack_metadata=self._get_attack_metadata_for_event_log(link.ability))
         if output and link.output:
-            event_dict['output'] = self.decode_bytes(file_svc.read_result_file(link.unique))
+            results_dict = self.decode_bytes(file_svc.read_result_file(link.unique, return_dict=True))
+            try:  # Added for backwards compatibility (old result files)
+                event_dict['output'] = json.loads(results_dict)
+            except:  # old result files / incorrectly formatted json
+                event_dict['output'] = results_dict
         if link.agent_reported_time:
             event_dict['agent_reported_time'] = link.agent_reported_time.strftime(self.TIME_FORMAT)
         return event_dict

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -312,16 +312,15 @@ class Operation(FirstClassObjectInterface, BaseObject):
                                                technique_id=step.ability.technique_id))
                 if output and step.output:
                     results_dict = self.decode_bytes(file_svc.read_result_file(step.unique, return_dict=True))
-                    try:  # Added for backwards compatibility (old result files)
-                        step_report['output'] = json.loads(results_dict)
-                    except: # old result files / incorrectly formatted json
+                    try:
+                        step_report['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
+                    except:  # old result files / incorrectly formatted json
                         step_report['output'] = results_dict
                 if step.agent_reported_time:
                     step_report['agent_reported_time'] = step.agent_reported_time.strftime(self.TIME_FORMAT)
                 agents_steps[step.paw]['steps'].append(step_report)
             report['steps'] = agents_steps
             report['skipped_abilities'] = await self.get_skipped_abilities_by_agent(data_svc)
-
             return report
         except Exception:
             logging.error('Error saving operation report (%s)' % self.name, exc_info=True)
@@ -381,8 +380,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           attack_metadata=self._get_attack_metadata_for_event_log(link.ability))
         if output and link.output:
             results_dict = self.decode_bytes(file_svc.read_result_file(link.unique, return_dict=True))
-            try:  # Added for backwards compatibility (old result files)
-                event_dict['output'] = json.loads(results_dict)
+            try:
+                event_dict['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
             except:  # old result files / incorrectly formatted json
                 event_dict['output'] = results_dict
         if link.agent_reported_time:

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -310,8 +310,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
                                                technique_name=step.ability.technique_name,
                                                technique_id=step.ability.technique_id))
                 if output and step.output:
-                    results_dict = self.decode_bytes(file_svc.read_result_file(step.unique))
-                    step_report['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
+                    results = self.decode_bytes(file_svc.read_result_file(step.unique))
+                    step_report['output'] = json.loads(results.replace('\\r\\n', '').replace('\\n', ''))
                 if step.agent_reported_time:
                     step_report['agent_reported_time'] = step.agent_reported_time.strftime(self.TIME_FORMAT)
                 agents_steps[step.paw]['steps'].append(step_report)
@@ -375,8 +375,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
                           operation_metadata=self._get_operation_metadata_for_event_log(),
                           attack_metadata=self._get_attack_metadata_for_event_log(link.ability))
         if output and link.output:
-            results_dict = self.decode_bytes(file_svc.read_result_file(link.unique))
-            event_dict['output'] = json.loads(results_dict.replace('\\r\\n', '').replace('\\n', ''))
+            results = self.decode_bytes(file_svc.read_result_file(link.unique))
+            event_dict['output'] = json.loads(results.replace('\\r\\n', '').replace('\\n', ''))
         if link.agent_reported_time:
             event_dict['agent_reported_time'] = link.agent_reported_time.strftime(self.TIME_FORMAT)
         return event_dict

--- a/app/objects/secondclass/c_result.py
+++ b/app/objects/secondclass/c_result.py
@@ -6,6 +6,7 @@ from app.utility.base_object import BaseObject
 class ResultSchema(ma.Schema):
     id = ma.fields.String()
     output = ma.fields.String()
+    stderr = ma.fields.String()
     pid = ma.fields.String()
     status = ma.fields.String()
     agent_reported_time = ma.fields.DateTime(format=BaseObject.TIME_FORMAT, missing=None)
@@ -25,10 +26,11 @@ class Result(BaseObject):
 
     schema = ResultSchema()
 
-    def __init__(self, id, output, pid=0, status=0, agent_reported_time=None):
+    def __init__(self, id, output, stderr="", pid=0, status=0, agent_reported_time=None):
         super().__init__()
         self.id = id
         self.output = output
+        self.stderr = stderr
         self.pid = pid
         self.status = status
         self.agent_reported_time = agent_reported_time

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -123,9 +123,9 @@ class ContactService(ContactServiceInterface, BaseService):
                 if result.output or result.stderr:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link)
-                    command_results = json.dumps(
-                        {'stdout': self.decode_bytes(result.output, strip_newlines=False),
-                         'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
+                    command_results = json.dumps(dict(
+                        stdout=self.decode_bytes(result.output, strip_newlines=False),
+                        stderr=self.decode_bytes(result.stderr, strip_newlines=False)))
                     encoded_command_results = self.encode_string(command_results)
                     self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
                     operation = await self.get_service('app_svc').find_op_with_link(result.id)
@@ -142,9 +142,9 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(self.get_service('learning_svc').learn(all_facts, link, result.output,
                                                                                 operation))
             else:
-                command_results = json.dumps(
-                    {'stdout': self.decode_bytes(result.output, strip_newlines=False),
-                     'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
+                command_results = json.dumps(dict(
+                    stdout=self.decode_bytes(result.output, strip_newlines=False),
+                    stderr=self.decode_bytes(result.stderr, strip_newlines=False)))
                 encoded_command_results = self.encode_string(command_results)
                 self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
         except Exception as e:

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -124,9 +124,9 @@ class ContactService(ContactServiceInterface, BaseService):
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link)
                     command_results = json.dumps(
-                        {'stdout' : self.decode_bytes(result.output, strip_newlines=False),
+                        {'stdout': self.decode_bytes(result.output, strip_newlines=False),
                          'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
-                    encoded_command_results = self.encode_string(str(command_results))
+                    encoded_command_results = self.encode_string(command_results)
                     self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
                     operation = await self.get_service('app_svc').find_op_with_link(result.id)
                     if not operation and not link.executor.parsers:
@@ -145,7 +145,7 @@ class ContactService(ContactServiceInterface, BaseService):
                 command_results = json.dumps(
                     {'stdout': self.decode_bytes(result.output, strip_newlines=False),
                      'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
-                encoded_command_results = self.encode_string(str(command_results))
+                encoded_command_results = self.encode_string(command_results)
                 self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
         except Exception as e:
             self.log.exception(f'Unexpected error occurred while saving link - {e}')

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -3,7 +3,7 @@ import json
 import re
 from collections import defaultdict
 from datetime import datetime, timezone
-from base64 import b64decode, b64encode
+from base64 import b64decode
 
 from app.objects.c_agent import Agent
 from app.objects.secondclass.c_instruction import Instruction
@@ -123,10 +123,10 @@ class ContactService(ContactServiceInterface, BaseService):
                 if result.output or result.stderr:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link)
-                    command_results = {'stdout' : BaseService.decode_bytes(result.output, strip_newlines=False),
-                                       'stderr': BaseService.decode_bytes(result.stderr, strip_newlines=False)}
-                    json_command_results = json.dumps(command_results)
-                    encoded_command_results = BaseService.encode_string(str(json_command_results))
+                    command_results = json.dumps(
+                        {'stdout' : self.decode_bytes(result.output, strip_newlines=False),
+                         'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
+                    encoded_command_results = self.encode_string(str(command_results))
                     self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
                     operation = await self.get_service('app_svc').find_op_with_link(result.id)
                     if not operation and not link.executor.parsers:
@@ -142,10 +142,10 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(self.get_service('learning_svc').learn(all_facts, link, result.output,
                                                                                 operation))
             else:
-                command_results = {'stdout': BaseService.decode_bytes(result.output, strip_newlines=False),
-                                   'stderr': BaseService.decode_bytes(result.stderr, strip_newlines=False)}
-                json_command_results = json.dumps(command_results)
-                encoded_command_results = BaseService.encode_string(str(json_command_results))
+                command_results = json.dumps(
+                    {'stdout': self.decode_bytes(result.output, strip_newlines=False),
+                     'stderr': self.decode_bytes(result.stderr, strip_newlines=False)})
+                encoded_command_results = self.encode_string(str(command_results))
                 self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
         except Exception as e:
             self.log.exception(f'Unexpected error occurred while saving link - {e}')

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -123,8 +123,8 @@ class ContactService(ContactServiceInterface, BaseService):
                 if result.output or result.stderr:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link)
-                    command_results = {'stdout' : BaseService.decode_bytes(result.output),
-                                       'stderr': BaseService.decode_bytes(result.stderr)}
+                    command_results = {'stdout' : BaseService.decode_bytes(result.output, strip_newlines=False),
+                                       'stderr': BaseService.decode_bytes(result.stderr, strip_newlines=False)}
                     json_command_results = json.dumps(command_results)
                     encoded_command_results = BaseService.encode_string(str(json_command_results))
                     self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
@@ -142,8 +142,8 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(self.get_service('learning_svc').learn(all_facts, link, result.output,
                                                                                 operation))
             else:
-                command_results = {'stdout': BaseService.decode_bytes(result.output),
-                                   'stderr': BaseService.decode_bytes(result.stderr)}
+                command_results = {'stdout': BaseService.decode_bytes(result.output, strip_newlines=False),
+                                   'stderr': BaseService.decode_bytes(result.stderr, strip_newlines=False)}
                 json_command_results = json.dumps(command_results)
                 encoded_command_results = BaseService.encode_string(str(json_command_results))
                 self.get_service('file_svc').write_result_file(result.id, encoded_command_results)

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -1,8 +1,9 @@
 import asyncio
+import json
 import re
 from collections import defaultdict
 from datetime import datetime, timezone
-from base64 import b64decode
+from base64 import b64decode, b64encode
 
 from app.objects.c_agent import Agent
 from app.objects.secondclass.c_instruction import Instruction
@@ -119,10 +120,14 @@ class ContactService(ContactServiceInterface, BaseService):
                 link.status = int(result.status)
                 if result.agent_reported_time:
                     link.agent_reported_time = self.get_timestamp_from_string(result.agent_reported_time)
-                if result.output:
+                if result.output or result.stderr:
                     link.output = True
                     result.output = await self._postprocess_link_result(result.output, link)
-                    self.get_service('file_svc').write_result_file(result.id, result.output)
+                    command_results = {'stdout' : BaseService.decode_bytes(result.output),
+                                       'stderr': BaseService.decode_bytes(result.stderr)}
+                    json_command_results = json.dumps(command_results)
+                    encoded_command_results = BaseService.encode_string(str(json_command_results))
+                    self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
                     operation = await self.get_service('app_svc').find_op_with_link(result.id)
                     if not operation and not link.executor.parsers:
                         agent = await self.get_service('data_svc').locate('agents', dict(paw=link.paw))
@@ -137,7 +142,11 @@ class ContactService(ContactServiceInterface, BaseService):
                         loop.create_task(self.get_service('learning_svc').learn(all_facts, link, result.output,
                                                                                 operation))
             else:
-                self.get_service('file_svc').write_result_file(result.id, result.output)
+                command_results = {'stdout': BaseService.decode_bytes(result.output),
+                                   'stderr': BaseService.decode_bytes(result.stderr)}
+                json_command_results = json.dumps(command_results)
+                encoded_command_results = BaseService.encode_string(str(json_command_results))
+                self.get_service('file_svc').write_result_file(result.id, encoded_command_results)
         except Exception as e:
             self.log.exception(f'Unexpected error occurred while saving link - {e}')
 

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -121,17 +121,16 @@ class FileSvc(FileServiceInterface, BaseService):
     def read_result_file(self, link_id, location='data/results'):
         buf = self._read(os.path.join(location, link_id))
         decoded_buf = buf.decode('utf-8')
-        try:  # Check if results file is valid dictionary
+        try:
             json.loads(self.decode_bytes(decoded_buf))
             return decoded_buf
-        except json.JSONDecodeError:  # Exception occurs on non-dict result files (legacy)
-            results_dict = json.dumps(
-                {'stdout': self.decode_bytes(decoded_buf, strip_newlines=False), 'stderr': ''})
-            return self.encode_string(str(results_dict))
-        except binascii.Error:  # Exception occurs on non base64 result files (irregular)
-            results_dict = json.dumps(
-                {'stdout': decoded_buf, 'stderr': ''})
-            return self.encode_string(str(results_dict))
+        except json.JSONDecodeError:
+            results = json.dumps(dict(
+                stdout=self.decode_bytes(decoded_buf, strip_newlines=False), stderr=''))
+            return self.encode_string(str(results))
+        except binascii.Error:
+            results = json.dumps(dict(stdout=decoded_buf, stderr=''))
+            return self.encode_string(str(results))
 
     def write_result_file(self, link_id, output, location='data/results'):
         output = bytes(output, encoding='utf-8')

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -426,18 +426,18 @@
                                     </pre>
                                 </div>
                             </template>
-                            <template x-if="selectedLinkResults != null && selectedLinkResults.stdout !== ''">
                                 <div>
-                                    <p class="mt-3 mb-2">Standard Output:</p>
-                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stdout"></pre>
+                                    <p class="mt-3 mb-2" x-text="`Standard Output: ${selectedLinkResults.stdout ? '' : 'Nothing to show'}`"></p>
+                                    <template x-if="selectedLinkResults != null && selectedLinkResults.stdout !== ''">
+                                        <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stdout"></pre>
+                                    </template>
                                 </div>
-                            </template>
-                            <template x-if="selectedLinkResults != null && selectedLinkResults.stderr !== ''">
                                 <div>
-                                    <p class="mt-3 mb-2">Standard Error:</p>
-                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stderr"></pre>
+                                    <p class="mt-3 mb-2" x-text="`Standard Error: ${selectedLinkResults.stderr ? '' : 'Nothing to show'}`"></p>
+                                    <template x-if="selectedLinkResults != null && selectedLinkResults.stderr !== ''">
+                                        <pre class="has-text-left white-space-pre-line has-text-danger" x-text="selectedLinkResults.stderr"></pre>
+                                    </template>
                                 </div>
-                            </template>
                         </section>
                         <footer class="modal-card-foot">
                             <nav class="level">

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -426,18 +426,18 @@
                                     </pre>
                                 </div>
                             </template>
-                                <div>
-                                    <p class="mt-3 mb-2" x-text="`Standard Output: ${selectedLinkResults.stdout ? '' : 'Nothing to show'}`"></p>
-                                    <template x-if="selectedLinkResults != null && selectedLinkResults.stdout !== ''">
-                                        <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stdout"></pre>
-                                    </template>
-                                </div>
-                                <div>
-                                    <p class="mt-3 mb-2" x-text="`Standard Error: ${selectedLinkResults.stderr ? '' : 'Nothing to show'}`"></p>
-                                    <template x-if="selectedLinkResults != null && selectedLinkResults.stderr !== ''">
-                                        <pre class="has-text-left white-space-pre-line has-text-danger" x-text="selectedLinkResults.stderr"></pre>
-                                    </template>
-                                </div>
+                            <div>
+                                <p class="mt-3 mb-2" x-text="`Standard Output: ${selectedLinkResults.stdout ? '' : 'Nothing to show'}`"></p>
+                                <template x-if="selectedLinkResults != null && selectedLinkResults.stdout !== ''">
+                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stdout"></pre>
+                                </template>
+                            </div>
+                            <div>
+                                <p class="mt-3 mb-2" x-text="`Standard Error: ${selectedLinkResults.stderr ? '' : 'Nothing to show'}`"></p>
+                                <template x-if="selectedLinkResults != null && selectedLinkResults.stderr !== ''">
+                                    <pre class="has-text-left white-space-pre-line has-text-danger" x-text="selectedLinkResults.stderr"></pre>
+                                </template>
+                            </div>
                         </section>
                         <footer class="modal-card-foot">
                             <nav class="level">

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -426,9 +426,18 @@
                                     </pre>
                                 </div>
                             </template>
-                            <div>
-                                <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults"></pre>
-                            </div>
+                            <template x-if="selectedLinkResults != null && selectedLinkResults.stdout !== ''">
+                                <div>
+                                    <p class="mt-3 mb-2">Standard Output:</p>
+                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stdout"></pre>
+                                </div>
+                            </template>
+                            <template x-if="selectedLinkResults != null && selectedLinkResults.stderr !== ''">
+                                <div>
+                                    <p class="mt-3 mb-2">Standard Error:</p>
+                                    <pre class="has-text-left white-space-pre-line" x-text="selectedLinkResults.stderr"></pre>
+                                </div>
+                            </template>
                         </section>
                         <footer class="modal-card-foot">
                             <nav class="level">
@@ -1705,7 +1714,7 @@
                     this.selectedLinkResults = null;
                 } else {
                     apiV2('GET', `${this.ENDPOINT}/${this.selectedOperationID}/links/${link.id}/result`).then((res) => {
-                        this.selectedLinkResults = b64DecodeUnicode(res.result);
+                        this.selectedLinkResults = JSON.parse(b64DecodeUnicode(res.result));
                     }).catch(() => console.error('Error getting link results.'));
                 }
             },

--- a/tests/api/v2/handlers/test_operations_api.py
+++ b/tests/api/v2/handlers/test_operations_api.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from http import HTTPStatus
@@ -70,7 +72,8 @@ class TestOperationsApi:
         with mocker.patch('app.objects.c_operation.Operation.all_facts') as mock_all_facts:
             mock_all_facts.return_value = async_return([])
             with mocker.patch('app.objects.c_operation.Operation.decode_bytes') as mock_decode:
-                mock_decode.return_value = expected_link_output
+                expected_link_output_dict = json.dumps({"stdout": expected_link_output, "stderr": ""})
+                mock_decode.return_value = expected_link_output_dict
                 with mocker.patch('app.service.file_svc.FileSvc.read_result_file') as mock_readfile:
                     mock_readfile.return_value = ''
                     payload = {'enable_agent_output': True}
@@ -114,7 +117,8 @@ class TestOperationsApi:
                                                                  test_operation, finished_link, test_agent,
                                                                  expected_link_output):
         with mocker.patch('app.objects.c_operation.Operation.decode_bytes') as mock_decode:
-            mock_decode.return_value = expected_link_output
+            expected_link_output_dict = {"stdout": expected_link_output, "stderr": ""}
+            mock_decode.return_value = json.dumps(expected_link_output_dict)
             with mocker.patch('app.service.file_svc.FileSvc.read_result_file') as mock_readfile:
                 mock_readfile.return_value = ''
                 payload = {'enable_agent_output': True}
@@ -123,7 +127,7 @@ class TestOperationsApi:
                 assert event_logs[1]['command'] == finished_link['command']
                 assert event_logs[1]['agent_metadata']['paw'] == test_agent.schema.dump(test_agent)['paw']
                 assert event_logs[1]['operation_metadata']['operation_name'] == test_operation['name']
-                assert event_logs[1]['output'] == expected_link_output
+                assert event_logs[1]['output'] == expected_link_output_dict
                 assert not event_logs[0].get('output')
 
     async def test_unauthorized_get_operation_event_logs(self, api_v2_client):

--- a/tests/api/v2/handlers/test_operations_api.py
+++ b/tests/api/v2/handlers/test_operations_api.py
@@ -72,7 +72,7 @@ class TestOperationsApi:
         with mocker.patch('app.objects.c_operation.Operation.all_facts') as mock_all_facts:
             mock_all_facts.return_value = async_return([])
             with mocker.patch('app.objects.c_operation.Operation.decode_bytes') as mock_decode:
-                expected_link_output_dict = json.dumps({"stdout": expected_link_output, "stderr": ""})
+                expected_link_output_dict = json.dumps(dict(stdout=expected_link_output, stderr=""))
                 mock_decode.return_value = expected_link_output_dict
                 with mocker.patch('app.service.file_svc.FileSvc.read_result_file') as mock_readfile:
                     mock_readfile.return_value = ''
@@ -117,7 +117,7 @@ class TestOperationsApi:
                                                                  test_operation, finished_link, test_agent,
                                                                  expected_link_output):
         with mocker.patch('app.objects.c_operation.Operation.decode_bytes') as mock_decode:
-            expected_link_output_dict = {"stdout": expected_link_output, "stderr": ""}
+            expected_link_output_dict = dict(stdout=expected_link_output, stderr="")
             mock_decode.return_value = json.dumps(expected_link_output_dict)
             with mocker.patch('app.service.file_svc.FileSvc.read_result_file') as mock_readfile:
                 mock_readfile.return_value = ''

--- a/tests/services/test_contact_svc.py
+++ b/tests/services/test_contact_svc.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 import pytest
 
@@ -53,7 +54,8 @@ class TestContactSvc:
         )
         await contact_svc._save(Result(**result))
         result = await rest_svc.display_result(dict(link_id=link.id))
-        assert base64.b64decode(result['output']) == test_string
+        result_dict = json.loads(base64.b64decode(result['output']))
+        assert result_dict['stdout'] == test_string.decode()
 
         # cleanup test
         try:

--- a/tests/services/test_contact_svc.py
+++ b/tests/services/test_contact_svc.py
@@ -44,21 +44,50 @@ def setup_contact_service(event_loop, data_svc, agent, ability, operation, link,
 class TestContactSvc:
     async def test_save_ability_hooks(self, setup_contact_service, contact_svc, event_svc):
         test_string = b'test_string'
+        err_string = b'err_string'
         link = setup_contact_service
         rest_svc = RestService()
         result = dict(
             id=link.id,
             output=str(base64.b64encode(base64.b64encode(test_string)), 'utf-8'),
+            stderr=str(base64.b64encode(err_string), 'utf-8'),
             pid=0,
             status=0
         )
         await contact_svc._save(Result(**result))
         result = await rest_svc.display_result(dict(link_id=link.id))
         result_dict = json.loads(base64.b64decode(result['output']))
+
         assert result_dict['stdout'] == test_string.decode()
+        assert result_dict['stderr'] == err_string.decode()
 
         # cleanup test
         try:
             os.remove(os.path.join('data', 'results', link.id))
         except FileNotFoundError:
             print('Unable to cleanup test_save_ability_hooks result file')
+
+    async def test_save_ability_hooks_with_no_link(self, setup_contact_service, contact_svc, event_svc, file_svc):
+        test_string = b'test_string'
+        err_string = b'err_string'
+        # Send version with link for comparison
+        result = dict(
+            id="12345",
+            output=str(base64.b64encode(test_string), 'utf-8'),
+            stderr=str(base64.b64encode(err_string), 'utf-8'),
+            pid=0,
+            status=0
+        )
+
+        await contact_svc._save(Result(**result))
+
+        result = file_svc.read_result_file("12345")
+        result_dict = json.loads(base64.b64decode(result))
+        assert result_dict['stdout'] == test_string.decode()
+        assert result_dict['stderr'] == err_string.decode()
+
+        # cleanup test
+        try:
+            os.remove(os.path.join('data', 'results', '12345'))
+        except FileNotFoundError:
+            print('Unable to cleanup test_save_ability_hooks_with_no_link result files')

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import os
 import pytest
 import yaml
@@ -51,12 +53,18 @@ class TestFileService:
     def test_read_write_result_file(self, tmpdir, file_svc):
         link_id = '12345'
         output = 'output testing unit'
+        output_encoded = str(b64encode(output.encode()), 'utf-8')
+
         # write output data
-        file_svc.write_result_file(link_id=link_id, output=output, location=tmpdir)
+        file_svc.write_result_file(link_id=link_id, output=output_encoded, location=tmpdir)
+
+        # construct expected output
+        output_dict = {'stdout': output, 'stderr': ''}
 
         # read output data
         output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
-        assert output_data == output
+        decoded_output_data = json.loads(base64.b64decode(output_data))
+        assert decoded_output_data == output_dict
 
     def test_upload_decode_plaintext(self, event_loop, file_svc, data_svc):
         content = b'this will be encoded and decoded as plaintext'

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -54,49 +54,34 @@ class TestFileService:
         link_id = '12345'
         output = 'output testing unit'
         error = 'error testing unit'
-        output_encoded = str(b64encode(json.dumps({'stdout': output, 'stderr': error}).encode()), 'utf-8')
-
-        # write output data
+        output_encoded = str(b64encode(json.dumps(dict(stdout=output, stderr=error)).encode()), 'utf-8')
         file_svc.write_result_file(link_id=link_id, output=output_encoded, location=tmpdir)
 
-        # construct expected output
-        output_dict = {'stdout': output, 'stderr': error}
-
-        # read output data
+        expected_output = dict(stdout=output, stderr=error)
         output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
         decoded_output_data = json.loads(base64.b64decode(output_data))
-        assert decoded_output_data == output_dict
+        assert decoded_output_data == expected_output
 
     def test_read_write_result_file_no_dict(self, tmpdir, file_svc):
         link_id = '12345'
         output = 'output testing unit'
         output_encoded = str(b64encode(output.encode()), 'utf-8')
-
-        # write output data
         file_svc.write_result_file(link_id=link_id, output=output_encoded, location=tmpdir)
 
-        # construct expected output
-        output_dict = {'stdout': output, 'stderr': ''}
-
-        # read output data
+        expected_output = {'stdout': output, 'stderr': ''}
         output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
         decoded_output_data = json.loads(base64.b64decode(output_data))
-        assert decoded_output_data == output_dict
+        assert decoded_output_data == expected_output
 
     def test_read_write_result_file_no_base64(self, tmpdir, file_svc):
         link_id = '12345'
         output = 'output testing unit'
-
-        # write output data
         file_svc.write_result_file(link_id=link_id, output=output, location=tmpdir)
 
-        # construct expected output
-        output_dict = {'stdout': output, 'stderr': ''}
-
-        # read output data
+        expected_output = {'stdout': output, 'stderr': ''}
         output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
         decoded_output_data = json.loads(base64.b64decode(output_data))
-        assert decoded_output_data == output_dict
+        assert decoded_output_data == expected_output
 
     def test_upload_decode_plaintext(self, event_loop, file_svc, data_svc):
         content = b'this will be encoded and decoded as plaintext'

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -53,10 +53,42 @@ class TestFileService:
     def test_read_write_result_file(self, tmpdir, file_svc):
         link_id = '12345'
         output = 'output testing unit'
+        error = 'error testing unit'
+        output_encoded = str(b64encode(json.dumps({'stdout': output, 'stderr': error}).encode()), 'utf-8')
+
+        # write output data
+        file_svc.write_result_file(link_id=link_id, output=output_encoded, location=tmpdir)
+
+        # construct expected output
+        output_dict = {'stdout': output, 'stderr': error}
+
+        # read output data
+        output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
+        decoded_output_data = json.loads(base64.b64decode(output_data))
+        assert decoded_output_data == output_dict
+
+    def test_read_write_result_file_no_dict(self, tmpdir, file_svc):
+        link_id = '12345'
+        output = 'output testing unit'
         output_encoded = str(b64encode(output.encode()), 'utf-8')
 
         # write output data
         file_svc.write_result_file(link_id=link_id, output=output_encoded, location=tmpdir)
+
+        # construct expected output
+        output_dict = {'stdout': output, 'stderr': ''}
+
+        # read output data
+        output_data = file_svc.read_result_file(link_id=link_id, location=tmpdir)
+        decoded_output_data = json.loads(base64.b64decode(output_data))
+        assert decoded_output_data == output_dict
+
+    def test_read_write_result_file_no_base64(self, tmpdir, file_svc):
+        link_id = '12345'
+        output = 'output testing unit'
+
+        # write output data
+        file_svc.write_result_file(link_id=link_id, output=output, location=tmpdir)
 
         # construct expected output
         output_dict = {'stdout': output, 'stderr': ''}


### PR DESCRIPTION
## Description

This PR allows the server to handle both stdout and stderr from an agent.  The primary change is that result files will be written as a dictionary, i.e., { stdout: '', stderr: ''}.  Thus, when different readers request result output (e.g., the API, reports, or plugins) they will now receive a dictionary.  Core CALDERA functionality has been updated in this PR to account for these changes (e.g., reports will generate properly, the UI will display results properly), but any non-CALDERA users of APIs/reports or any custom plugins may be effected.

The PR accounts for old result files, and constructs a dictionary with the old results as "stdout".

Any agents that only send output will have their data stored in stdout, regardless of the origination.  An associated PR for Sandcat will be made in conjunction to this one which will return both stdout and stderr from commands.  However, stderr from other agents will appear as stdout.  Note that the link result itself is NOT effected, and will still show an error even on other agents.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested with Sandcat/Manx, old result files, and new result files.  Generated every type of report.  Tested with stdout, stderr, and both.  Automated test suites run successfully (with updates to account for the dict).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation - future ticket
- [N/A] I have added tests that prove my fix is effective or that my feature works - future ticket
