### PR TITLE
Fixed golang error with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD . .
 RUN if [ -z "$(ls plugins/stockpile)" ]; then echo "stockpile plugin not downloaded - please ensure you recursively cloned the caldera git repository and try again."; exit 1; fi
 
 RUN apt-get update && \
-    apt-get -y install python3 python3-pip git curl
+    apt-get -y install python3 python3-pip git curl golang-go
 
 #WIN_BUILD is used to enable windows build in sandcat plugin
 ARG WIN_BUILD=false
@@ -24,12 +24,6 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 # Set up config file and disable atomic by default
 RUN python3 -c "import app; import app.utility.config_generator; app.utility.config_generator.ensure_local_config();"; \
     sed -i '/\- atomic/d' conf/local.yml;
-
-# Install golang
-RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz;
-ENV PATH="${PATH}:/usr/local/go/bin"
-RUN go version;
 
 # Compile default sandcat agent binaries, which will download basic golang dependencies.
 WORKDIR /usr/src/app/plugins/sandcat


### PR DESCRIPTION
## Description
Was running into an error using the provided Dockerfile, error related to golang.
<img width="1720" alt="image" src="https://github.com/mitre/caldera/assets/53032089/7ac29a07-2b2e-4cbc-821d-c7dd00e2249e">

## Type of change
Changed from installing go from source, to using apt, this resolved the issue.
<img width="1715" alt="image" src="https://github.com/mitre/caldera/assets/53032089/c6132e8d-b539-4944-9751-8bf044da5f70">


Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
  Running an instance with modified Dockerfile was successful

Please describe the tests that you ran to verify your changes.
  docker build . --build-arg WIN_BUILD=true -t caldera:latest
  docker-compose up

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
