### PR TITLE
Change Docker image to 24.04 since 23.04 is out of support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 SHELL ["/bin/bash", "-c"]
 
 ARG TZ="UTC"


### PR DESCRIPTION
## Description

When building using Docker an error is raised when installing Python dependencies:

```
1.041 Reading package lists...
1.054 E: The repository 'http://security.ubuntu.com/ubuntu lunar-security Release' does not have a Release file.
1.054 E: The repository 'http://archive.ubuntu.com/ubuntu lunar Release' does not have a Release file.
1.054 E: The repository 'http://archive.ubuntu.com/ubuntu lunar-updates Release' does not have a Release file.
1.054 E: The repository 'http://archive.ubuntu.com/ubuntu lunar-backports Release' does not have a Release file.
------
Dockerfile:14
--------------------
  13 |     
  14 | >>> RUN apt-get update && \
  15 | >>>     apt-get -y install python3 python3-pip python3-venv git curl golang-go
  16 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c apt-get update &&     apt-get -y install python3 python3-pip python3-venv git curl golang-go" did not complete successfully: exit code: 100
****
```

This happens because 23.04 is no longer a stable version. 

## Type of change

Simple change in the Ubuntu version for the base Docker image:

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Rebuilding and deploying Caldera using Docker with 24.04.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
