### PR TITLE
security(ci): pin SonarSource/sonarqube-scan-action to commit SHA (defense against mutable-tag supply-chain)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: SonarQube Scan
         if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
-        uses: SonarSource/sonarqube-scan-action@v6.0.0
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-fork-pr.yml
+++ b/.github/workflows/sonar-fork-pr.yml
@@ -138,7 +138,7 @@ jobs:
           fi
 
       - name: SonarQube Scan (fork PR, trusted base)
-        uses: SonarSource/sonarqube-scan-action@v6.0.0
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

\`SonarSource/sonarqube-scan-action@v6.0.0\` was referenced by mutable tag in two workflows that hold \`SONAR_TOKEN\` (and, for \`quality.yml\`, \`GITHUB_TOKEN\` too):

- \`.github/workflows/quality.yml\` — push + non-fork pull_request scans
- \`.github/workflows/sonar-fork-pr.yml\` — workflow_run handler for fork PRs (added in #3376)

Tags are mutable. If SonarSource's org/account were ever compromised, an attacker could force-push \`v6.0.0\` to a malicious commit and exfiltrate \`SONAR_TOKEN\` on the next CI run, **without a single line hitting our tree**. This is exactly the supply-chain class GitHub recommends pinning by SHA to defend against.

## Fix

Both call sites now reference the current \`v6.0.0\` commit by SHA:

\`\`\`yaml
uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
\`\`\`

Matches the SHA-pinning style already used in this repo for \`actions/checkout\`, \`actions/setup-python\`, \`actions/setup-node\`, \`actions/upload-artifact\`, \`actions/download-artifact\`, and \`github/codeql-action\`. Dependabot's GitHub-Actions ecosystem will keep the SHA + tag-comment up to date going forward.

## Test plan

- [ ] CI: \`Code Quality\` workflow runs and the \`SonarQube Scan\` step succeeds (same scan behavior as before — only the action's resolution method changes).
- [ ] On the next fork PR, \`SonarQube Scan (Fork PR)\` (sonar-fork-pr.yml) still triggers via \`workflow_run\` and produces a SonarCloud analysis.

## Refs

- GitHub guidance — Security hardening for GitHub Actions: <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>
- Reported externally on 2026-05-18 alongside the broader CI security pass.