### PR TITLE
Makes Docker directly handle the SIGINT signal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ RUN apt-get update && \
 
 WORKDIR /usr/src/app
 
+STOPSIGNAL SIGINT
+
 # Default HTTP port for web interface and agent beacons over HTTP
 EXPOSE 8888
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ To gracefully terminate your docker container, do the following:
 # Find the container ID for your docker container running Caldera
 docker ps
 
-# Send interrupt signal, e.g. "docker kill --signal=SIGINT 5b9220dd9c0f"
-docker kill --signal=SIGINT [container ID]
+# Stop the container
+docker stop [container ID]
 ```
 
 ## Contributing


### PR DESCRIPTION
## Description

Caldera needs the SIGINT signal to be properly stopped.
As Docker defaults to the SIGTERM signal, a workaround was, until now, to manually send the SIGINT signal.

This PR makes the Docker image directly set the signal tu use when stopping a related container.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Building a new image and invoking `docker stop <container-id>` instead of `docker kill --signal=SIGINT <container-id>`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

