### PR TITLE
Use updated golang version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ ENV PATH="$PATH:/usr/local/go/bin"
 RUN go version
 
 # Fix line ending error that can be caused by cloning the project in a Windows environment
-RUN cd /usr/src/app/plugins/sandcat; tr -d '\15\32' < ./update-agents.sh > ./update-agents.sh
+# RUN cd /usr/src/app/plugins/sandcat && \
+cp ./update-agents.sh ./update-agents_orig.sh && \
+tr -d '\15\32' < ./update-agents_orig.sh > ./update-agents.sh
 
 # Set timezone (default to UTC)
 ARG TZ="UTC"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ rm -rf /var/lib/apt/lists/*
 
 # Install Golang from source (apt version is too out-of-date)
 RUN curl -k -L https://go.dev/dl/go1.25.0.linux-amd64.tar.gz -o go1.25.0.linux-amd64.tar.gz && \
-tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz && rm go1.25.0.linux-amd64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 RUN go version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV PATH="$PATH:/usr/local/go/bin"
 RUN go version
 
 # Fix line ending error that can be caused by cloning the project in a Windows environment
-# RUN cd /usr/src/app/plugins/sandcat && \
+RUN cd /usr/src/app/plugins/sandcat && \
 cp ./update-agents.sh ./update-agents_orig.sh && \
 tr -d '\15\32' < ./update-agents_orig.sh > ./update-agents.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,14 @@ COPY --from=ui-build /usr/src/app/plugins/magma/dist /usr/src/app/plugins/magma/
 # From https://docs.docker.com/build/building/best-practices/
 # Install caldera dependencies
 RUN apt-get update && \
-apt-get --no-install-recommends -y install git curl unzip python3-dev python3-pip golang-go mingw-w64 zlib1g gcc && \
+apt-get --no-install-recommends -y install git curl unzip python3-dev python3-pip mingw-w64 zlib1g gcc && \
 rm -rf /var/lib/apt/lists/*
+
+# Install Golang from source (apt version is too out-of-date)
+RUN curl -k -L https://go.dev/dl/go1.25.0.linux-amd64.tar.gz -o go1.25.0.linux-amd64.tar.gz && \
+tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+ENV PATH="$PATH:/usr/local/go/bin"
+RUN go version
 
 # Fix line ending error that can be caused by cloning the project in a Windows environment
 RUN cd /usr/src/app/plugins/sandcat; tr -d '\15\32' < ./update-agents.sh > ./update-agents.sh
@@ -52,7 +58,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
 
 # Install pip requirements
-RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt 
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
 
 # For offline atomic (disable it by default in slim image)
 # Disable atomic if this is not downloaded


### PR DESCRIPTION
## Description
Dockerfile currently installs golang using apt, which only provides golang v1.19. To meet sandcat's minimum version of v1.24, the new Dockerfile will download and install golang v1.25 directly from the Go website.

Also fixes a bug where update-agents.sh contents are wiped during docker build.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Built docker locally and compiled agents using the update-agents.sh script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
