### PR TITLE
Add API functionality to update planners

### DIFF
--- a/app/api/v2/handlers/planner_api.py
+++ b/app/api/v2/handlers/planner_api.py
@@ -17,6 +17,7 @@ class PlannerApi(BaseObjectApi):
         router = app.router
         router.add_get('/planners', self.get_planners)
         router.add_get('/planners/{planner_id}', self.get_planner_by_id)
+        router.add_patch('/planners/{planner_id}', self.update_planner)
 
     @aiohttp_apispec.docs(tags=['planners'],
                           summary='Retrieve planners',
@@ -49,3 +50,20 @@ class PlannerApi(BaseObjectApi):
     async def get_planner_by_id(self, request: web.Request):
         planner = await self.get_object(request)
         return web.json_response(planner)
+
+    @aiohttp_apispec.docs(tags=['planners'],
+                          summary='Updates an existing planner.',
+                          description='Updates a planner based on the `PlannerSchema` value provided in the message body.',
+                          parameters=[{
+                              'in': 'path',
+                              'name': 'planner_id',
+                              'schema': {'type': 'string'},
+                              'required': 'true',
+                              'description': 'UUID of the Planner to be updated'
+                          }])
+    @aiohttp_apispec.request_schema(PlannerSchema(partial=True))
+    @aiohttp_apispec.response_schema(PlannerSchema(partial=True),
+                                     description='JSON dictionary representation of the replaced Planner.')
+    async def update_planner(self, request: web.Request):
+        planner = await self.update_on_disk_object(request)
+        return web.json_response(planner.display)

--- a/app/objects/c_planner.py
+++ b/app/objects/c_planner.py
@@ -18,6 +18,12 @@ class PlannerSchema(ma.Schema):
     allow_repeatable_abilities = ma.fields.Boolean()
     plugin = ma.fields.String(load_default=None)
 
+    @ma.pre_load
+    def fix_id(self, data, **_):
+        if 'planner_id' in data:
+            data['id'] = data.pop('planner_id')
+        return data
+
     @ma.post_load()
     def build_planner(self, data, **kwargs):
         return None if kwargs.get('partial') is True else Planner(**data)
@@ -54,6 +60,8 @@ class Planner(FirstClassObjectInterface, BaseObject):
             existing.update('stopping_conditions', self.stopping_conditions)
             existing.update('params', self.params)
             existing.update('plugin', self.plugin)
+            existing.update('description', self.description)
+            existing.update('allow_repeatable_abilities', self.allow_repeatable_abilities)
         return existing
 
     async def which_plugin(self):

--- a/tests/api/v2/handlers/test_planners_api.py
+++ b/tests/api/v2/handlers/test_planners_api.py
@@ -26,6 +26,13 @@ def expected_test_planner_dump(test_planner):
     return test_planner.display_schema.dump(test_planner)
 
 
+@pytest.fixture
+def updated_planner(test_planner):
+    planner_dict = test_planner.schema.dump(test_planner)
+    planner_dict.update(dict(description="a test planner with updated description"))
+    return planner_dict
+
+
 class TestPlannersApi:
     async def test_get_planners(self, api_v2_client, api_cookies, test_planner, expected_test_planner_dump):
         resp = await api_v2_client.get('/api/v2/planners', cookies=api_cookies)
@@ -57,3 +64,19 @@ class TestPlannersApi:
         assert len(planners_list) == 2
         assert planners_list[0]["id"] == "456"
         assert planners_list[0]["name"][0] > planners_list[1]["name"][0]  # prove that this wasn't an alphabetical sort
+
+    async def test_update_planner(self, api_v2_client, api_cookies, test_planner, updated_planner, mocker):
+        with mocker.patch('app.api.v2.managers.base_api_manager.BaseApiManager.strip_yml') as mock_strip_yml:
+            mock_strip_yml.return_value = [test_planner.schema.dump(test_planner)]
+            resp = await api_v2_client.patch('/api/v2/planners/123', cookies=api_cookies, json=updated_planner)
+            assert resp.status == HTTPStatus.OK
+            planner = (await BaseService.get_service('data_svc').locate('planners'))[0]
+            assert planner.description == updated_planner["description"]
+
+    async def test_unauthorized_update_planner(self, api_v2_client, updated_planner):
+        resp = await api_v2_client.patch('/api/v2/planners/123', json=updated_planner)
+        assert resp.status == HTTPStatus.UNAUTHORIZED
+
+    async def test_update_nonexistent_planner(self, api_v2_client, api_cookies, updated_planner):
+        resp = await api_v2_client.patch('/api/v2/planners/999', cookies=api_cookies, json=updated_planner)
+        assert resp.status == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Description

This pull request adds the functionality to Caldera's API to update existing planners.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The new feature was tested manually using the Swagger UI.
Updating a planner, e.g. its description, results in the Caldera GUI showing the new description of the planner.
Also the corresponding YAML file was reviewed and it was found that it is correctly updated.

New pytest tests were written and executed successfully after applying PR https://github.com/mitre/caldera/pull/3013 that fixes the currently broken tests.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# More Info / Feature Request Issue

Instead of opening a feature request for this PR as an issue, the respective text can be found below.

**What problem are you trying to solve? Please describe.**
The new Caldera planners released recently (e.g. the look ahead planner) offer much more configuration than the classic planners. I think it would be really useful to configure them using the API (and thus enabling configuration using the GUI) instead of working with the planners' YAML files.

Also, I have implemented a new planner (https://github.com/mitre/caldera/discussions/2914) that also offers a lot of configuration possibilities. In the future I intend to make my planner configurable using the Caldera GUI. To do so, I saw the need to update planners using the Caldera API.


**The ideal solution: What should the feature should do?**
The API should offer a way to update existing planners.


**What category of feature is this?**

- [ ] UI/UX
- [x] API
- [ ] Other

**If you have code or pseudo-code please provide:**
See PR https://github.com/mitre/caldera/pull/3020.

**Screenshot of Swagger UI**
![Bildschirmfoto vom 2024-07-22 14-24-30](https://github.com/user-attachments/assets/d6bccb97-40c5-4e33-9d76-7f71f0c0dd3d)

