### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.7
-            toxenv: py37,style,coverage-ci
           - python-version: 3.8
             toxenv: py38,style,coverage-ci
           - python-version: 3.9

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.7
-            toxenv: safety
           - python-version: 3.8
             toxenv: safety
           - python-version: 3.9
             toxenv: safety
           - python-version: 3.10.9
+            toxenv: safety
+          - python-version: 3.11
             toxenv: safety
 
     steps:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These plugins are ready to use but are not included by default and are not maint
 These requirements are for the computer running the core framework:
 
 * Any Linux or MacOS
-* Python 3.7+ (with Pip3)
+* Python 3.8+ (with Pip3)
 * Recommended hardware to run on is 8GB+ RAM and 2+ CPUs
 * Recommended: GoLang 1.17+ to dynamically compile GoLang-based agents.
 

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -50,7 +50,7 @@ requirements:
     attr: version
     module: sys
     type: python_module
-    version: 3.7.0
+    version: 3.8.0
 users:
   blue:
     blue: admin

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ aiohttp-security==0.4.0
 aiohttp-apispec==2.2.3
 jinja2==3.0.3
 pyyaml>=5.1
-cryptography>=3.2,<37.0.0; python_version <= '3.7'
-cryptography>=3.2; python_version > '3.7'
+cryptography>=3.2
 websockets>=10.3
 Sphinx==5.1.1
 docutils==0.16 # Broken bullet lists in sphinx_rtd_theme https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
@@ -24,5 +23,4 @@ svglib==1.0.1  # debrief
 Markdown==3.3.3  # training
 dnspython==2.1.0
 asyncssh==2.11.0
-aioftp~=0.20.0; python_version >= '3.7'
-aioftp==0.16.1; python_version < '3.7'
+aioftp~=0.20.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.sources=./app
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.7,3.8,3.9,3.10
+sonar.python.version=3.8,3.9,3.10,3.11
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Make an exception to Link's constructor, since it requires a refactor to pass

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -122,7 +122,7 @@ async def test_command_overwrite_failure(aiohttp_client, authorized_cookies):
                                                           python=dict(attr='version',
                                                                       module='sys',
                                                                       type='python_module',
-                                                                      version='3.7.0'))))
+                                                                      version='3.11.0'))))
 
     assert resp.status == HTTPStatus.OK
     config_dict = await resp.json()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{37,38,39,310,311}
+    py{38,39,310,311}
     style
     coverage
     safety
@@ -24,8 +24,7 @@ deps =
     pytest-aiohttp
     coverage
 commands =
-    py37: coverage run -p -m pytest --tb=short -Werror --asyncio-mode=auto tests
-    py{38,39,310,311}: coverage run -p -m pytest --tb=short --asyncio-mode=auto tests
+    coverage run -p -m pytest --tb=short --asyncio-mode=auto tests
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
## Description

Python 3.7 has reached end of life and is no longer officially supported. Thus we no longer need to explicitly support it or test it. This is will also remove an issue with 3.7 tests failing.

Related: https://github.com/mitre/fieldmanual/pull/113

## Type of change


## How Has This Been Tested?

Ran locally in new environment.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
