### PR TITLE
fix handler signature to address websocket errors

### DIFF
--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -38,6 +38,6 @@ class Handler:
         try:
             path = connection.request.path
             for handle in [h for h in self.handles if path.split('/', 1)[1].startswith(h.tag)]:
-                await handle.run(socket, path, self.services)
+                await handle.run(connection, path, self.services)
         except Exception as e:
             self.log.debug(e)

--- a/app/contacts/contact_websocket.py
+++ b/app/contacts/contact_websocket.py
@@ -34,8 +34,9 @@ class Handler:
         self.handles = []
         self.log = BaseWorld.create_logger('websocket_handler')
 
-    async def handle(self, socket, path):
+    async def handle(self, connection):
         try:
+            path = connection.request.path
             for handle in [h for h in self.handles if path.split('/', 1)[1].startswith(h.tag)]:
                 await handle.run(socket, path, self.services)
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ aiohttp-apispec==3.0.0b2
 jinja2==3.1.3
 pyyaml==6.0.1
 cryptography==42.0.2
-websockets==11.0.3
+websockets==15.0
 Sphinx==7.1.2
 sphinx_rtd_theme==1.3.0
 myst-parser==2.0.0


### PR DESCRIPTION
## Description
Address websocket errors in https://github.com/mitre/caldera/issues/3121 caused by incorrect handler function signatures.

Update required websockets version to 15.0

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran with response plugin to verify at least one websocket handler was triggered. Also confirmed error message stopped appearing on server startup.

Tested with Python 3.12.3 and websockets v15 


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
