### PR TITLE
fix: bump aiohttp to 3.10.8 to avoid 500 errors caused by yarl issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp-jinja2==1.5.1
-aiohttp==3.9.3
+aiohttp==3.10.8
 aiohttp_session==2.12.0
 aiohttp-security==0.4.0
 aiohttp-apispec==3.0.0b2


### PR DESCRIPTION
## Description

Bumps aiohttp to 3.10.8 to fix an issue with yarl that causes a 500 error message on the GUI/HTTP server related to the Host variable containing a `:`

Resolves https://github.com/mitre/caldera/issues/3062 and https://github.com/mitre/caldera/issues/3061

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All tests passed...and tested on Kali 2024.1 system to confirm regular functionality


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
