### PR TITLE
Remove/Change Python 3.8 References

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.8
-            toxenv: safety
           - python-version: 3.9
             toxenv: safety
           - python-version: 3.10.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
         - id: bandit
           entry: bandit -ll --exclude=tests/ --skip=B303
           additional_dependencies:
-            - importlib-metadata<5; python_version < '3.8'
+            - importlib-metadata<5; python_version < '3.9'

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -53,7 +53,7 @@ requirements:
     attr: version
     module: sys
     type: python_module
-    version: 3.8.0
+    version: 3.9.0
 users:
   blue:
     blue: admin

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.sources=./app
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.python.version=3.8,3.9,3.10,3.11
+sonar.python.version=3.9,3.10,3.11
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Make an exception to Link's constructor, since it requires a refactor to pass

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 skipsdist = True
 envlist =
-    py{38,39,310,311,312}
+    py{39,310,311,312}
     style
     coverage
     safety


### PR DESCRIPTION
Bumped up requirements to python 3.9 and removed test and build references for python 3.8.

## Description

Python 3.9 is now the minimum version of python required. Bumped up requirement versions and removed tests that still had 3.8. Documentation already reflects the minimum required version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Pulled PR repo and built caldera with python 3.10, no issues. I can't test github\sonar tests.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
