### PR TITLE
Uses a dedicated setting to generate the magma VITE_CALDERA_URL variable

### DIFF
--- a/conf/default.yml
+++ b/conf/default.yml
@@ -22,6 +22,7 @@ app.contact.ftp.user: caldera_user
 app.contact.tcp: 0.0.0.0:7010
 app.contact.udp: 0.0.0.0:7011
 app.contact.websocket: 0.0.0.0:7012
+app.frontend.api_base_url: http://localhost:8888
 objects.planners.default: atomic
 crypt_salt: REPLACE_WITH_RANDOM_VALUE
 encryption_key: ADMIN123

--- a/server.py
+++ b/server.py
@@ -149,10 +149,9 @@ async def start_vue_dev_server():
 
 def configure_magma_env_file():
     logging.info("Setting VueJS environment file.")
-    host = BaseWorld.get_config("host")
-    port = BaseWorld.get_config("port")
+    url = BaseWorld.get_config("app.frontend.api_base_url")
     with open(f"{MAGMA_PATH}/.env", "w") as fp:
-        fp.write(f"VITE_CALDERA_URL=http://{host}:{port}")
+        fp.write(f"VITE_CALDERA_URL={url}")
 
 
 def _get_parser():


### PR DESCRIPTION
## Description

Fix proposal for issue #2984, using a dedicated setting to be properly transferred to the magma's `.env` file when using the `--build` option.

The setting name can be changed if needed.

Note the related issue is linked to a more general topic about configuration variables: Separating server listening settings, (HTTP) client and contact (agent) ones. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Locally tested.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
