### PR TITLE
[VIRTS-4695] Fix Deprecated Manx Socket Issues

### DIFF
--- a/tests/contacts/test_contact_tcp.py
+++ b/tests/contacts/test_contact_tcp.py
@@ -9,28 +9,34 @@ logger = logging.getLogger(__name__)
 
 class TestTcpSessionHandler:
 
-    def test_refresh_with_socket_errors(self, event_loop):
+    def test_refresh_with_socket_errors(self, event_loop, async_return):
         handler = TcpSessionHandler(services=None, log=logger)
 
         session_with_socket_error = mock.Mock()
         session_with_socket_error.connection.send.side_effect = socket.error()
 
+        standard_session = mock.Mock()
+        standard_session.connection.send.return_value = async_return(True)
+
         handler.sessions = [
             session_with_socket_error,
             session_with_socket_error,
-            mock.Mock()
+            standard_session
         ]
 
         event_loop.run_until_complete(handler.refresh())
         assert len(handler.sessions) == 1
         assert all(x is not session_with_socket_error for x in handler.sessions)
 
-    def test_refresh_without_socket_errors(self, event_loop):
+    def test_refresh_without_socket_errors(self, event_loop, async_return):
+        standard_session = mock.Mock()
+        standard_session.connection.send.return_value = async_return(True)
+
         handler = TcpSessionHandler(services=None, log=logger)
         handler.sessions = [
-            mock.Mock(),
-            mock.Mock(),
-            mock.Mock()
+            standard_session,
+            standard_session,
+            standard_session
         ]
 
         event_loop.run_until_complete(handler.refresh())


### PR DESCRIPTION
## Description

Fixes deprecated Python 3 error which discontinues send/receive functionality of TransportSockets. Manx repo changes must be merged first [changes to the Manx plugin.](https://github.com/mitre/manx/pull/42), and merging those changes should resolve the unit test issues in this repo. This PR is ready for review, but is marked as a draft to prevent accidental merging.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested manually, can confirm manx plugin works without error.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
