### PR TITLE
add user_format_string to allow use with AD

### DIFF
--- a/app/service/login_handlers/default.py
+++ b/app/service/login_handlers/default.py
@@ -57,9 +57,11 @@ class DefaultLoginHandler(LoginHandlerInterface):
         server = ldap3.Server(self._ldap_config.get('server'))
         dn = self._ldap_config.get('dn')
         user_attr = self._ldap_config.get('user_attr') or 'uid'
-        user_string = '%s=%s,%s' % (user_attr, username, dn)
         user_format_string = self._ldap_config.get("user_format") or "{user_attr}={user},{dn}"
-        user_string = user_format_string.format(user_attr=user_attr, user=username, dn=dn)
+        try:
+            user_string = user_format_string.format(user_attr=user_attr, user=username, dn=dn)
+        except KeyError:
+            user_string = '%s=%s,%s' % (user_attr, username, dn)
 
         try:
             with ldap3.Connection(server, user=user_string, password=password) as conn:

--- a/app/service/login_handlers/default.py
+++ b/app/service/login_handlers/default.py
@@ -58,6 +58,8 @@ class DefaultLoginHandler(LoginHandlerInterface):
         dn = self._ldap_config.get('dn')
         user_attr = self._ldap_config.get('user_attr') or 'uid'
         user_string = '%s=%s,%s' % (user_attr, username, dn)
+        user_format_string = self._ldap_config.get("user_format") or "{user_attr}={user},{dn}"
+        user_string = user_format_string.format(user_attr=user_attr, user=username, dn=dn)
 
         try:
             with ldap3.Connection(server, user=user_string, password=password) as conn:


### PR DESCRIPTION
## Description
We encountered issues with LDAP login integration using our Active Directory (AD) when binding with the user_attr format. This update introduces a new `user_format` property in the LDAP configuration. This property accepts a Python format string, which defaults to the previous configuration but allows for custom user string formats.

config example:
```yaml
  ldap:
    dn: OU=BASE,DC=foo,DC=local
    group_attr: memberOf
    red_group: "CN=Some Security Group Name,OU=Security Groups,OU=BASE,DC=foo,DC=local"
    server: ldaps://dc-prod04.foo.local:636
    user_attr: userPrincipalName
    user_format: "{user}"
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Current testing is broken on Caldera(see #3013). But this is being used in production.
 
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
