### PR TITLE
Include a newline at the end of operation event logs

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import re
 import uuid
 from collections import defaultdict
@@ -351,7 +352,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         logging.debug('Wrote event logs for operation %s to disk at %s/%s' % (self.name, event_logs_dir, file_name))
 
     async def _write_logs_to_disk(self, logs, file_name, dest_dir, file_svc):
-        logs_dumps = json.dumps(logs)
+        logs_dumps = json.dumps(logs) + os.linesep
         await file_svc.save_file(file_name, logs_dumps.encode(), dest_dir, encrypt=False)
 
     async def _load_objective(self, data_svc):


### PR DESCRIPTION
## Description

Operation event logs do not terminate with a newline, which causes certain log forwarding agents not to process the line. In addition, not having the newline seems to break the [POSIX definition of a line](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html), defined as:

> A sequence of zero or more non- <newline> characters plus a terminating <newline> character.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I verified that adding `os.linesep` after `json.dumps()` works. I also expect the [test_writing_event_logs_to_disk](https://github.com/mitre/caldera/blob/master/tests/objects/test_operation.py#L266-L342) test to pass without issue.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
