### PR TITLE
Update app_svc.py

### DIFF
--- a/app/service/app_svc.py
+++ b/app/service/app_svc.py
@@ -207,6 +207,9 @@ class AppService(AppServiceInterface, BaseService):
                 files = (os.path.join(rt, fle) for rt, _, f in os.walk(p.data_dir+'/abilities') for fle in f if
                          time.time() - os.stat(os.path.join(rt, fle)).st_mtime < int(self.get_config('ability_refresh')))
                 for f in files:
+                    if f.endswith('.swp'):
+                        self.log.debug('[%s] Skipping swap file %s' % (p.name, f))
+                        continue
                     self.log.debug('[%s] Reloading %s' % (p.name, f))
                     await self.get_service('data_svc').load_ability_file(filename=f, access=p.access)
             await asyncio.sleep(int(self.get_config('ability_refresh')))


### PR DESCRIPTION
Skip swap files created by nano while developing rules. 

## Description

Small fix for app_svc to avoid errors from swp files while locally editing with nano while caldera is running.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally, after making the change nano editing no longer throws errors (like the following)

```
                    ERROR    Task exception was never retrieved                                                                                                                                                           base_events.py:1821
                             future: <Task finished name='Task-1981' coro=<AppService.watch_ability_files() done, defined at /usr/local/caldera/app/service/app_svc.py:201> exception=UnicodeDecodeError('utf-8',
                             b'b0nano
                             7.2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xed\xd0\n\x00root\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
                             0\x00\x00\x00\x00\x00\x00\x00\x00.....00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00data/abilities/execution/999a9999-
                             e761-4c16-891a-3dc4eff02e74.yml\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
```


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
(none needed)
- [X] I have added tests that prove my fix is effective or that my feature works
