### PR TITLE
Fix CWE 22 in Payload API

### DIFF
--- a/app/api/v2/handlers/payload_api.py
+++ b/app/api/v2/handlers/payload_api.py
@@ -154,16 +154,13 @@ class PayloadApi(BaseApi):
         :return: The canonicalized absolute path if valid.
         :raises ValueError: If the path resolves outside the base directory.
         """
-        # Resolve the base directory to an absolute path
         base_dir = pathlib.Path(base_directory).resolve()
 
-        # Sanitize and resolve the input path to prevent traversal
         try:
             resolved_path = (base_dir / pathlib.Path(input_path).name).resolve()
         except Exception as e:
             raise ValueError(f"Invalid path: {input_path}. Error: {e}")
 
-        # Ensure the resolved path is within the base directory
         if not str(resolved_path).startswith(str(base_dir)):
             raise ValueError(f"Invalid path: {input_path} resolves outside the designated directory {base_directory}")
 


### PR DESCRIPTION
## Description

User found CWE-22 which is a File Update/Delete Path Traversal within the payload_api.py.  I confirmed this CWE did exist and added a function in `payload_api.py` to canonicalize paths within the `data/payloads` directory and reject paths outside the designated directory. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Used Burpsuite to Replicate PoC sent to MITRE team. Fixed the directory traversal issue and then retested with Burpsuite to ensure the fix is effective. Included a screenshot of the Burp successful test. 


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

Bug
<img width="528" alt="image" src="https://github.com/user-attachments/assets/83716fa1-8194-4258-8526-f4307d4276ee" />
Fix
![Screenshot 2025-06-24 at 10 51 19 AM](https://github.com/user-attachments/assets/4a6ab7ba-d82f-4bec-9803-f3d41825c12c)

