### PR TITLE
Fix - dnspython version in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,3 @@ coverage
 pre-commit
 safety
 bandit
-dnspython==2.1.0


### PR DESCRIPTION


## Description

The version of `dnspython` did not match the `requirements.txt` one.

Moreover, this dependency was already in `requirements.txt` and thus not necessary in `requirements-dev.txt`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

```shell
# No crash due to incompatibility of versions, only one dnspython dependency declaration.
pip install -r requirements.txt -r requirements-dev.txt
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
