### PR TITLE
fix: remove failing quality test for unsupported, obsolete Python version

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,8 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.8
-            toxenv: py38,style,coverage-ci
           - python-version: 3.9
             toxenv: py39,style,coverage-ci
           - python-version: 3.10.9


### PR DESCRIPTION
## Description

Python 3.8 is no longer supported. See:
https://endoflife.date/python
This change simply removes the failing quality test from the GitHub Action related to that version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by verifying that the old 3.8 quality test is no longer run in the automated pipeline.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
