### PR TITLE
fix: refresh stale agents in running operations

### DIFF
--- a/app/api/v2/managers/operation_api_manager.py
+++ b/app/api/v2/managers/operation_api_manager.py
@@ -134,6 +134,7 @@ class OperationApiManager(BaseApiManager):
         except IndexError:
             raise JsonHttpNotFound(f'Operation not found: {operation_id}')
         if operation.match(access):
+            await operation.refresh_agents(self._data_svc)
             return operation
         raise JsonHttpForbidden(f'Cannot view operation due to insufficient permissions: {operation_id}')
 

--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -475,6 +475,22 @@ class Operation(FirstClassObjectInterface, BaseObject):
         )
         await services.get('rest_svc').persist_source(dict(access=[self.access]), data)
 
+    async def refresh_agents(self, data_svc):
+        """Refresh the operation's agent list from data_svc to pick up newly connected agents.
+
+        Queries data_svc for agents matching the operation's group (or all agents if no group
+        is set) and appends any that are not already in the operation's agent list. Existing
+        agents are never removed or duplicated.
+        """
+        if self.group:
+            agents = await data_svc.locate('agents', match=dict(group=self.group))
+        else:
+            agents = await data_svc.locate('agents')
+        existing_paws = {a.paw for a in self.agents}
+        for agent in agents:
+            if agent.paw not in existing_paws:
+                self.agents.append(agent)
+
     async def update_operation_agents(self, services):
         self.agents = await services.get('rest_svc').construct_agents_for_group(self.group)
 

--- a/app/service/planning_svc.py
+++ b/app/service/planning_svc.py
@@ -130,6 +130,7 @@ class PlanningService(PlanningServiceInterface, BasePlanningService):
 
         while planner.next_bucket is not None and not (planner.stopping_condition_met and planner.stopping_conditions) \
                 and not await planner.operation.is_finished():
+            await planner.operation.refresh_agents(self.get_service('data_svc'))
             if publish_transitions:
                 await _publish_bucket_transition(planner.next_bucket)
             await getattr(planner, planner.next_bucket)()

--- a/tests/objects/test_operation.py
+++ b/tests/objects/test_operation.py
@@ -731,3 +731,59 @@ class TestOperation:
         assert seeded_rel.target.value == 's3cr3t', (
             'Relationship target fact value should be resolved from the source fact list, not None'
         )
+
+    # -- Tests for refresh_agents: pick up newly connected agents --
+
+    def test_refresh_agents_picks_up_new_agent(self, event_loop, agent, adversary):
+        """refresh_agents should add agents from data_svc that are not already in the operation."""
+        existing_agent = agent(sleep_min=30, sleep_max=60, watchdog=0, platform='windows',
+                               host='HOST1', username='user1', group='red', paw='paw1',
+                               executors=['psh'])
+        new_agent = agent(sleep_min=30, sleep_max=60, watchdog=0, platform='linux',
+                          host='HOST2', username='user2', group='red', paw='paw2',
+                          executors=['sh'])
+        op = Operation(name='test-refresh', agents=[existing_agent], adversary=adversary, group='red')
+
+        class FakeDataSvc:
+            async def locate(self, key, match=None):
+                if key == 'agents' and match and match.get('group') == 'red':
+                    return [existing_agent, new_agent]
+                return []
+
+        event_loop.run_until_complete(op.refresh_agents(FakeDataSvc()))
+        paws = [a.paw for a in op.agents]
+        assert 'paw1' in paws
+        assert 'paw2' in paws
+        assert len(op.agents) == 2
+
+    def test_refresh_agents_no_duplicates(self, event_loop, agent, adversary):
+        """refresh_agents should not duplicate agents that are already in the operation."""
+        existing_agent = agent(sleep_min=30, sleep_max=60, watchdog=0, platform='windows',
+                               host='HOST1', username='user1', group='red', paw='paw1',
+                               executors=['psh'])
+        op = Operation(name='test-no-dup', agents=[existing_agent], adversary=adversary, group='red')
+
+        class FakeDataSvc:
+            async def locate(self, key, match=None):
+                return [existing_agent]
+
+        event_loop.run_until_complete(op.refresh_agents(FakeDataSvc()))
+        assert len(op.agents) == 1
+        assert op.agents[0].paw == 'paw1'
+
+    def test_refresh_agents_no_group_returns_all(self, event_loop, agent, adversary):
+        """When operation has no group, refresh_agents should query all agents."""
+        agent1 = agent(sleep_min=30, sleep_max=60, watchdog=0, platform='windows',
+                       host='HOST1', username='user1', group='blue', paw='paw1',
+                       executors=['psh'])
+        op = Operation(name='test-no-group', agents=[], adversary=adversary, group=None)
+
+        class FakeDataSvc:
+            async def locate(self, key, match=None):
+                if key == 'agents' and match is None:
+                    return [agent1]
+                return []
+
+        event_loop.run_until_complete(op.refresh_agents(FakeDataSvc()))
+        assert len(op.agents) == 1
+        assert op.agents[0].paw == 'paw1'


### PR DESCRIPTION
## Summary
- Add `Operation.refresh_agents(data_svc)` method that queries data_svc for agents matching the operation's group and appends any new ones (without duplicating existing agents)
- Call `refresh_agents` in `OperationApiManager.get_operation_object()` so all API endpoints (GET operation, potential links, manual commands) return fresh agent data
- Call `refresh_agents` in `PlanningService.execute_planner()` before each bucket iteration so the automated planner picks up newly connected agents mid-operation

## Test plan
- [x] `test_refresh_agents_picks_up_new_agent` - verifies new agents matching the group are added
- [x] `test_refresh_agents_no_duplicates` - verifies existing agents are not duplicated
- [x] `test_refresh_agents_no_group_returns_all` - verifies ungrouped operations query all agents
- [ ] Manual: start an operation, connect a new agent to the same group, verify it appears in the operation's agent list via the API and in potential links