### PR TITLE
Fix async learning race condition & add link uniqueness check

### DIFF
--- a/app/objects/c_operation.py
+++ b/app/objects/c_operation.py
@@ -179,7 +179,9 @@ class Operation(FirstClassObjectInterface, BaseObject):
         self.chain.append(link)
 
     def has_link(self, link_id):
-        return any(lnk.id == link_id for lnk in self.potential_links + self.chain)
+        link_identifier = str(link_id)
+        return any(lnk.id == link_identifier or lnk.unique == link_identifier
+                   for lnk in self.potential_links + self.chain)
 
     def update_untrusted_agents(self, agent):
         if not agent.trusted and agent in self.agents:

--- a/app/service/contact_svc.py
+++ b/app/service/contact_svc.py
@@ -113,11 +113,9 @@ class ContactService(ContactServiceInterface, BaseService):
 
     async def _save(self, result):
         try:
-            loop = asyncio.get_event_loop()
             link = await self.get_service('app_svc').find_link(result.id)
             if link:
                 link.pid = int(result.pid)
-                link.finish = self.get_service('data_svc').get_current_timestamp()
                 link.status = int(result.status)
                 if result.agent_reported_time:
                     link.agent_reported_time = self.get_timestamp_from_string(result.agent_reported_time)
@@ -133,16 +131,16 @@ class ContactService(ContactServiceInterface, BaseService):
                     operation = await self.get_service('app_svc').find_op_with_link(result.id)
                     if not operation and not link.executor.parsers:
                         agent = await self.get_service('data_svc').locate('agents', dict(paw=link.paw))
-                        loop.create_task(self.get_service('learning_svc').learn(await agent[0].all_facts(), link,
-                                                                                result.output))
+                        await self.get_service('learning_svc').learn(await agent[0].all_facts(), link, result.output)
                     elif not operation:
-                        loop.create_task(link.parse(None, result.output))
+                        await link.parse(None, result.output)
                     elif link.executor.parsers:
-                        loop.create_task(link.parse(operation, result.output))
+                        await link.parse(operation, result.output)
                     elif operation.use_learning_parsers:
                         all_facts = await operation.all_facts()
-                        loop.create_task(self.get_service('learning_svc').learn(all_facts, link, result.output,
-                                                                                operation))
+                        await self.get_service('learning_svc').learn(all_facts, link, result.output, operation)
+                # Only mark the link finished once any parser/learning side effects are visible to the operation.
+                link.finish = self.get_service('data_svc').get_current_timestamp()
             else:
                 command_results = json.dumps(dict(
                     stdout=self.decode_bytes(result.output, strip_newlines=False),

--- a/tests/services/test_contact_svc.py
+++ b/tests/services/test_contact_svc.py
@@ -1,6 +1,8 @@
 import base64
 import json
 import os
+import asyncio
+import uuid
 import pytest
 
 from app.service.rest_svc import RestService
@@ -18,31 +20,48 @@ class TestProcessor:
 
 
 @pytest.fixture
-def setup_contact_service(event_loop, data_svc, agent, ability, operation, link, adversary):
+async def setup_contact_service(data_svc, agent, ability, operation, link, adversary):
     texecutor = Executor(name='special_executor', platform='darwin', command='whoami', payloads=['wifi.sh'])
     tability = ability(tactic='discovery', technique_id='T1033', technique_name='Find', name='test',
                        description='find active user', privilege=None, executors=[texecutor])
     tability.HOOKS['special_executor'] = TestProcessor()
-    event_loop.run_until_complete(data_svc.store(tability))
+    await data_svc.store(tability)
     tagent = agent(sleep_min=10, sleep_max=60, watchdog=0, executors=['special_executor'])
-    event_loop.run_until_complete(data_svc.store(tagent))
+    await data_svc.store(tagent)
     toperation = operation(name='sample', agents=[tagent], adversary=adversary())
     tlink = link(command='', paw=tagent.paw, ability=tability, id='5212fca4-6544-49ce-a78d-a95d30e95705',
                  executor=texecutor)
-    event_loop.run_until_complete(toperation.apply(tlink))
-    event_loop.run_until_complete(data_svc.store(toperation))
+    await toperation.apply(tlink)
+    await data_svc.store(toperation)
     yield tlink
+
+
+@pytest.fixture
+async def setup_learning_contact_service(data_svc, agent, ability, operation, link, adversary):
+    texecutor = Executor(name='psh', platform='windows', command='whoami')
+    tability = ability(tactic='discovery', technique_id='T1033', technique_name='Find', name='learn-test',
+                       description='learn active host data', privilege=None, executors=[texecutor])
+    await data_svc.store(tability)
+    tagent = agent(sleep_min=10, sleep_max=60, watchdog=0, platform='windows', executors=['psh'])
+    await data_svc.store(tagent)
+    toperation = operation(name='sample-learning', agents=[tagent], adversary=adversary(), use_learning_parsers=True)
+    tlink = link(command='', paw=tagent.paw, ability=tability, id=str(uuid.uuid4()),
+                 executor=texecutor)
+    await toperation.apply(tlink)
+    await data_svc.store(toperation)
+    yield toperation, tlink
 
 
 @pytest.mark.usefixtures(
     'app_svc',
     'data_svc',
     'file_svc',
+    'knowledge_svc',
     'learning_svc',
-    'obfuscator'
+    'fire_event_mock'
 )
 class TestContactSvc:
-    async def test_save_ability_hooks(self, setup_contact_service, contact_svc, event_svc):
+    async def test_save_ability_hooks(self, setup_contact_service, contact_svc):
         test_string = b'test_string'
         err_string = b'err_string'
         test_exit_code = "-1"
@@ -70,7 +89,7 @@ class TestContactSvc:
         except FileNotFoundError:
             print('Unable to cleanup test_save_ability_hooks result file')
 
-    async def test_save_ability_hooks_with_no_link(self, setup_contact_service, contact_svc, event_svc, file_svc):
+    async def test_save_ability_hooks_with_no_link(self, setup_contact_service, contact_svc, file_svc):
         test_string = b'test_string'
         err_string = b'err_string'
         test_exit_code = "0"
@@ -97,3 +116,63 @@ class TestContactSvc:
             os.remove(os.path.join('data', 'results', '12345'))
         except FileNotFoundError:
             print('Unable to cleanup test_save_ability_hooks_with_no_link result files')
+
+    async def test_save_result_with_unique_id_updates_operation_facts(self, setup_learning_contact_service,
+                                                                      contact_svc):
+        operation, link = setup_learning_contact_service
+        result = Result(
+            id=link.unique,
+            output=str(base64.b64encode('10.10.10.10'.encode('utf-8')), 'utf-8'),
+            pid=0,
+            status=0
+        )
+
+        await contact_svc._save(result)
+
+        learned_facts = await operation.all_facts()
+        assert len(learned_facts) == 1
+        assert learned_facts[0].trait == 'host.ip.address'
+        assert learned_facts[0].value == '10.10.10.10'
+
+        try:
+            os.remove(os.path.join('data', 'results', link.unique))
+        except FileNotFoundError:
+            print('Unable to cleanup test_save_result_with_unique_id_updates_operation_facts result file')
+
+    async def test_save_waits_for_learning_before_marking_link_finished(self, setup_learning_contact_service,
+                                                                        contact_svc, mocker):
+        operation, link = setup_learning_contact_service
+        learning_started = asyncio.Event()
+        allow_learning_to_finish = asyncio.Event()
+        learning_svc = contact_svc.get_service('learning_svc')
+        app_svc = contact_svc.get_service('app_svc')
+
+        async def slow_learn(*args, **kwargs):
+            learning_started.set()
+            await allow_learning_to_finish.wait()
+
+        patched_learn = mocker.AsyncMock(side_effect=slow_learn)
+        with mocker.patch.object(learning_svc, 'learn', new=patched_learn):
+            save_task = asyncio.create_task(contact_svc._save(Result(
+                id=link.unique,
+                output=str(base64.b64encode('10.10.10.10'.encode('utf-8')), 'utf-8'),
+                pid=0,
+                status=0
+            )))
+
+            await asyncio.wait_for(learning_started.wait(), timeout=2)
+            saved_link = await app_svc.find_link(link.unique)
+            assert not save_task.done()
+            assert saved_link.finish is None
+
+            allow_learning_to_finish.set()
+            await asyncio.wait_for(save_task, timeout=2)
+
+        assert patched_learn.await_count == 1
+        saved_link = await app_svc.find_link(link.unique)
+        assert saved_link.finish is not None
+
+        try:
+            os.remove(os.path.join('data', 'results', link.unique))
+        except FileNotFoundError:
+            print('Unable to cleanup test_save_waits_for_learning_before_marking_link_finished result file')


### PR DESCRIPTION
Separated PR addressing two core execution path issues:\n1. Fixes an asynchronous race condition within the learning service parsing links in `contact_svc.py`.\n2. Adds explicit `link.unique` string identifier boundaries to the owning operation lookup in `c_operation.py`.\n\nThese fixes are thoroughly unit tested under `test_contact_svc.py` to guarantee Quality Code coverage.