### PR TITLE
[Plugin] Add mmc_clsid_uac_bypass/data/adversaries/clsid_escalation_chain.yml

### DIFF
--- a/plugins/abilities/windows/privilege-escalation/uac_bypass_mmc_clsid.yml/data/adversaries/clsid_escalation_chain.yml
+++ b/plugins/abilities/windows/privilege-escalation/uac_bypass_mmc_clsid.yml/data/adversaries/clsid_escalation_chain.yml
@@ -1,0 +1,12 @@
+id: 204820f1-d333-4f08-bc09-078bf16dbdca
+name: CLSID Escalation & Recon Chain
+description: Emulates a threat actor who leverages a UAC bypass via CLSID hijack,
+  followed by host and domain reconnaissance, user privilege escalation, and lateral
+  movement using built-in Windows utilities.
+atomic_ordering:
+- a3f94b9c-1cc2-4a64-9092-7c0e3ae2f99a
+- 75869467-7c9c-4432-9a19-029082cd4176
+- 6295e328-ebd8-470a-b7c6-59e5ec02adb1
+- 0aed311e-630f-4a6b-8811-f8ff10436e4d
+- c54da140-7f1c-406d-bb6a-20e4c4839db9
+- f497196e-ad8c-459e-95ea-12f51ee35f05


### PR DESCRIPTION
## Description
Adds a new adversary profile (`clsid_escalation_chain.yml`) under the plugin `mmc_clsid_uac_bypass`. This profile chains multiple real-world TTPs, beginning with the MMC CLSID UAC bypass contributed earlier, followed by host reconnaissance and simulated lateral movement actions. It is designed to support purple team exercises and adversary emulation using only built-in Windows binaries.

This profile is especially useful for defenders and red teams aiming to test detection logic for:
- UAC bypass via registry hijack
- Discovery actions without external tools
- Lateral movement attempts via standard OS capabilities
## Summary

This update adds an adversary chain that combines a custom CLSID UAC bypass with standard system discovery and lateral movement techniques.

The chain emulates a stealthy post-exploitation scenario where a local user:
1. Escalates privileges using a COM hijack on MMC auto-elevated CLSID
2. Performs host-based discovery
3. Attempts lateral movement via SMB share access

## Reference Techniques

- `T1548.002` – Bypass User Access Control (via CLSID hijack)
- `T1082` – System Information Discovery
- `T1077` – Lateral Movement via SMB/Net Use

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Confirmed adversary profile appears in the Caldera UI
- Executed full chain using a deployed Sandcat agent on a Windows VM
- Verified successful payload execution, discovery commands, and simulated lateral movement
- Ensured cleanup logic from abilities executes as expected
- Used only native Windows commands (no external payload dependencies)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
