### PR TITLE
Fix ghost facts

### DIFF
--- a/app/api/v2/handlers/fact_source_api.py
+++ b/app/api/v2/handlers/fact_source_api.py
@@ -104,4 +104,5 @@ class FactSourceApi(BaseObjectApi):
         await self.delete_on_disk_object(request)
         knowledge_svc_handle = self._api_manager.knowledge_svc
         await knowledge_svc_handle.delete_fact(criteria=dict(source=request.match_info.get('id')))
+        await knowledge_svc_handle.delete_relationship(criteria=dict(origin=request.match_info.get('id')))
         return web.HTTPNoContent()

--- a/app/api/v2/handlers/operation_api.py
+++ b/app/api/v2/handlers/operation_api.py
@@ -134,6 +134,7 @@ class OperationApi(BaseObjectApi):
         await self.delete_object(request)
         knowledge_svc_handle = self._api_manager.knowledge_svc
         await knowledge_svc_handle.delete_fact(criteria=dict(source=request.match_info.get('id')))
+        await knowledge_svc_handle.delete_relationship(criteria=dict(origin=request.match_info.get('id')))
         return web.HTTPNoContent()
 
     @aiohttp_apispec.docs(tags=['operations'],

--- a/app/api/v2/handlers/operation_api.py
+++ b/app/api/v2/handlers/operation_api.py
@@ -132,6 +132,8 @@ class OperationApi(BaseObjectApi):
                                      description='There is an empty response from a successful delete request.')
     async def delete_operation(self, request: web.Request):
         await self.delete_object(request)
+        knowledge_svc_handle = self._api_manager.knowledge_svc
+        await knowledge_svc_handle.delete_fact(criteria=dict(source=request.match_info.get('id')))
         return web.HTTPNoContent()
 
     @aiohttp_apispec.docs(tags=['operations'],

--- a/app/api/v2/managers/fact_source_manager.py
+++ b/app/api/v2/managers/fact_source_manager.py
@@ -1,0 +1,6 @@
+from app.api.v2.managers.base_api_manager import BaseApiManager
+
+class FactSourceApiManager(BaseApiManager):
+    def __init__(self, data_svc, file_svc, knowledge_svc):
+        super().__init__(data_svc=data_svc, file_svc=file_svc)
+        self.knowledge_svc = knowledge_svc

--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -21,6 +21,7 @@ class OperationApiManager(BaseApiManager):
     def __init__(self, services):
         super().__init__(data_svc=services['data_svc'], file_svc=services['file_svc'])
         self.services = services
+        self.knowledge_svc = services['knowledge_svc']
 
     async def get_operation_report(self, operation_id: str, access: dict, output: bool):
         operation = await self.get_operation_object(operation_id, access)

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -187,9 +187,10 @@ class Operation(FirstClassObjectInterface, BaseObject):
 
     async def all_facts(self):
         knowledge_svc_handle = BaseService.get_service('knowledge_svc')
+        data_svc_handle = BaseService.get_service('data_svc')
         seeded_facts = []
         if self.source:
-            seeded_facts = await knowledge_svc_handle.get_facts(criteria=dict(source=self.source.id))
+            seeded_facts = await data_svc_handle.get_facts_from_source(self.source.id)
         learned_facts = await knowledge_svc_handle.get_facts(criteria=dict(source=self.id))
         learned_facts = [f for f in learned_facts if f.score > 0]
         return seeded_facts + learned_facts

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -487,6 +487,6 @@ class DataService(DataServiceInterface, BaseService):
         if len(fact_sources) == 0:
             return []
         elif len(fact_sources) > 1:
-            self.log.error('Found multiple fact sources with the same id')
+            self.log.error('Found multiple fact sources with the same id', fact_source_id)
             return []
         return fact_sources[0].facts

--- a/app/service/data_svc.py
+++ b/app/service/data_svc.py
@@ -481,3 +481,12 @@ class DataService(DataServiceInterface, BaseService):
     def _get_plugin_name(self, filename):
         plugin_path = pathlib.PurePath(filename).parts
         return plugin_path[1] if 'plugins' in plugin_path else ''
+    
+    async def get_facts_from_source(self, fact_source_id):
+        fact_sources = await self.locate('sources', match=dict(id=fact_source_id))
+        if len(fact_sources) == 0:
+            return []
+        elif len(fact_sources) > 1:
+            self.log.error('Found multiple fact sources with the same id')
+            return []
+        return fact_sources[0].facts


### PR DESCRIPTION
## Description

Attempt to fix #2930 and close #2971. (update: as of 2024/06/14, it should fix them all)

This PR is an attempt to fix the 4 following issues:

1. A fact that has been loaded into an operation from a fact source will remain in the `fact_store` even after being deleted from the fact source. Consequences:
  - When starting a new operation with the same fact source, the deleted fact will still be used.
  - Unnecessary clutter that may become noticeable over time, potential for unintended data leak (agreed that Caldera shouldn't be used in a way that exposes sensitive data, but still).
2. A fact that has been loaded into an operation from a fact source will be duplicated in the `fact_store` when its value is updated in the fact source (very similar to the first item). Consequences:
  - When starting a new operation with the same fact source, the fact will have both the old and the new value (or more if it is updated several times), and there is no way to stop that apart from creating a new fact source or fiddling with the `fact_store` manually.
  - Unnecessary clutter that may become noticeable over time, potential for unintended data leak (agreed that Caldera shouldn't be used in a way that exposes sensitive data, but still).
3. A fact that has been loaded into an operation from a fact source will remain in the `fact_store` even when the fact source is deleted. Consequences:
  - Unnecessary clutter that may become noticeable over time, potential for unintended data leak (agreed that Caldera shouldn't be used in a way that exposes sensitive data, but still).
4. A fact that has been generated by an operation (from parsers) will remain in the `fact_store` even after the operation is deleted, seemingly never to be used again. Consequences:
  - Unnecessary clutter that may become noticeable over time, potential for unintended data leak (agreed that Caldera shouldn't be used in a way that exposes sensitive data, but still).

## Status (last update 2024/06/14)

At this point, all of the items mentioned are fixed, i.e.:
- When a fact is deleted from a Fact Source, it is no longer available to the future operations (item 1).
- When a fact is updated within a Fact Source, only its updated value is available to the future operations (item 2). 
- Additionally, the facts artifacts are cleaned up when their source (a.k.a. Fact Source or Operation) is deleted (item 3 and 4).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Item 1 & 2 and explanations


Situation: I created a Fact Source `FactSource1` with 2 facts in it named `Source1Fact1` & `Source1Fact2`, then loaded them in an operation with an adversary that contains a single ability. This ability is `echo #{Source1Fact1}`. There is nothing that uses `Source1Fact2`.

Here's the `fact_store` after running the operation then shutting down the server:
```
unique: Source1Fact1xyz, trait: Source1Fact1, value: xyz, created: 2024-06-14 09:27:55.013666+00:00, score: 0, source: a2a4ecb6-2529-4d78-adc6-ee78e1be212f, origin_type: OriginType.SEEDED, collected_by: []    
unique: Source1Fact2abc, trait: Source1Fact2, value: abc, created: 2024-06-14 09:36:35.491128+00:00, score: 0, source: a2a4ecb6-2529-4d78-adc6-ee78e1be212f, origin_type: OriginType.SEEDED, collected_by: []
```
Note that facts are loaded all the same whether they are used or not in the operation.

Now for the tests:
- Item 1: Deleting a fact from a fact source sends a `PUT` to `/api/v2/sources/xxx` with the fact removed from the json, which makes sense. The Fact Source object is then updated, but here's the first issue: **both facts, including the deleted one, are still in `fact_store `exactly the same.** For now, this does not raise any visible problem. But start a new operation that uses `FactSource1` as Fact Source and has an ability that uses `Source1Fact1`... And it somehow finds it, even though this fact does not exist in the Fact Source. The cause seems to be `Operation.all_facts()` with the line `seeded_facts = await knowledge_svc_handle.get_facts(criteria=dict(source=self.source.id))`. As we saw, the deleted fact remains in the `fact_store`, so this line finds every fact that has ever been loaded from this specific Fact Source.
  - We can solve this 2 ways: being more specific in the facts retrieval to avoid the deleted facts, or actually delete the facts from the internal store upon deletion from the Fact Source.
- Item 2: it's the same cause as for item 1. Updating a fact's value in a Fact Source sends a `PUT` to `/api/v2/sources/xxx`, which updates the Fact Source but keeps previously loaded values the same in the internal store:
```
unique: Source1Fact1xyz, trait: Source1Fact1, value: xyz, created: 2024-06-14 09:27:55.013666+00:00, score: 0, source: a2a4ecb6-2529-4d78-adc6-ee78e1be212f, origin_type: OriginType.SEEDED, collected_by: []      
unique: Source1Fact2abc, trait: Source1Fact2, value: abc, created: 2024-06-14 09:36:35.491128+00:00, score: 0, source: a2a4ecb6-2529-4d78-adc6-ee78e1be212f, origin_type: OriginType.SEEDED, collected_by: []      
unique: Source1Fact2def, trait: Source1Fact2, value: def, created: 2024-06-14 10:10:33.464996+00:00, score: 0, source: a2a4ecb6-2529-4d78-adc6-ee78e1be212f, origin_type: OriginType.SEEDED, collected_by: []
```
   - Again, 2 solutions: find a way not to load facts artefacts, or update the internal fact store when a Fact Source is updated.

I tried quite a bit to modify the method that updates fact sources by trying to keep track of old configurations to be able to reflect changes on the internal fact store, but with not much of a satisfactory result. However, a much more straightforward way I found was, at the operation's start, to retrieve the facts directly from the Fact Source object itself instead of the `fact_store` / `fact_ram` (commits [a253e6b](https://github.com/mitre/caldera/pull/2978/commits/a253e6bb26fae9830b0c3df753153d19ea542714) & [3ad8849](https://github.com/mitre/caldera/pull/2978/commits/3ad88491bd9ec61e817e815f15c627002f2c0dc6)).

This solves the issue and should not have any side effect since it uses a new method without changing `knowledge_svc`.

### Item 3 & 4

- Item 3: Deletion of data related to deleted fact sources:
  - Create a fact source with 1 fact/value, 1 rule, 1 relationship
  - Load it into an operation
  - Stop the server and check that the fact and the relationship have been added to the `fact_store` (rules are unaffected in my tests)
  - Restart the server and Delete the fact source
  - Stop the server and check that the fact and relationship have been deleted from the `fact_store`
- Item 4: Deletion of data related to deleted operations:
  - Create and launch an operation that generates facts and relationships
  - Stop the server and check that facts and relationships have been added to the `fact_store`
  - Restart the server and Delete the operation
  - Stop the server and check that the facts and relationships have been deleted from the `fact_store`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
