### PR TITLE
Add capability to download fact sources from sources page

### DIFF
--- a/templates/sources.html
+++ b/templates/sources.html
@@ -60,6 +60,11 @@
                     <span class="icon"><em class="fas fa-copy"></em></span>
                     <span>Duplicate Source</span>
                 </button>
+                <button class="button is-primary is-small mb-2" @click="downloadSource()"
+                        x-bind:disabled="!selectedSourceId">
+                    <span class="icon"><em class="fas fa-arrow-down"></em></span>
+                    <span>Download Source</span>
+                </button>
                 <div class="hr"></div>
                 <button class="button is-small mb-2 is-danger is-outlined"
                         @click="openModal = { isOpen: true, name: 'Delete Source' }">
@@ -1258,6 +1263,22 @@
                     toast('Error loading page', false);
                     console.error(error);
                 });
+            },
+
+            downloadSource() {
+                apiV2('GET', `/api/v2/sources/${this.selectedSourceId}`)
+                    .then((res) => {
+                      const dataURL = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(res, null, 2))}`
+                      const fileName = `${this.selectedSource.name}.json`
+                      const elem = document.createElement('a');
+                      elem.setAttribute('href', dataURL);
+                      elem.setAttribute('download', fileName);
+                      elem.click();
+                      elem.remove();
+                    }).catch((error) => {
+                      toast('Error downloading source');
+                      console.error(error)
+                    });
             },
 
             resetSearch() {


### PR DESCRIPTION
## Description

This PR adds a download button to the fact sources page when a source is selected. When clicked, it downloads the source information in JSON format.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've download multiple different sources and they were all successful.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
