### PR TITLE
Replace planner_id property name with id

### DIFF
--- a/app/api/v2/handlers/operation_api.py
+++ b/app/api/v2/handlers/operation_api.py
@@ -69,7 +69,7 @@ class OperationApi(BaseObjectApi):
                           summary='Create a new CALDERA operation record',
                           description='Create a new CALDERA operation using the format provided in the '
                                       '`OperationSchema`. Required schema fields are as follows: "name", '
-                                      '"adversary.adversary_id", "planner.planner_id", and "source.id"')
+                                      '"adversary.adversary_id", "planner.id", and "source.id"')
     @aiohttp_apispec.request_schema(OperationSchema)
     @aiohttp_apispec.response_schema(OperationSchema,
                                      description='The response is the newly-created operation report.')


### PR DESCRIPTION
## Description

I've tried calling the `/operations` `POST` endpoint and saw the description mentioning the mandatory fields:

> Required schema fields are as follows: "name", "adversary.adversary_id", "planner.planner_id", and "source.id"

As you can see in the corresponding [schema](https://github.com/mitre/caldera/blob/fcb0d31a971b310d8d3414877b34ee93d13344ef/app/objects/c_planner.py#L11) and when trying out the API the property under the `planner` object is called ìd` and not `planner_id`.

## Type of change

OpenAPI documentation change.

## How Has This Been Tested?

This doesn't work:
``´sh
curl -X 'POST' \
  'http://localhost:8888/api/v2/operations' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{"name": "MyApiTest", "adversary": {"adversary_id": "5d3e170e-f1b8-49f9-9ee1-c51605552a08"},"planner": {"planner_id": aaa7c857-7a0-4c4a-85f7-4e9f7f30e31a"},"source": {"id": "ed32b9c3-9593-4c33-b0db-e2007315096b"}}'
```

This works:
``´sh
curl -X 'POST' \
  'http://localhost:8888/api/v2/operations' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{"name": "MyApiTest", "adversary": {"adversary_id": "5d3e170e-f1b8-49f9-9ee1-c51605552a08"},"planner": {"id": aaa7c857-7a0-4c4a-85f7-4e9f7f30e31a"},"source": {"id": "ed32b9c3-9593-4c33-b0db-e2007315096b"}}'
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
