### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2==3.0.3
 pyyaml>=5.1
 cryptography>=3.2,<37.0.0; python_version <= '3.7'
 cryptography>=3.2; python_version > '3.7'
-websockets>=10.3
+websockets>=10.3,<=10.4
 Sphinx==5.1.1
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
## Description

Websockets 11.0 introduced breaking changes so we could not read from the socket. We have to stay in version 10.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Yes in our environment websockets 11+ didn't work. We reverted to 10.4 and it started working like normal.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
