### PR TITLE
Replace deprecated logging function

### DIFF
--- a/app/utility/base_world.py
+++ b/app/utility/base_world.py
@@ -60,7 +60,7 @@ class BaseWorld:
         i = fraction.split('/')
         min, max = int(i[0]), int(i[1])
         if min > max:
-            logging.warn(f'Jitter range max value (max={max}) less than min value (min={min}). Using min={max} and max={min}.')
+            logging.warning(f'Jitter range max value (max={max}) less than min value (min={min}). Using min={max} and max={min}.')
             min, max = max, min
         return randint(min, max)
 


### PR DESCRIPTION
## Description

Python's `logging.warn` is deprecated and should be replaced by the functionally equivalent `logging.warning`. As mentioned in [the documentation of the logging module](https://docs.python.org/3/library/logging.html#logging.Logger.warning)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Functionally equivalent.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works