### PR TITLE
Secure API key comparison

### DIFF
--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -1,5 +1,6 @@
 import base64
 from collections import namedtuple
+from hmac import compare_digest
 from importlib import import_module
 
 from aiohttp import web, web_request
@@ -142,9 +143,9 @@ class AuthService(AuthServiceInterface, BaseService):
 
         if api_key is None:
             return False
-        if api_key == self.get_config(CONFIG_API_KEY_RED):
+        if compare_digest(api_key, self.get_config(CONFIG_API_KEY_RED)):
             return True
-        if api_key == self.get_config(CONFIG_API_KEY_BLUE):
+        if compare_digest(api_key, self.get_config(CONFIG_API_KEY_BLUE)):
             return True
         return False
 


### PR DESCRIPTION
## Description

Change authorization service to utilize "hmac.compare_digest" instead of "==" when checking API keys. This improves Caldera's resistance to timing attacks.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
