### PR TITLE
[VIRTS-4695] Fix Manx Console Error/Timing Error

### DIFF
--- a/app/contacts/contact_tcp.py
+++ b/app/contacts/contact_tcp.py
@@ -85,6 +85,7 @@ class TcpSessionHandler(BaseWorld):
         try:
             conn = next(i.connection for i in self.sessions if i.id == int(session_id))
             conn.send(str.encode(' '))
+            time.sleep(0.01)
             conn.send(str.encode('%s\n' % cmd))
             response = await self._attempt_connection(session_id, conn, timeout=timeout)
             response = json.loads(response)


### PR DESCRIPTION
## Description
For <= Python3.10, Manx would throw a JSON decoding console error due to the server receiving an empty message from the agent. The plugin would still work, but this message can be confusing for users. After adding a short sleep command between messages sent to the agent, the problem no longer occurs. I believe this is because the agent now has sufficient time to process both received messages.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Reran manx agents before and after changes. Agents continue to work as expected with change, and no longer send empty JSON messages to the server (and consequentially, no longer cause console errors).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
