### PR TITLE
Pin tabs to top of page

### DIFF
--- a/static/css/core.css
+++ b/static/css/core.css
@@ -30,6 +30,7 @@ body {
 #active-tab-display {
   color: white;
   max-width: initial;
+  margin-top: 62px;
 }
 
 [data-tooltip]::before {
@@ -144,9 +145,13 @@ main.main {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  margin-top: 62px;
 }
 
 .nav.tabs {
+  position: fixed;
+  width: 100%;
+  z-index: 10;
   display: block !important;
   margin-bottom: 0 !important;
   padding: 10px 10px 0 10px;


### PR DESCRIPTION
## Description

Pins the page tabs to the top of the page so you can switch tabs at any time.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Works on Firefox, Chrome, and Safari -- tabs are always pinned to the top with appropriate padding.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
