### PR TITLE
Add ReadTheDocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: plugins/fieldmanual/sphinx-docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: requirements.txt
+
+# Build all formats (incl. pdf, epub)
+formats: all
+
+# Include all submodules
+submodules:
+  include: all
+  recursive: true


### PR DESCRIPTION
## Description

Add a ReadTheDocs config file to prevent builds failing in September. See https://blog.readthedocs.com/migrate-configuration-v2/

## Type of change

Infrastructure settings

## How Has This Been Tested?

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
