### PR TITLE
Dockerfile Updates for Emu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ WORKDIR /usr/src/app
 #    ./usr/src/app/plugins/emu/download_payloads.sh; \
 #fi
 RUN apt-get -y install zlib1g unzip;
+RUN pip3 install pyminizip;
 RUN ./plugins/emu/download_payloads.sh;
 
 # Default HTTP port for web interface and agent beacons over HTTP

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set up config file and disable atomic by default
 RUN sed -i '/\- atomic/d' conf/default.yml
-RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml; fi
+RUN if [! -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;      \
+    else grep -v "\- atomic" conf/default.yml > conf/local.yml;                 \
+    fi
 
 # Install golang
 RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz
@@ -64,10 +66,10 @@ fi
 WORKDIR /usr/src/app
 
 # If emu is enabled, complete necessary installation steps
-RUN if [ $(grep -c "\- emu" conf/default.yml) ]; then \
+RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
     apt-get -y install zlib1g unzip; \
     pip3 install -r ./plugins/emu/requirements.txt; \
-    ./plugins/emu/download_payloads.sh; \
+    #./plugins/emu/download_payloads.sh; \
 fi
 
 # Default HTTP port for web interface and agent beacons over HTTP

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ fi
 
 WORKDIR /usr/src/app
 
+# If emu is enabled, complete necessary installation steps
 RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
     apt-get -y install zlib1g unzip; \
     pip3 install -r ./plugins/emu/requirements.txt; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,11 @@ fi
 
 WORKDIR /usr/src/app
 
-#RUN if [ grep "\- emu" /usr/src/app/conf/local.yml ]; then \
-#    apt-get install zlib1g; \
-#    ./usr/src/app/plugins/emu/download_payloads.sh; \
-#fi
-RUN apt-get -y install zlib1g unzip;
-RUN pip3 install pyminizip;
-RUN ./plugins/emu/download_payloads.sh;
+RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
+    apt-get -y install zlib1g unzip; \
+    pip3 install -r ./plugins/emu/requirements.txt; \
+    ./plugins/emu/download_payloads.sh; \
+fi
 
 # Default HTTP port for web interface and agent beacons over HTTP
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,14 +62,16 @@ RUN if [ ! -d "/usr/src/app/plugins/atomic/data/atomic-red-team" ]; then   \
         /usr/src/app/plugins/atomic/data/atomic-red-team;                  \
 fi
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/plugins/emu
 
 # If emu is enabled, complete necessary installation steps
 RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
-    apt-get -y install zlib1g unzip; \
-    pip3 install -r ./plugins/emu/requirements.txt; \
-    ./plugins/emu/download_payloads.sh; \
+    apt-get -y install zlib1g unzip;                \
+    pip3 install -r ./requirements.txt;             \
+    ./download_payloads.sh;                         \
 fi
+
+WORKDIR /usr/src/app
 
 # Default HTTP port for web interface and agent beacons over HTTP
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set up config file and disable atomic by default
-RUN sed -i '/\- atomic/d' conf/default.yml
-RUN if [! -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;      \
+RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;      \
     else grep -v "\- atomic" conf/default.yml > conf/local.yml;                 \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ fi
 WORKDIR /usr/src/app/plugins/emu
 
 # If emu is enabled, complete necessary installation steps
-RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
+RUN if [ $(grep -c "\- emu" ../../conf/local.yml)  ]; then \
     apt-get -y install zlib1g unzip;                \
-    pip3 install -r ./requirements.txt;             \
+    pip3 install -r requirements.txt;               \
     ./download_payloads.sh;                         \
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set up config file and disable atomic by default
-RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;      \
-    else grep -v "\- atomic" conf/default.yml > conf/local.yml;                 \
+RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;                                             \
+    else sed -i '/\- atomic/d' conf/default.yml;                                                                       \
+    python3 -c "import app; import app.utility.config_generator; app.utility.config_generator.ensure_local_config();"; \
     fi
 
 # Install golang

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ WORKDIR /usr/src/app
 RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
     apt-get -y install zlib1g unzip; \
     pip3 install -r ./plugins/emu/requirements.txt; \
-    #./plugins/emu/download_payloads.sh; \
+    ./plugins/emu/download_payloads.sh; \
 fi
 
 # Default HTTP port for web interface and agent beacons over HTTP

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,13 @@ fi
 
 WORKDIR /usr/src/app
 
+#RUN if [ grep "\- emu" /usr/src/app/conf/local.yml ]; then \
+#    apt-get install zlib1g; \
+#    ./usr/src/app/plugins/emu/download_payloads.sh; \
+#fi
+RUN apt-get -y install zlib1g unzip;
+RUN ./plugins/emu/download_payloads.sh;
+
 # Default HTTP port for web interface and agent beacons over HTTP
 EXPOSE 8888
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,8 @@ RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set up config file and disable atomic by default
-RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml;                                             \
-    else sed -i '/\- atomic/d' conf/default.yml;                                                                       \
-    python3 -c "import app; import app.utility.config_generator; app.utility.config_generator.ensure_local_config();"; \
-    fi
+RUN python3 -c "import app; import app.utility.config_generator; app.utility.config_generator.ensure_local_config();"; \
+    sed -i '/\- atomic/d' conf/local.yml;
 
 # Install golang
 RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set up config file and disable atomic by default
-RUN grep -v "\- atomic" conf/default.yml > conf/local.yml
+RUN sed -i '/\- atomic/d' conf/default.yml
+RUN if [ -f "conf/local.yml" ]; then sed -i '/\- atomic/d' conf/local.yml; fi
 
 # Install golang
 RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz
@@ -63,7 +64,7 @@ fi
 WORKDIR /usr/src/app
 
 # If emu is enabled, complete necessary installation steps
-RUN if [ $(grep -c "\- emu" conf/local.yml) ]; then \
+RUN if [ $(grep -c "\- emu" conf/default.yml) ]; then \
     apt-get -y install zlib1g unzip; \
     pip3 install -r ./plugins/emu/requirements.txt; \
     ./plugins/emu/download_payloads.sh; \


### PR DESCRIPTION
## Description
Users were running into `InvalidToken` cryptography errors when running the platform with Docker. This was due to the following scenario:
* The platform was started and stopped locally first (without Docker). This created an encrypted local backup.
* Users then tried to run the app with the Dockerfile, which does not run CALDERA with any flags in the Dockerfile. So the app would attempt to start with an existing local.yml file and a backup, should they exist.
* The original Dockerfile rewrote `local.yml` and its encryption keys used to load previous saves of the platform, writing a copy of `default.yml` into `local.yml`. The correct encryption keys from the original `local.yml` were overwritten, and the platform was unable to load previously saved data, ending execution with an `InvalidToken` error.

The Dockerfile has been updated to account for an existing `local.yml` file, and will make the necessary edits to that file as an opposed to overwriting it entirely. If a `local.yml` file is missing, a new one will be generated from `default.yml`, but with randomly set encryption/passwords (similarly to how the server normally creates that file).

Additionally, the Dockerfile has been updated to conditionally run necessary Emu installations if the Emu plugin is enabled.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

Used this branch to rerun steps that produced error on `master`:
1. Ran server with --fresh. Shut down the server.
2. Built Docker Image (`docker build . --build-arg WIN_BUILD=true -t caldera:latest`).
3. Ran Docker Image (`docker run -p 8888:8888 caldera:latest`).

The server was verified to start successfully, with the Emu plugin loaded.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
