### PR TITLE
Update Dockerfile to build vue for 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,20 @@ fi
 
 WORKDIR /usr/src/app
 
+# Install Node.js, npm, and other build VueJS front-end
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    # Directly use npm to install dependencies and build the application
+    (cd plugins/magma && npm install) && \
+    (cd plugins/magma && npm run build) && \
+    # Remove Node.js, npm, and other unnecessary packages
+    apt-get remove -y nodejs npm && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /usr/src/app
+
 # Default HTTP port for web interface and agent beacons over HTTP
 EXPOSE 8888
 


### PR DESCRIPTION
Build vue before packaging with docker.

Closes #2889

## Description

As the VUE build is now part of the server.py and needs to be run once before startup we have to include this step in the docker file too, as this is ran on docker build.

allows the docker build to succeed and run in offline / airgapped systems

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

2 docker build systems, MacOS 14.2.1 + Ubuntu 23.04


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
