### PR TITLE
ignore fact creation timestamp comparison in scheduling unit test

### DIFF
--- a/tests/api/v2/handlers/test_schedules_api.py
+++ b/tests/api/v2/handlers/test_schedules_api.py
@@ -75,7 +75,7 @@ def expected_new_schedule_dump(new_schedule_payload):
     dump['task']['id'] = mock.ANY
     if 'facts' in dump['task']['source']:
         for f in dump['task']['source']['facts']:
-            dump['task']['source']['facts']['created'] = mock.ANY
+            f['created'] = mock.ANY
     return dump
 
 


### PR DESCRIPTION
## Description
`tests/api/v2/handlers/test_schedules_api.py:183` would often fail due to a [race condition](https://github.com/mitre/caldera/actions/runs/18480294799/job/52653557362#step:6:555) where a fact creation date would be off by 1 second from the expected value. This fix replaces the expected creation date with a mock placeholder catch-all to avoid this issue, since the fact creation date is not part of the unit test criteria. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran test via workflow


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
