### PR TITLE
Remove references to VITE_CALDERA_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,8 @@ Finally, start the server.
 ```Bash
 python3 server.py --insecure --build
 ```
-The --build flag automatically installs any VueJS UI dependencies, bundles the UI into a dist directory, writes the Magma plugin's `.env` file, and is served by the Caldera server. You will only have to use the --build flag again if you add any plugins or make any changes to the UI.
+The --build flag automatically installs any VueJS UI dependencies, bundles the UI into a dist directory and is served by the Caldera server. You will only have to use the --build flag again if you add any plugins or make any changes to the UI.
 Once started, log into http://localhost:8888 using the default credentials red/admin. Then go into Plugins -> Training and complete the capture-the-flag style training course to learn how to use Caldera.
-
-In some situations the default configuration values can cause the UI to appear unresponsive due to misrouted requests. Modify the `app.frontend.api_base_url` config value and start the server using the --build flag to update the UI's request URL environment variable.
 
 If you prefer to not use the new VueJS UI, revert to Caldera v4.2.0. Correspondingly, do not use the `--build` flag for earlier versions as not required.
 

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -22,7 +22,6 @@ app.contact.ftp.user: caldera_user
 app.contact.tcp: 0.0.0.0:7010
 app.contact.udp: 0.0.0.0:7011
 app.contact.websocket: 0.0.0.0:7012
-app.frontend.api_base_url: http://localhost:8888
 objects.planners.default: atomic
 crypt_salt: REPLACE_WITH_RANDOM_VALUE
 encryption_key: ADMIN123

--- a/server.py
+++ b/server.py
@@ -147,13 +147,6 @@ async def start_vue_dev_server():
     logging.info("VueJS development server is live.")
 
 
-def configure_magma_env_file():
-    logging.info("Setting VueJS environment file.")
-    url = BaseWorld.get_config("app.frontend.api_base_url")
-    with open(f"{MAGMA_PATH}/.env", "w") as fp:
-        fp.write(f"VITE_CALDERA_URL={url}")
-
-
 def _get_parser():
 
     def list_str(values):
@@ -269,7 +262,6 @@ if __name__ == "__main__":
 
     if args.build:
         if len(os.listdir(MAGMA_PATH)) > 0:
-            configure_magma_env_file()
             logging.info("Building VueJS front-end.")
             subprocess.run(["npm", "install"], cwd=MAGMA_PATH, check=True)
             subprocess.run(["npm", "run", "build"], cwd=MAGMA_PATH, check=True)


### PR DESCRIPTION
Related to the removal for VITE_CALDRA_URL in the magma repository in favor of using window.location.origin. Depends on https://github.com/mitre/magma/pull/67. magma must be re-pinned.

## Description

See the PR in the magma repository.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

System testing on a local instance (browsing and interacting with the UI).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [DOES NOT APPLY] I have added tests that prove my fix is effective or that my feature works
