### PR TITLE
Update caldera base image to use python official base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM python:3.8-buster
 SHELL ["/bin/bash", "-c"]
 
 ARG TZ="UTC"
@@ -12,7 +12,7 @@ ADD . .
 RUN if [ -z "$(ls plugins/stockpile)" ]; then echo "stockpile plugin not downloaded - please ensure you recursively cloned the caldera git repository and try again."; exit 1; fi
 
 RUN apt-get update && \
-    apt-get -y install python3 python3-pip git curl
+    apt-get -y install python3-venv git curl
 
 #WIN_BUILD is used to enable windows build in sandcat plugin
 ARG WIN_BUILD=false


### PR DESCRIPTION
## Description

This is a PR as a direct response to the following issue https://github.com/mitre-atlas/arsenal/issues/2. We have found that counterfit, one of the requirements for the plugin arsenal is incompatible with python 3.9 and above. The ubuntu base image as of the time of writing will install python 3.10 by default.

In general this could be problematic not only for this change but potentially for future versions as the ubuntu:latest base image will imply it will use the latest version of ubuntu (and hence python, and other things) which can cause breaking changes. Hence we propose to use python official image as our base image such that we are able to pin the python version to 3.8.

We confirmed that after applying this change and some minor typo fix in the arsenal repo (we could be opening another PR for the fix in the arsenal repo), we could successfully access arsenal in the containerized version of caldera. Also we did not face any other issues during image building and deployment.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

We have not run it with properly testing suite, please recommend the testing method for the containerized version of caldera.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
