### PR TITLE
Refactor Docker setup, follow best-practices in containerization and make caldera easier to deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,27 @@ tests/
 **/release.sh
 **/requirements-dev.txt
 **/tox.ini
+
+# Artifacts from previous use/compilation
+**/__pycache__/
+**/node_modules/
+**/plugins/magma/dist/
+
+# Artifacts from previous caldera use
+data/*_store
+data/abilities/*
+data/adversaries/*
+data/results/*
+data/payloads/*
+data/facts/*
+data/sources/*
+data/objectives/*
+data/backup/*
+data/planners/*
+!data/planners/aaa7c857-37a0-4c4a-85f7-4e9f7f30e31a.yml
+conf/local.yml
+conf/ssh_keys/*
+ftp_dir/*
+**/plugins/atomic/data/atomic-red-team
+**/plugins/emu/data/adversary-emulation-plans
+**/plugins/emu/payloads/*

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -32,16 +32,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
+      - name: Extract metadata (tags, labels) for Docker (slim variant)
+        id: meta-slim
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
+        flavor: |
+          latest=auto
+          prefix=slim-,onlatest=true
+          suffix=
+        
+      - name: Build and push Docker image (slim)
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-slim.outputs.tags }}
+          labels: ${{ steps.meta-slim.outputs.labels }}
+          build-args: |
+            VARIANT=slim
+      
+      - name: Extract metadata (tags, labels) for Docker (full variant)
+        id: meta-full
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image (full)
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta-full.outputs.tags }}
+          labels: ${{ steps.meta-full.outputs.labels }}
+          build-args: |
+            VARIANT=full

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,95 +1,91 @@
-FROM ubuntu:24.04
-SHELL ["/bin/bash", "-c"]
+# This file uses a staged build, using a different stage to build the UI (magma)
+# Build the UI
+FROM node:23 AS ui-build
 
+WORKDIR /usr/src/app
+
+ADD . .
+# Build VueJS front-end
+RUN (cd plugins/magma; npm install && npm run build)
+
+# This is the runtime stage
+# It containes all dependencies required by caldera
+FROM debian:bookworm-slim AS runtime
+
+# There are two variants - slim and full
+# The slim variant excludes some dependencies of *emu* and *atomic* that can be downloaded on-demand if needed
+# They are very large
+ARG VARIANT=full
+ENV VARIANT=${VARIANT}
+
+# Display an error if variant is set incorrectly, otherwise just print information regarding which variant is in use
+RUN if [ "$VARIANT" = "full" ]; then \
+        echo "Building \"full\" container suitable for offline use!"; \
+    elif [ "$VARIANT" = "slim" ]; then \
+        echo "Building slim container - some plugins (emu, atomic) may not be available without an internet connection!"; \
+    else \
+        echo "Invalid Docker build-arg for VARIANT! Please provide either \"full\" or \"slim\"."; \
+        exit 1; \
+fi
+
+WORKDIR /usr/src/app
+
+# Copy in source code and compiled UI
+# IMPORTANT NOTE: the .dockerignore file is very important in preventing weird issues.
+# Especially if caldera was ever compiled outside of Docker - we don't want those files to interfere with this build process,
+# which should be repeatable.
+ADD . .
+COPY --from=ui-build /usr/src/app/plugins/magma/dist /usr/src/app/plugins/magma/dist
+
+# From https://docs.docker.com/build/building/best-practices/
+# Install caldera dependencies
+RUN apt-get update && \
+apt-get --no-install-recommends -y install git curl unzip python3-dev python3-pip golang-go mingw-w64 zlib1g gcc && \
+rm -rf /var/lib/apt/lists/*
+
+# Fix line ending error that can be caused by cloning the project in a Windows environment
+RUN cd /usr/src/app/plugins/sandcat; tr -d '\15\32' < ./update-agents.sh > ./update-agents.sh
+
+# Set timezone (default to UTC)
 ARG TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
 
-WORKDIR /usr/src/app
-
-# Make sure user cloned caldera recursively before installing anything.
-ADD . .
-RUN if [ -z "$(ls plugins/stockpile)" ]; then echo "stockpile plugin not downloaded - please ensure you recursively cloned the caldera git repository and try again."; exit 1; fi
-
-RUN apt-get update && \
-    apt-get -y install python3 python3-pip python3-venv git curl golang-go
-
-
-#WIN_BUILD is used to enable windows build in sandcat plugin
-ARG WIN_BUILD=false
-RUN if [ "$WIN_BUILD" = "true" ] ; then apt-get -y install mingw-w64; fi
-
-# Set up python virtualenv
-ENV VIRTUAL_ENV=/opt/venv/caldera
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
 # Install pip requirements
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt 
 
-# Set up config file and disable atomic by default
-RUN python3 -c "import app; import app.utility.config_generator; app.utility.config_generator.ensure_local_config();"; \
-    sed -i '/\- atomic/d' conf/local.yml;
+# For offline atomic (disable it by default in slim image)
+# Disable atomic if this is not downloaded
+RUN if [ ! -d "/usr/src/app/plugins/atomic/data/atomic-red-team" ] && [ "$VARIANT" = "full" ]; then   \
+        git clone --depth 1 https://github.com/redcanaryco/atomic-red-team.git \
+            /usr/src/app/plugins/atomic/data/atomic-red-team;                  \
+    else \
+        sed -i '/\- atomic/d' conf/default.yml; \
+fi
 
-# Compile default sandcat agent binaries, which will download basic golang dependencies.
+# For offline emu
+# (Emu is disabled by default, no need to disable it if slim variant is being built)
+RUN if [ ! -d "/usr/src/app/plugins/emu/data/adversary-emulation-plans" ] && [ "$VARIANT" = "full" ]; then   \
+        git clone --depth 1 https://github.com/center-for-threat-informed-defense/adversary_emulation_library \
+            /usr/src/app/plugins/emu/data/adversary-emulation-plans;                  \
+fi
+
+# Download emu payloads
+# emu doesn't seem capable of running this itself - always download
+RUN cd /usr/src/app/plugins/emu; ./download_payloads.sh
+
+# The commands above (git clone) will generate *huge* .git folders - remove them
+RUN (find . -type d -name ".git") | xargs rm -rf
 
 # Install Go dependencies
-WORKDIR /usr/src/app/plugins/sandcat/gocat
-RUN go mod tidy && go mod download
+RUN cd /usr/src/app/plugins/sandcat/gocat; go mod tidy && go mod download
 
-WORKDIR /usr/src/app/plugins/sandcat
+# Update sandcat agents
+RUN cd /usr/src/app/plugins/sandcat; ./update-agents.sh
 
-# Fix line ending error that can be caused by cloning the project in a Windows environment
-RUN if [ "$WIN_BUILD" = "true" ] ; then cp ./update-agents.sh ./update-agents-copy.sh; fi
-RUN if [ "$WIN_BUILD" = "true" ] ; then tr -d '\15\32' < ./update-agents-copy.sh > ./update-agents.sh; fi
-RUN if [ "$WIN_BUILD" = "true" ] ; then rm ./update-agents-copy.sh; fi
-
-RUN ./update-agents.sh
-
-# Check if we can compile the sandcat extensions, which will download golang dependencies for agent extensions
-RUN mkdir /tmp/gocatextensionstest
-
-RUN cp -R ./gocat /tmp/gocatextensionstest/gocat
-RUN cp -R ./gocat-extensions/* /tmp/gocatextensionstest/gocat/
-
-RUN cp ./update-agents.sh /tmp/gocatextensionstest/update-agents.sh
-
-WORKDIR /tmp/gocatextensionstest
-
-RUN mkdir /tmp/gocatextensionstest/payloads
-
-RUN ./update-agents.sh
-
-# Clone atomic red team repo for the atomic plugin
-RUN if [ ! -d "/usr/src/app/plugins/atomic/data/atomic-red-team" ]; then   \
-    git clone --depth 1 https://github.com/redcanaryco/atomic-red-team.git \
-        /usr/src/app/plugins/atomic/data/atomic-red-team;                  \
-fi
-
-WORKDIR /usr/src/app/plugins/emu
-
-# If emu is enabled, complete necessary installation steps
-RUN if [ $(grep -c "\- emu" ../../conf/local.yml)  ]; then \
-    apt-get -y install zlib1g unzip;                \
-    pip3 install -r requirements.txt;               \
-    ./download_payloads.sh;                         \
-fi
-
-WORKDIR /usr/src/app
-
-# Install Node.js, npm, and other build VueJS front-end
-RUN apt-get update && \
-    apt-get install -y nodejs npm && \
-    # Directly use npm to install dependencies and build the application
-    (cd plugins/magma && npm install) && \
-    (cd plugins/magma && npm run build) && \
-    # Remove Node.js, npm, and other unnecessary packages
-    apt-get remove -y nodejs npm && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-WORKDIR /usr/src/app
+# Make sure emu can always be used in container (even if not enabled right now)
+RUN cd /usr/src/app/plugins/emu; \
+    pip3 install --break-system-packages -r requirements.txt
 
 STOPSIGNAL SIGINT
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Local build:
 git clone https://github.com/mitre/caldera.git --recursive
 cd caldera
 docker build --build-arg VARIANT=full -t caldera .
-docker run -p 8888:8888 caldera
+docker run -it -p 8888:8888 caldera
 ```
 
 Adjust the port forwarding (`-p`) and build args (`--build-arg`) as desired to make ports accessible or change the caldera variant.
@@ -98,7 +98,7 @@ The ports that you expose depend on which contacts you plan on using (see `Docke
 
 Pre-Built Image (from GitHub Container Registry):
 ```sh
-docker run -p 8888:8888 ghcr.io/mitre/caldera:latest
+docker run -it -p 8888:8888 ghcr.io/mitre/caldera:latest
 ```
 This container may be slightly outdated, we recommend building the container yourself.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,56 @@ These requirements are for the computer running the core framework:
 * Recommended: GoLang 1.17+ to dynamically compile GoLang-based agents.
 * NodeJS (v16+ recommended for v5 VueJS UI)
 
+## Docker Installation (Recommended)
+**Note 1: The image on DockerHub is outdated, please do not use it for the time being!**
+
+**Note 2: The builder plugin will not work within Docker**
+
+**Note 3: The caldera container will automatically generate keys/usernames/password on first start.**
+**If you wish to override the default configuration or avoid automatically generated keys/passwords, consider bind-mounting your own**
+**configuration file with the `-v <your_path>/conf.yml:/usr/src/app/conf/local.yml` flag**
+
+**Note 4: Data stored by caldera is ephermal by default.**
+**If you wish to make it persistent, use docker volumes and/or bind mounts (`-v <path_to_your_data_or_volume_name>:/usr/src/app/data/`).**
+**Ensure that the directory structure is the same as in the `data/` directory on GitHub, as caldera will refuse to create these sub-directories if they are missing.**
+**Lastly, make sure that the configuration file (Note #3) is also made persistent to prevent issues with encryption keys.**
+
+**Note 5: If you wish to modify data used by the `atomic` plugin, clone the `Atomic Red Team` repository outside the container, apply your modifications and bind-mount it (`-v`) to `/usr/src/app/plugins/atomic/data/atomic-red-team` within the container.**
+
+**Note 6: If you wish to modify data used by `emu`,**
+**clone the `adversary_emulation_library` repository locally and bind-mount it (`-v`) to**
+**`/usr/src/app/plugins/emu/data/adversary-emulation-plans`**
+
+Local build:
+```sh
+git clone https://github.com/mitre/caldera.git --recursive
+cd caldera
+docker build --build-arg VARIANT=full -t caldera .
+docker run -p 8888:8888 caldera
+```
+
+Adjust the port forwarding (`-p`) and build args (`--build-arg`) as desired to make ports accessible or change the caldera variant.
+The ports that you expose depend on which contacts you plan on using (see `Dockerfile` and `docker-compose.yml` for reference).
+
+Pre-Built Image (from GitHub Container Registry):
+```sh
+docker run -p 8888:8888 ghcr.io/mitre/caldera:latest
+```
+This container may be slightly outdated, we recommend building the container yourself.
+
+To gracefully terminate your docker container, do the following:
+```Bash
+# Find the container ID for your docker container running Caldera
+docker ps
+
+# Stop the container
+docker stop [container ID]
+```
+
+There are two variants available, *full* and *slim*.
+The *slim* variant doesn't include files necessary for the *emu* and *atomic* plugins, which will be downloaded on-demand if the plugins are ever enabled. The *full* variant is suitable for operation in environments without an internet connection. Slim images on GHCR are prefixed with "slim".
+
+
 ## Installation
 
 Concise installation steps:
@@ -111,31 +161,6 @@ If you'll be developing the UI, there are a few more additional installation ste
 1. Start the Caldera server with an additional flag: `python3 server.py --uidev localhost`
 
 Your Caldera server is available at http://localhost:8888 as usual, but there will now be a hot-reloading development server for the VueJS front-end available at http://localhost:3000. Both logs from the server and the front-end will display in the terminal you launched the server from.
-
-## Docker Deployment
-To build a Caldera docker image, ensure you have docker installed and perform the following actions:
-```Bash
-# Recursively clone the Caldera repository if you have not done so
-git clone https://github.com/mitre/caldera.git --recursive
-
-# Build the docker image. Change image tagging as desired.
-# WIN_BUILD is set to true to allow Caldera installation to compile windows-based agents.
-# Alternatively, you can use the docker compose YML file via "docker-compose build"
-cd caldera
-docker build . --build-arg WIN_BUILD=true -t caldera:latest
-
-# Run the image. Change port forwarding configuration as desired.
-docker run -p 8888:8888 caldera:latest
-```
-
-To gracefully terminate your docker container, do the following:
-```Bash
-# Find the container ID for your docker container running Caldera
-docker ps
-
-# Stop the container
-docker stop [container ID]
-```
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        TZ: "UTC" #TZ sets timezone for ubuntu setup
-        WIN_BUILD: "true" #WIN_BUILD is used to enable windows build in sandcat plugin
+        TZ: "UTC" # Timezone to use in container
+        VARIANT: "full"
     image: caldera:latest
     ports:
       - "8888:8888"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ asyncssh==2.14.1
 aioftp~=0.20.0
 packaging==23.2
 croniter~=3.0.3
+setuptools==75.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ description = run tests
 deps =
     -rrequirements.txt
     virtualenv!=20.0.22
-    setuptools==59.5.0
     pre-commit
     pytest
     pytest-aiohttp


### PR DESCRIPTION
## Description

This project is currently quite difficult to get working. This is one of (at least) three pull requests intended to make caldera simpler to deploy or get running locally. Docker is a great tool for this, and should be the easiest and quickest deployment option.

Unfortunately, the current Dockerfile doesn't even build (due to an outdated version of Ubuntu).
This PR:
- Updates the Dockerfile to use a staged build to compile the UI and copies it over to the final container. This avoids the dance of installing node and npm, building the UI, then removing node and npm.
- Ensures that previous builds of caldera do not pollute the build within the container. For example, if caldera was ever compiled outside of Docker (especially the UI), it will not be recompiled in the container. This can cause a large headache, for example when the Docker build does not re-build the UI when the VITE_BASE_URL was changed.
- Containers should contain all basic requirements for all of the functionality to work. For example - if a container is compiled without emu support and then published to DockerHub, a user will not be able to easily get all the dependencies into the container (without modifying the Dockerfile and building it themselves). This PR ensures this is the case.
- The emu and atomic plugins depend on large submodules to work, but are capable of fetching them when they are enabled. This PR introduces two flavours of images - *slim* and *full*. The *full* (default) flavor contains said submodules to allow the container to work in environments without an internet connection, while the *slim* flavour disables the plugins and only fetches the submodules when they are enabled.
- Modify the workflow to build and push both *slim* and *full* images to GHCR (tagged appropriately).
- Adds a dependency on `setuptools` to work with recent versions of Python3
- Makes Docker the recommended deployment option in the README
- **Every deployment of caldera using any of the currently provided Docker containers has the same password as it is generated during build-time.**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Repeated build tests of both flavors of caldera (full + slim). The resulting containers appear to work when interacted with.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [NOT RELEVANT] I have added tests that prove my fix is effective or that my feature works 
