### PR TITLE
sanitize user-provided LDFLAG parameters

### DIFF
--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -23,6 +23,7 @@ FILE_ENCRYPTION_FLAG = '%encrypted%'
 ALLOWED_SERVER_LDFLAG_REGEX = re.compile(r'^[\w\-\.:%+/]+$')
 ALLOWED_DEFAULT_LDFLAG_REGEX = re.compile(r'^[\w\-\.]+$')
 
+
 class FileSvc(FileServiceInterface, BaseService):
 
     def __init__(self):

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -20,8 +20,13 @@ from app.utility.base_service import BaseService
 from app.utility.payload_encoder import xor_file, xor_bytes
 
 FILE_ENCRYPTION_FLAG = '%encrypted%'
-ALLOWED_SERVER_LDFLAG_REGEX = re.compile(r'^[\w\-\.:%+/]+$')
+URL_SANITIZATION_REGEX = re.compile(r'^[\w\-\.:%+/]+$')
 ALLOWED_DEFAULT_LDFLAG_REGEX = re.compile(r'^[\w\-\.]+$')
+ALLOWED_LDFLAG_REGEXES = {
+    'server': URL_SANITIZATION_REGEX,
+    'http': URL_SANITIZATION_REGEX,
+    'socket': re.compile(r'^[\w\-\.:]+$')
+}
 
 
 class FileSvc(FileServiceInterface, BaseService):
@@ -176,23 +181,14 @@ class FileSvc(FileServiceInterface, BaseService):
             self.log.warning('Problem building golang executable {}: {} '.format(src_fle, e))
 
     @staticmethod
-    def sanitize_ldflag_value(value):
+    def sanitize_ldflag_value(param, value):
         """
-        Validate that the specified LDFLAG value only contains safe characters.
+        Validate that the specified LDFLAG value for the given parameter
+        only contains safe characters.
         Raises a ValueError if disallowed characters are found.
         """
-        if not ALLOWED_DEFAULT_LDFLAG_REGEX.fullmatch(value):
-            raise ValueError('Invalid characters in LDFLAG value: %s' % value)
-        return value
-
-    @staticmethod
-    def sanitize_server_ldflag_value(value):
-        """
-        Validate that the specified server LDFLAG value only contains safe characters.
-        Raises a ValueError if disallowed characters are found.
-        """
-        if not ALLOWED_SERVER_LDFLAG_REGEX.fullmatch(value):
-            raise ValueError('Invalid characters in server LDFLAG value: %s' % value)
+        if not ALLOWED_LDFLAG_REGEXES.get(param, ALLOWED_DEFAULT_LDFLAG_REGEX).fullmatch(value):
+            raise ValueError('Invalid characters in %s LDFLAG value: %s' % (param, value))
         return value
 
     def get_payload_name_from_uuid(self, payload):

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -181,7 +181,7 @@ class FileSvc(FileServiceInterface, BaseService):
         Raises a ValueError if disallowed characters are found.
         """
         if not ALLOWED_DEFAULT_LDFLAG_REGEX.fullmatch(value):
-            ValueError('Invalid characters in LDFLAG value: %s' % value)
+            raise ValueError('Invalid characters in LDFLAG value: %s' % value)
         return value
 
     @staticmethod
@@ -191,7 +191,7 @@ class FileSvc(FileServiceInterface, BaseService):
         Raises a ValueError if disallowed characters are found.
         """
         if not ALLOWED_SERVER_LDFLAG_REGEX.fullmatch(value):
-            ValueError('Invalid characters in server LDFLAG value: %s' % value)
+            raise ValueError('Invalid characters in server LDFLAG value: %s' % value)
         return value
 
     def get_payload_name_from_uuid(self, payload):

--- a/app/service/file_svc.py
+++ b/app/service/file_svc.py
@@ -20,7 +20,7 @@ from app.utility.base_service import BaseService
 from app.utility.payload_encoder import xor_file, xor_bytes
 
 FILE_ENCRYPTION_FLAG = '%encrypted%'
-ALLOWED_SERVER_LDFLAG_REGEX = re.compile(r'^[\w\-\.:%+]+$')
+ALLOWED_SERVER_LDFLAG_REGEX = re.compile(r'^[\w\-\.:%+/]+$')
 ALLOWED_DEFAULT_LDFLAG_REGEX = re.compile(r'^[\w\-\.]+$')
 
 class FileSvc(FileServiceInterface, BaseService):

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -322,14 +322,10 @@ class TestFileService:
             'some.domain.net:8443 && test',
             'domain-with-dash.net:8443; test',
         ]
-        for value in unsafe_server_values:
+        for value in unsafe_socket_values:
             with pytest.raises(Exception) as e_info:
-                file_svc.sanitize_ldflag_value('server', value)
-            assert str(e_info.value) == 'Invalid characters in server LDFLAG value: {}'.format(value)
-
-            with pytest.raises(Exception) as e_info:
-                file_svc.sanitize_ldflag_value('http', value)
-            assert str(e_info.value) == 'Invalid characters in http LDFLAG value: {}'.format(value)
+                file_svc.sanitize_ldflag_value('socket', value)
+            assert str(e_info.value) == 'Invalid characters in socket LDFLAG value: {}'.format(value)
 
     @staticmethod
     def _test_download_file_with_encoding(event_loop, file_svc, data_svc, encoding, original_content, encoded_content):

--- a/tests/services/test_file_svc.py
+++ b/tests/services/test_file_svc.py
@@ -251,7 +251,9 @@ class TestFileService:
             '1234567890'
         ]
         for value in safe_values:
-            assert value == file_svc.sanitize_ldflag_value(value)
+            assert value == file_svc.sanitize_ldflag_value('contact', value)
+            assert value == file_svc.sanitize_ldflag_value('group', value)
+            assert value == file_svc.sanitize_ldflag_value('genericparam', value)
 
         safe_server_values = [
             'http://localhost',
@@ -261,7 +263,17 @@ class TestFileService:
             'https://_underscore.domain-with-dash.net:8443/home+test.html',
         ]
         for value in safe_server_values:
-            assert value == file_svc.sanitize_server_ldflag_value(value)
+            assert value == file_svc.sanitize_ldflag_value('server', value)
+            assert value == file_svc.sanitize_ldflag_value('http', value)
+
+        safe_socket_values = [
+            'localhost:1234',
+            '10.10.10.10.:8888',
+            'f.q.d.n:443',
+            'domain-with-dash.net:443',
+        ]
+        for value in safe_socket_values:
+            assert value == file_svc.sanitize_ldflag_value('socket', value)
 
         unsafe_values = [
             'unsafe with spaces',
@@ -278,8 +290,8 @@ class TestFileService:
         ]
         for value in unsafe_values:
             with pytest.raises(Exception) as e_info:
-                file_svc.sanitize_ldflag_value(value)
-            assert str(e_info.value) == 'Invalid characters in LDFLAG value: {}'.format(value)
+                file_svc.sanitize_ldflag_value('group', value)
+            assert str(e_info.value) == 'Invalid characters in group LDFLAG value: {}'.format(value)
 
         unsafe_server_values = [
             'http://localhost||test',
@@ -293,8 +305,31 @@ class TestFileService:
         ]
         for value in unsafe_server_values:
             with pytest.raises(Exception) as e_info:
-                file_svc.sanitize_server_ldflag_value(value)
+                file_svc.sanitize_ldflag_value('server', value)
             assert str(e_info.value) == 'Invalid characters in server LDFLAG value: {}'.format(value)
+
+            with pytest.raises(Exception) as e_info:
+                file_svc.sanitize_ldflag_value('http', value)
+            assert str(e_info.value) == 'Invalid characters in http LDFLAG value: {}'.format(value)
+
+        unsafe_socket_values = [
+            'localhost:8888||test',
+            '127.0.0.1:8443 space',
+            'domain.com:8443@',
+            'localhost:8443"test',
+            'localhost:8443\'test',
+            '127.0.0.1:8443$(test)',
+            'some.domain.net:8443 && test',
+            'domain-with-dash.net:8443; test',
+        ]
+        for value in unsafe_server_values:
+            with pytest.raises(Exception) as e_info:
+                file_svc.sanitize_ldflag_value('server', value)
+            assert str(e_info.value) == 'Invalid characters in server LDFLAG value: {}'.format(value)
+
+            with pytest.raises(Exception) as e_info:
+                file_svc.sanitize_ldflag_value('http', value)
+            assert str(e_info.value) == 'Invalid characters in http LDFLAG value: {}'.format(value)
 
     @staticmethod
     def _test_download_file_with_encoding(event_loop, file_svc, data_svc, encoding, original_content, encoded_content):


### PR DESCRIPTION
## Description
Sanitize user-provided LDFLAG values for custom golang compilation to avoid RCE.

Creates new static methods that can be used by plugins such as sandcat and manx

Sandcat PR: https://github.com/mitre/sandcat/pull/443
Manx PR: https://github.com/mitre/manx/pull/45

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Unit tests
Tested with sandcat and manx plugins 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
