### PR TITLE
Remove operation visibility slider

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -743,18 +743,6 @@
                                         </p>
                                     </div>
                                 </div>
-                                <div>
-                                    <label for="stealth-queue"><span
-                                            class="has-tooltip-multiline has-tooltip-top"
-                                            x-bind:data-tooltip="usage['Visibility']">Visibility</span></label>
-                                    <div class="modal-form-fields">
-                                        <input x-model="operationToStart.visibility"
-                                               id="stealth-queue"
-                                               type="range" value="50" min="1" max="100"
-                                               x-on:change.once="toast('The higher the visibility number, the more risk you will take with your operation getting noticed by the defense.', true)">
-                                        <span x-text="operationToStart.visibility"></span>
-                                    </div>
-                                </div>
                             </div>
                         </section>
                         <footer class="modal-card-foot">


### PR DESCRIPTION
## Description

- Removes the visibility slider option when creating a new operation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Started a new operation with no visibility slider

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
