### PR TITLE
Fix Golang in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:23.04
 SHELL ["/bin/bash", "-c"]
 
 ARG TZ="UTC"
@@ -12,11 +12,17 @@ ADD . .
 RUN if [ -z "$(ls plugins/stockpile)" ]; then echo "stockpile plugin not downloaded - please ensure you recursively cloned the caldera git repository and try again."; exit 1; fi
 
 RUN apt-get update && \
-    apt-get -y install python3 python3-pip git curl golang-go
+    apt-get -y install python3 python3-pip python3-venv git curl golang-go
+
 
 #WIN_BUILD is used to enable windows build in sandcat plugin
 ARG WIN_BUILD=false
 RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
+
+# Set up python virtualenv
+ENV VIRTUAL_ENV=/opt/venv/caldera
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install pip requirements
 RUN pip3 install --no-cache-dir -r requirements.txt
@@ -26,6 +32,11 @@ RUN python3 -c "import app; import app.utility.config_generator; app.utility.con
     sed -i '/\- atomic/d' conf/local.yml;
 
 # Compile default sandcat agent binaries, which will download basic golang dependencies.
+
+# Install Go dependencies
+WORKDIR /usr/src/app/plugins/sandcat/gocat
+RUN go mod tidy && go mod download
+
 WORKDIR /usr/src/app/plugins/sandcat
 
 # Fix line ending error that can be caused by cloning the project in a Windows environment

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Next, install the PIP requirements:
 ```Bash
 pip3 install -r requirements.txt
 ```
-**Super-power your Caldera server installation! [Install GoLang (1.17+)](https://go.dev/doc/install)**
+**Super-power your Caldera server installation! [Install GoLang (1.19+)](https://go.dev/doc/install)**
 
 Finally, start the server.
 ```Bash

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -45,7 +45,7 @@ requirements:
   go:
     command: go version
     type: installed_program
-    version: 1.11
+    version: 1.19
   python:
     attr: version
     module: sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp-security==0.4.0
 aiohttp-apispec==2.2.3
 jinja2==3.1.2
 pyyaml==6.0.1
-cryptography==41.0.3
+cryptography==41.0.4
 websockets==11.0.3
 Sphinx==7.1.2
 sphinx_rtd_theme==1.3.0


### PR DESCRIPTION
## Description

Supersedes #2802. Fixes the same issue with compiling Go. I also updated mentions of minimum required golang version. Ubuntu 23.04 is the earliest version with Go v1.19+, so switched to it as the base. However, it also gives an error when running `pip` outside of a virtual environment, so I added that to the Dockerfile as well. Finally, I got go errors about "`no required module provides package`" until I added the `go mod` commands.

Must be merged in tandem with https://github.com/mitre/sandcat/pull/434.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran Caldera via Dockerfile.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
