### PR TITLE
fix: Docker Workflow indentation

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -37,10 +37,10 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        flavor: |
-          latest=auto
-          prefix=slim-,onlatest=true
-          suffix=
+          flavor: |
+            latest=auto
+            prefix=slim-,onlatest=true
+            suffix=
         
       - name: Build and push Docker image (slim)
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825


### PR DESCRIPTION
## Description

Caldera Docker Workflow broken after release of v5.3.0 due to "Unexpected Value Flavor" which was caused by improper indentation. According to [docker meta-action docs](https://github.com/docker/metadata-action/blob/v4.0.0/README.md#tags-input), Flavor falls under "with".

<img width="1674" height="549" alt="image" src="https://github.com/user-attachments/assets/03de0c34-5ba4-4818-b32d-3a90deaa220f" />

Error:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/31ada737-1c7e-4c22-898e-0bc094450d5c" />

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Successfully ran a self-hosted workflow in a private repository using CALDERA Docker Workflow configurations, with modified indentation.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/4b5ccc83-22e4-459d-b5f0-2921a1ee8767" />

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code