### PR TITLE
filter 0-score facts from operation source

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -191,6 +191,7 @@ class Operation(FirstClassObjectInterface, BaseObject):
         seeded_facts = []
         if self.source:
             seeded_facts = await data_svc_handle.get_facts_from_source(self.source.id)
+            seeded_facts = [f for f in seeded_facts if f.score > 0]
         learned_facts = await knowledge_svc_handle.get_facts(criteria=dict(source=self.id))
         learned_facts = [f for f in learned_facts if f.score > 0]
         return seeded_facts + learned_facts

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -190,7 +190,7 @@ def custom_agent(test_agent, test_executor):
 
 @pytest.fixture
 def op_with_learning_and_seeded(ability, adversary, operation_agent, parse_datestring):
-    sc = Source(id='3124', name='test', facts=[Fact(trait='domain.user.name', value='bob')])
+    sc = Source(id='3124', name='test', facts=[Fact(trait='domain.user.name', value='bob'), Fact(trait='domain.user.name', value='jane', score=0)])
     op = Operation(id='6789', name='testC', agents=[], adversary=adversary, source=sc, use_learning_parsers=True)
     # patch operation to make it 'realistic'
     op.start = parse_datestring(OP_START_TIME)


### PR DESCRIPTION
## Description
Fix bug from https://github.com/mitre/caldera/issues/3132 where 0-score facts were included in operations.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added 0-score fact to unit test
- verified with custom operation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
