### PR TITLE
Add new events

### DIFF
--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -89,6 +89,7 @@ class ContactService(ContactServiceInterface, BaseService):
             self.log.debug("Agent %s can accept deadman abilities. Will return any available deadman abilities." %
                            agent.paw)
             await agent.deadman(data_svc)
+        await self.get_service('event_svc').fire_event(exchange='agent', queue='added', agent=agent.display)
         return agent, await self._get_instructions(agent)
 
     async def build_filename(self):

--- a/app/service/knowledge_svc.py
+++ b/app/service/knowledge_svc.py
@@ -21,9 +21,11 @@ class KnowledgeService(KnowledgeServiceInterface, BaseService):
 
     async def add_fact(self, fact, constraints=None):
         if isinstance(fact, Fact):
+            await self.get_service('event_svc').fire_event(exchange='fact', queue='added', fact=fact.display, constraints=constraints)
             return await self.__loaded_knowledge_module._add_fact(fact, constraints)
 
     async def update_fact(self, criteria, updates):
+        await self.get_service('event_svc').fire_event(exchange='fact', queue='updated', criteria=criteria, updates=updates)
         return await self.__loaded_knowledge_module._update_fact(criteria, updates)
 
     async def get_facts(self, criteria, restrictions=None):

--- a/server.py
+++ b/server.py
@@ -68,6 +68,7 @@ def run_tasks(services):
     loop.create_task(learning_svc.build_model())
     loop.create_task(app_svc.watch_ability_files())
     loop.run_until_complete(start_server())
+    loop.run_until_complete(event_svc.fire_event(exchange='system', queue='ready'))
     try:
         logging.info('All systems ready.')
         loop.run_forever()


### PR DESCRIPTION
## Description

A plugin in Caldera required knowledge of when facts were added or updated and when a new agent is added. These events can be shared with others.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Each uses the same single function call. If fire_event works, then these will work. No additional tests besides fire_event's are needed.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
