### PR TITLE
ci: swap safety check for pip-audit (PyPA, no API key)

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,6 +1,0 @@
-# Safety policy file for `safety check`.
-# Required by safety 3.x — the CLI looks for this file in cwd even when
-# --ignore is passed inline. Ignores are kept on the tox command line
-# (see tox.ini [testenv:safety]) so they stay visible in CI output.
-security:
-    ignore-vulnerabilities: {}

--- a/tox.ini
+++ b/tox.ini
@@ -54,16 +54,23 @@ commands =
     coverage report
 
 [testenv:safety]
-# Safety ignore list:
-# 39642: reportlab vuln resolved in https://github.com/mitre/debrief/pull/39
-# 39659: aiohttp cannot be upgraded to 3.7.4: https://github.com/mitre/caldera/pull/2062
+# Dependency vulnerability scan. Env name kept as "safety" so branch
+# protection contexts (`build (3.13, safety)`) don't need a coordinated
+# update; underlying tool is pip-audit (PyPA, no API key, free).
+#
+# `safety check` was deprecated 2024-06; the pyup.io account/scan
+# replacement was not worth the new secret + auth integration when
+# Dependabot, GitGuardian, and SonarCloud already cover supply chain.
+#
+# Legacy pyup ignores (39642 reportlab, 39659 aiohttp) are obsolete
+# now that aiohttp>=3.13 and reportlab>=4.0 are pinned. Add
+# `--ignore-vuln GHSA-...` here if a real exemption is needed later.
 deps =
-    safety
+    pip-audit
 skip_install = true
-whitelist_externals=find
 commands =
-    safety check -r requirements.txt --policy-file .safety-policy.yml --ignore 39642 --ignore 39659
-    safety check -r requirements-dev.txt --policy-file .safety-policy.yml
+    pip-audit -r requirements.txt
+    pip-audit -r requirements-dev.txt
 
 [testenv:bandit]
 deps =


### PR DESCRIPTION
## Why

`safety check` was deprecated 2024-06 (see warning banner on every CI run since). `safety scan` is the replacement but requires a pyup.io API key + a new GitHub Actions secret to manage, in exchange for one more layer of supply-chain scanning on top of what Dependabot + GitGuardian + SonarCloud already cover.

`pip-audit` (PyPA's official tool) gives the same Python dependency coverage as a zero-auth drop-in.

## What

- `[testenv:safety]` now installs `pip-audit` and runs `pip-audit -r requirements.txt` / `-r requirements-dev.txt`.
- `.safety-policy.yml` deleted (was only needed to work around the safety 3.x auto-lookup bug).
- Legacy pyup ignore IDs removed: 39642 was a reportlab vuln long fixed by the current `reportlab==4.0.4` pin; 39659 was an aiohttp <3.7.4 issue, and we're on aiohttp==3.13.4.
- Env name `safety` kept intact so branch-protection contexts (`build (3.13, safety)`) don't need a coordinated update. A follow-up PR can rename to `audit` + update the required check at the same time.

## Test

Local `python3 -m tox -e safety` (now pip-audit under the hood):
```
No known vulnerabilities found
  safety: OK (69.04s)
```

Both requirements files come back clean.

## Followups (not in this PR)

- Rename `[testenv:safety]` → `[testenv:audit]` + update branch protection to expect `build (3.13, audit)` (paired change).
- Consider adding `pip-audit --strict` once we're confident in the noise level.