### PR TITLE
Have server.py automatically configure Magma .env when build flag set

### DIFF
--- a/server.py
+++ b/server.py
@@ -151,8 +151,8 @@ def configure_magma_env_file():
     logging.info("Setting VueJS environment file.")
     host = BaseWorld.get_config("host")
     port = BaseWorld.get_config("port")
-    with open("%s/.env" % MAGMA_PATH, "w") as fp:
-        fp.write("VITE_CALDERA_URL=http://%s:%s" % (host, port))
+    with open(f"{MAGMA_PATH}/.env", "w") as fp:
+        fp.write(f"VITE_CALDERA_URL=http://{host}:{port}")
 
 
 def _get_parser():
@@ -262,20 +262,26 @@ if __name__ == "__main__":
     app_svc.register_subapp("/api/v2", app.api.v2.make_app(app_svc.get_services()))
     init_swagger_documentation(app_svc.application)
     if args.uiDevHost:
-        if not os.path.exists("%s/dist" % MAGMA_PATH):
+        if not os.path.exists(f"{MAGMA_PATH}/dist"):
             logging.info("Building VueJS front-end.")
             subprocess.run(["npm", "run", "build"], cwd=MAGMA_PATH, check=True)
             logging.info("VueJS front-end build complete.")
         app_svc.application.on_response_prepare.append(enable_cors)
 
     if args.build:
-        configure_magma_env_file()
-        logging.info("Building VueJS front-end.")
-        subprocess.run(["npm", "install"], cwd=MAGMA_PATH, check=True)
-        subprocess.run(["npm", "run", "build"], cwd=MAGMA_PATH, check=True)
-        logging.info("VueJS front-end build complete.")
+        if len(os.listdir(MAGMA_PATH)) > 0:
+            configure_magma_env_file()
+            logging.info("Building VueJS front-end.")
+            subprocess.run(["npm", "install"], cwd=MAGMA_PATH, check=True)
+            subprocess.run(["npm", "run", "build"], cwd=MAGMA_PATH, check=True)
+            logging.info("VueJS front-end build complete.")
+        else:
+            logging.warning(
+                f"[bright_yellow]The `--build` flag was supplied, but the Caldera v5 Vue UI is not present."
+                f" The Vue UI should be located in {MAGMA_PATH}. Use `--recursive` when cloning Caldera.[/bright_yellow]"
+            )
     else:
-        if not os.path.exists("%s/dist" % MAGMA_PATH):
+        if not os.path.exists(f"{MAGMA_PATH}/dist"):
             logging.warning(
                 "[bright_yellow]Built Caldera v5 Vue components not detected, and `--build` flag not supplied."
                 " If attempting to start Caldera v5 for the first time, the `--build` flag must be"


### PR DESCRIPTION
## Description

These changes modify `server.py` to set the contents of `./plugins/magma/.env` when `--build` is used. The contents of Magma's `VITE_CALDERA_URL` environment variable is set to the `host` and `port` values set in the Caldera config.

A discrepancy between the URL used by Magma's router and the location of the Caldera server was noted as the cause of multiple issues: https://github.com/mitre/caldera/issues/2901, https://github.com/mitre/caldera/issues/2944, https://github.com/mitre/caldera/issues/2955

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The change was manually verified by starting the Caldera server and noting through browser developer tools that the URL used for Caldera's requests changed when the Caldera config values changed, and the UI was rebuilt.

It should be noted that the inciting bug was still present the first time I tested. In testing, I used Caldera by running on a cloud VM and port forwarding to my local machine. The Caldera config's default host value of `0.0.0.0` caused the login screen to be impassable. In my specific situation, I had to change the config's host value to `localhost` or the VM's domain name to get past the login screen.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
