### PR TITLE
Update operations.html

### DIFF
--- a/templates/operations.html
+++ b/templates/operations.html
@@ -1648,7 +1648,7 @@
 
                 let combinations = [];
                 Object.keys(this.selectedPotentialLinkFacts).forEach((factName) => {
-                    combinations.push(this.selectedPotentialLinkFacts[factName].filter((fact) => fact.selected).map((fact) => `${factName}|${fact.value}`));
+                    combinations.push(this.selectedPotentialLinkFacts[factName].filter((fact) => fact.selected).map((fact) => `${factName.length}|${factName}${fact.value}`));
                 });
                 combinations = cartesian(combinations);
 
@@ -1673,8 +1673,8 @@
                 combinations.forEach((factGroup) => {
                     let command = this.potentialLinkCommand;
                     factGroup.forEach((fact) => {
-                        let split = fact.split('|');
-                        command = command.replaceAll(`#{${split[0]}}`, split[1])
+                        let factNameLength = fact.split('|', 1)[0], restOfFact = fact.slice(1+factNameLength.length);
+                        command = command.replaceAll(`#{${restOfFact.slice(0, parseInt(factNameLength))}}`, restOfFact.slice(parseInt(factNameLength)))
                     });
 
                     this.potentialLinksToAdd.push({


### PR DESCRIPTION
Fix Pipe characters dropped from Fact during Parsing #2877

## Description

Fixes an issue with facts containing the pipe character |, so that they are no longer dropped. Instead of using a separator value to delimit the fact name and value, prepend and store the length of the fact name, then extract the name and value using that.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Ran the modified code with links with associated facts. Some facts contained the pipe character and some did not.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
