### PR TITLE
Fix command modal for manual commands

### DIFF
--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -99,7 +99,7 @@ class OperationApiManager(BaseApiManager):
                                               file_svc=self.services['file_svc']))
         executor = self.build_executor(data=data.pop('executor', {}), agent=agent)
         ability = self.build_ability(data=data.pop('ability', {}), executor=executor)
-        link = Link.load(dict(command=encoded_command, paw=agent.paw, ability=ability, executor=executor,
+        link = Link.load(dict(command=encoded_command, plaintext_command=encoded_command, paw=agent.paw, ability=ability, executor=executor,
                               status=operation.link_status(), score=data.get('score', 0), jitter=data.get('jitter', 0),
                               cleanup=data.get('cleanup', 0), pin=data.get('pin', 0),
                               host=agent.host, deadman=data.get('deadman', False), used=data.get('used', []),

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -224,7 +224,6 @@ class Link(BaseObject):
     def replace_origin_link_id(self):
         decoded_cmd = self.decode_bytes(self.command)
         self.command = self.encode_string(decoded_cmd.replace(self.RESERVED['origin_link_id'], self.id))
-        self.plaintext_command = decoded_cmd
 
     def _emit_status_change_event(self, from_status, to_status):
         event_svc = BaseService.get_service('event_svc')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ docker==4.2.0
 donut-shellcode==0.9.2
 marshmallow-enum==1.5.1
 ldap3==2.8.1
-lxml~=4.6.2  # debrief
+lxml~=4.9.1  # debrief
 reportlab==3.5.67  # debrief
 svglib==1.0.1  # debrief
 Markdown==3.3.3  # training


### PR DESCRIPTION
## Description

When viewing the command for a manual command in an operation, the "Obfuscated" and "Plaintext" command outputs didn't always make sense, even if obfuscation wasn't used. This PR ensures that the command is always accurately displayed, as the user entered it.

Worth noting that we're still aware that `command` and `plaintext_command` as returned from the API are _always_ base64 encoded. i.e., if no obfuscation is used, `command` and `plaintext_command` will be base64 obfuscated, but they will equal each other. When they don't equal each other, it means obfuscation was used. The View Command modal in the UI will always decode those commands for you.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running a command with an adversary and adding a manual command showed the correct command in the View Command modal each time.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
