### PR TITLE
ci: fix Security Checks by adding .safety-policy.yml

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,6 @@
+# Safety policy file for `safety check`.
+# Required by safety 3.x — the CLI looks for this file in cwd even when
+# --ignore is passed inline. Ignores are kept on the tox command line
+# (see tox.ini [testenv:safety]) so they stay visible in CI output.
+security:
+    ignore-vulnerabilities: {}

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,8 @@ deps =
 skip_install = true
 whitelist_externals=find
 commands =
-    safety check -r requirements.txt --ignore 39642 --ignore 39659
-    safety check -r requirements-dev.txt
+    safety check -r requirements.txt --policy-file .safety-policy.yml --ignore 39642 --ignore 39659
+    safety check -r requirements-dev.txt --policy-file .safety-policy.yml
 
 [testenv:bandit]
 deps =


### PR DESCRIPTION
Security Checks is failing on master (run [26038577932](https://github.com/mitre/caldera/actions/runs/26038577932)) with 'Invalid value for --policy-file: Policy file YAML is not valid / No such file or directory: .safety-policy.yml'.

The safety 3.x CLI auto-looks for a .safety-policy.yml in cwd even when --ignore is passed inline. Without the file, safety check errors out before running. This affects every Python minor on the matrix.

**Fix:** Add an empty .safety-policy.yml at repo root to satisfy the auto-lookup, and pass --policy-file explicitly in [testenv:safety]. The existing 39642 / 39659 ignores stay on the CLI so they remain visible in workflow output.

**Test:** Local 'python3 -m tox -e safety' no longer errors at the policy-file check (it gets past that step and then fails on a downstream network call, which works on GHA runners).

**Followup (separate PR):** 'safety check' is deprecated as of 2024-06 in favor of 'safety scan'.