### PR TITLE
Eliminate Caldera Core Dependencies on Plugins: magma

### DIFF
--- a/app/api/rest_api.py
+++ b/app/api/rest_api.py
@@ -29,7 +29,9 @@ class RestApi(BaseWorld):
         asyncio.get_event_loop().create_task(AdvancedPack(services).enable())
 
     async def enable(self):
-        self.app_svc.application.router.add_static('/assets', 'plugins/magma/dist/assets/', append_version=True)
+        # check if plugin path is present
+        if os.path.exists("plugins/magma/dist/assets") and (len(os.listdir("plugins/magma/dist/assets")) > 0):
+            self.app_svc.application.router.add_static('/assets', 'plugins/magma/dist/assets/', append_version=True)
         # TODO: only serve static files in legacy plugin mode
         self.app_svc.application.router.add_static('/gui', 'static/', append_version=True)
         # unauthorized GUI endpoints

--- a/tests/web_server/test_core_endpoints.py
+++ b/tests/web_server/test_core_endpoints.py
@@ -63,6 +63,8 @@ async def sample_agent(aiohttp_client):
 
 
 async def test_home(aiohttp_client):
+    if not (len(os.listdir("plugins/magma/dist/assets")) > 0):
+        pytest.xfail("Magma plugin not present, expecting failure")
     resp = await aiohttp_client.get('/')
     assert resp.status == HTTPStatus.OK
     assert resp.content_type == 'text/html'


### PR DESCRIPTION
## Description

#3227 
Removed magma plugin dependencies from caldera core

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- unit tests run, test_core_endpoints.py::test_home edited to have expected failure when magma plugin is not present
- launched Caldera web server, interacted with it via API
- fully removed magma plugin from working dir for tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
