### PR TITLE
Feature - Manage schedules with cron (1/3)

### DIFF
--- a/app/objects/c_schedule.py
+++ b/app/objects/c_schedule.py
@@ -13,7 +13,7 @@ class ScheduleSchema(ma.Schema):
         unknown = ma.EXCLUDE
 
     id = ma.fields.String()
-    schedule = ma.fields.Time(required=True)
+    schedule = ma.fields.String(required=True)
     task = ma.fields.Nested(OperationSchema())
 
     @ma.post_load

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -84,6 +84,10 @@ class AppService(AppServiceInterface, BaseService):
             interval = 60
             for s in await self.get_service('data_svc').locate('schedules'):
                 now = datetime.now(timezone.utc)
+                if not croniter.croniter.is_valid(s.schedule):
+                    self.log.warning(f"The schedule {s.id} with the format `{s.schedule}` is incompatible with cron!")
+                    continue
+
                 cron = croniter.croniter(s.schedule, now)
                 diff = now - cron.get_prev(datetime)
                 if interval > diff.total_seconds() > 0:

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -13,6 +13,7 @@ import aiohttp_jinja2
 import jinja2
 import yaml
 from aiohttp import web
+import croniter
 
 from app.objects.c_plugin import Plugin
 from app.service.interfaces.i_app_svc import AppServiceInterface
@@ -82,9 +83,9 @@ class AppService(AppServiceInterface, BaseService):
         while True:
             interval = 60
             for s in await self.get_service('data_svc').locate('schedules'):
-                now = datetime.now(timezone.utc).time()
-                today_utc = datetime.now(timezone.utc).date()
-                diff = datetime.combine(today_utc, now) - datetime.combine(today_utc, s.schedule)
+                now = datetime.now(timezone.utc)
+                cron = croniter.croniter(s.schedule, now)
+                diff = now - cron.get_prev(datetime)
                 if interval > diff.total_seconds() > 0:
                     self.log.debug('Pulling %s off the scheduler' % s.id)
                     sop = copy.deepcopy(s.task)

--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import json
 import os
+import re
 import time
 from collections import namedtuple
 from datetime import datetime, timezone
@@ -83,11 +84,17 @@ class AppService(AppServiceInterface, BaseService):
         while True:
             interval = 60
             for s in await self.get_service('data_svc').locate('schedules'):
-                now = datetime.now(timezone.utc)
                 if not croniter.croniter.is_valid(s.schedule):
-                    self.log.warning(f"The schedule {s.id} with the format `{s.schedule}` is incompatible with cron!")
-                    continue
+                    match = re.match(r'^(\d{2}):(\d{2}):\d{2}\.\d{6}$', s.schedule)
+                    if match:
+                        hour, minute = match.groups()
+                        s.schedule = f"{minute} {hour} * * *"
+                        self.log.info(f"Converted time schedule {s.id} to cron format: {s.schedule}")
+                    else:
+                        self.log.warning(f"The schedule {s.id} with the format `{s.schedule}` is incompatible with cron!")
+                        continue
 
+                now = datetime.now()
                 cron = croniter.croniter(s.schedule, now)
                 diff = now - cron.get_prev(datetime)
                 if interval > diff.total_seconds() > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ dnspython==2.4.2
 asyncssh==2.14.1
 aioftp~=0.20.0
 packaging==23.2
+croniter~=3.0.3


### PR DESCRIPTION
This is the part of the schedule management that replaces cron.

Linked Merge Requests:
https://github.com/mitre/caldera/pull/3026
https://github.com/mitre/magma/pull/61

- Manage schedules with cron:
  - Replace time management with cron syntax for better control.
- Add conversion from old format to new one:
  - Replace the old date with the new cron syntax to create a new operation each day at the same hour and minute as before.