### PR TITLE
feat: add API key rotation endpoint to auth service

### DIFF
--- a/app/service/auth_svc.py
+++ b/app/service/auth_svc.py
@@ -1,4 +1,5 @@
 import base64
+import secrets
 from collections import namedtuple
 from hmac import compare_digest
 from importlib import import_module
@@ -208,6 +209,21 @@ class AuthService(AuthServiceInterface, BaseService):
         else:
             self.log.debug('Using default login handler.')
             self._login_handler = self._default_login_handler
+
+    def rotate_api_key(self, group):
+        """Generate a new API key for the given group and update config.
+
+        :param group: 'red' or 'blue'
+        :returns: the new API key
+        :raises ValueError: if group is not 'red' or 'blue'
+        """
+        key_config_map = {'red': CONFIG_API_KEY_RED, 'blue': CONFIG_API_KEY_BLUE}
+        if group not in key_config_map:
+            raise ValueError(f'Invalid group: {group}. Must be "red" or "blue".')
+        new_key = secrets.token_hex(32)
+        self.set_config('main', key_config_map[group], new_key)
+        self.log.info('API key rotated for group: %s', group)
+        return new_key
 
     def _get_login_handler_from_config(self, services):
         login_handler_module_path = self.get_config(CONFIG_AUTH_LOGIN_HANDLER)

--- a/tests/security/test_api_key_rotation.py
+++ b/tests/security/test_api_key_rotation.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+
+class TestApiKeyRotation(unittest.TestCase):
+    def _make_auth_svc(self):
+        from app.service.auth_svc import AuthService
+        svc = AuthService.__new__(AuthService)
+        svc.log = MagicMock()
+        svc.user_map = {}
+        svc._login_handler = None
+        svc._default_login_handler = None
+        return svc
+
+    def test_rotate_generates_new_key(self):
+        svc = self._make_auth_svc()
+        with patch.object(type(svc), 'set_config') as mock_set:
+            new_key = svc.rotate_api_key('red')
+        self.assertEqual(len(new_key), 64)  # hex(32 bytes) = 64 chars
+        mock_set.assert_called_once()
+
+    def test_rotate_invalid_group(self):
+        svc = self._make_auth_svc()
+        with self.assertRaises(ValueError):
+            svc.rotate_api_key('invalid')
+
+    def test_rotate_blue_key(self):
+        svc = self._make_auth_svc()
+        with patch.object(type(svc), 'set_config') as mock_set:
+            new_key = svc.rotate_api_key('blue')
+        self.assertEqual(len(new_key), 64)
+        mock_set.assert_called_once_with('main', 'api_key_blue', new_key)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds rotate_api_key() to auth_svc.py with tests. Allows operators to rotate red/blue API keys without server restart.