### PR TITLE
fix(docker): add working docker-compose with data volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
-version: '3'
+version: "3.9"
 
 services:
   caldera:
     build:
       context: .
-      dockerfile: Dockerfile
       args:
         TZ: "UTC" # Timezone to use in container
-        VARIANT: "full"
+        VARIANT: "full"        # full install: plugins, agents, docs, etc.
     image: caldera:latest
+    command: --log DEBUG
     ports:
       - "8888:8888"
       - "8443:8443"
@@ -19,5 +19,8 @@ services:
       - "8022:8022"
       - "2222:2222"
     volumes:
-      - ./:/usr/src/app
-    command: --log DEBUG
+      # keeps operation data & uploaded files between runs
+      - caldera-data:/usr/src/app/data
+
+volumes:
+  caldera-data:


### PR DESCRIPTION
## Description

Add working docker-compose with data volume

Replace the full source bind-mount (which hid Magma UI assets and caused 'plugins/magma/dist/assets/' startup error) with a named volume mounted to /usr/src/app/data. 

CALDERA now starts cleanly via 'docker compose up' and preserves operation data between runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. `docker compose up --build`  

```
user@debian:~$ uname -a
Linux debian 6.1.0-37-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.140-1 (2025-05-22) x86_64 GNU/Linux
user@debian:~$ docker -v
Docker version 28.2.2, build e6534b4
user@debian:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 12 (bookworm)
Release:	12
Codename:	bookworm
```

   ✅ CALDERA starts, UI accessible at [http://localhost:8888](http://localhost:8888).

2. Verified an operation run; data survives `docker compose down/up`.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No changes needed to the documentation
- [x] No further testing needed as this is a bug fix
