### PR TITLE
Link commands are now unencoded by default

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -296,8 +296,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
             for step in self.chain:
                 step_report = dict(link_id=step.id,
                                    ability_id=step.ability.ability_id,
-                                   command=step.command,
-                                   plaintext_command=step.plaintext_command,
+                                   command=self.decode_bytes(step.command),
+                                   plaintext_command=self.decode_bytes(step.plaintext_command),
                                    delegated=step.decide.strftime(self.TIME_FORMAT),
                                    run=step.finish,
                                    status=step.status,
@@ -361,8 +361,8 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.objective = deepcopy(obj[0])
 
     async def _convert_link_to_event_log(self, link, file_svc, data_svc, output=False):
-        event_dict = dict(command=link.command,
-                          plaintext_command=link.plaintext_command,
+        event_dict = dict(command=self.decode_bytes(link.command),
+                          plaintext_command=self.decode_bytes(link.plaintext_command),
                           delegated_timestamp=link.decide.strftime(self.TIME_FORMAT),
                           collected_timestamp=link.collect.strftime(self.TIME_FORMAT) if link.collect else None,
                           finished_timestamp=link.finish,

--- a/app/objects/secondclass/c_link.py
+++ b/app/objects/secondclass/c_link.py
@@ -131,6 +131,13 @@ class Link(BaseObject):
     def status(self):
         return self._status
 
+    @property
+    def display(self):
+        dump = LinkSchema(exclude=['jitter']).dump(self)
+        dump['command'] = self.decode_bytes(dump['command'])
+        dump['plaintext_command'] = self.decode_bytes(dump['plaintext_command'])
+        return dump
+
     @status.setter
     def status(self, value):
         previous_status = getattr(self, '_status', NO_STATUS_SET)

--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1696,9 +1696,9 @@
                         if (res.facts) {
                             this.selectedLinkFacts = Array.from(new Set(res.facts)).sort((a, b) => b.score - a.score);
                         }
-                        this.selectedLinkCommand = b64DecodeUnicode(res.command);
-                        this.selectedLinkPlaintextCommand = b64DecodeUnicode(res.plaintext_command);
-                        this.editableCommand = b64DecodeUnicode(res.command);
+                        this.selectedLinkCommand = res.command;
+                        this.selectedLinkPlaintextCommand = res.plaintext_command;
+                        this.editableCommand = res.command;
                     })
                     .catch(() => {
                         this.selectedLinkResults = null;
@@ -1722,7 +1722,7 @@
             updateLink(status, command = null) {
                 const updateLink = {
                     ...this.selectedLink,
-                    command: b64DecodeUnicode(this.selectedLink.command)
+                    command: this.selectedLink.command
                 };
                 if (command) {
                     updateLink.command = command;
@@ -1793,8 +1793,8 @@
                     rowItems.push(link.paw);
                     rowItems.push(link.host);
                     rowItems.push(link.pid);
-                    rowItems.push(b64DecodeUnicode(link.command));
-                    rowItems.push(b64DecodeUnicode(link.plaintext_command));
+                    rowItems.push(link.command);
+                    rowItems.push(link.plaintext_command);
                     csv.push(rowItems.join(','));
                 });
                 this.createDownloadReport(new Blob([csv.join('\n')], { type: 'text/csv' }), this.selectedOperation.name, true);

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -222,8 +222,8 @@ class TestOperation:
         )
         want = [
             dict(
-                command='d2hvYW1p',
-                plaintext_command='d2hvYW1p',
+                command='whoami',
+                plaintext_command='whoami',
                 delegated_timestamp=LINK1_DECIDE_TIME,
                 collected_timestamp=LINK1_COLLECT_TIME,
                 finished_timestamp=LINK1_FINISH_TIME,
@@ -241,8 +241,8 @@ class TestOperation:
                 attack_metadata=want_attack_metadata,
             ),
             dict(
-                command='aG9zdG5hbWU=',
-                plaintext_command='aG9zdG5hbWU=',
+                command='hostname',
+                plaintext_command='hostname',
                 delegated_timestamp=LINK2_DECIDE_TIME,
                 collected_timestamp=LINK2_COLLECT_TIME,
                 finished_timestamp=LINK2_FINISH_TIME,
@@ -293,8 +293,8 @@ class TestOperation:
         )
         want = [
             dict(
-                command='d2hvYW1p',
-                plaintext_command='d2hvYW1p',
+                command='whoami',
+                plaintext_command='whoami',
                 delegated_timestamp=LINK1_DECIDE_TIME,
                 collected_timestamp=LINK1_COLLECT_TIME,
                 finished_timestamp=LINK1_FINISH_TIME,
@@ -312,8 +312,8 @@ class TestOperation:
                 attack_metadata=want_attack_metadata,
             ),
             dict(
-                command='aG9zdG5hbWU=',
-                plaintext_command='aG9zdG5hbWU=',
+                command='hostname',
+                plaintext_command='hostname',
                 delegated_timestamp=LINK2_DECIDE_TIME,
                 collected_timestamp=LINK2_COLLECT_TIME,
                 finished_timestamp=LINK2_FINISH_TIME,

--- a/tests/services/test_planning_svc.py
+++ b/tests/services/test_planning_svc.py
@@ -331,9 +331,8 @@ class TestPlanningService:
         f3 = Fact(trait='a.b.e', value='3')
 
         gen = await planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3])
-
         assert len(gen) == 2
-        assert BaseWorld.decode_bytes(gen[1].display['command']) == target_string
+        assert gen[1].display['command'] == target_string
 
     async def test_trim_links(self, setup_planning_test, planning_svc):
         """
@@ -364,7 +363,7 @@ class TestPlanningService:
         trimmed_links = await planning_svc.trim_links(operation, [link], agent)
 
         assert len(trimmed_links) == 1
-        assert BaseWorld.decode_bytes(trimmed_links[0].display['command']) == target_string
+        assert trimmed_links[0].display['command'] == target_string
 
     async def test_filter_bs(self, setup_planning_test, planning_svc):
         _, agent, operation, ability = setup_planning_test
@@ -382,7 +381,7 @@ class TestPlanningService:
         gen = await planning_svc.add_test_variants([link], agent, facts=[f0, f1, f2, f3, f4, f5, f6])
 
         assert len(gen) == 4
-        assert BaseWorld.decode_bytes(gen[1].display['command']) == target_string
+        assert gen[1].display['command'] == target_string
 
     async def test_duplicate_lateral_filter(self, setup_planning_test, planning_svc, link, fact):
         ability, agent, operation, sability = setup_planning_test


### PR DESCRIPTION
## Description

Link commands are typically stored encoded in base64, even when no obfuscation is used during an operation. While the UI and other plugins have been design to accommodate this, it causes some confusion when reading reports or links from the operations API. This PR makes changes to the Link object, specifically its display property, so that whenever a link is retrieved for display purposes, the `command` and `plaintext_command` fields are unencoded. The UI, tests, and relevant classes have been modified accordingly.

This is sort of a patch for a larger issue, since we really don't need link commands to be stored encoded at all. However, given the amount of refactoring needed within core, plugins, and deployable agents, this should be a stop-gap solution for the time being.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All operation API endpoints that return links now return `command` and `plaintext_command` unencoded, though `command` will be encoded if any obfuscation was used during an operation. The tests have also been updated and pass with these changes.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
