### PR TITLE
build(deps): bump setuptools to 83.0.0 and pyasn1 to 0.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ marshmallow==3.26.2
 dirhash==0.2.1
 marshmallow-enum==1.5.1
 ldap3==2.9.1
-pyasn1==0.6.3
+pyasn1==0.6.4
 reportlab==4.0.4  # debrief
 rich==13.7.0
 lxml==6.1.0  # debrief
@@ -26,4 +26,4 @@ asyncssh==2.20.0
 aioftp==0.27.2
 packaging==23.2
 croniter~=3.0.3
-setuptools==78.1.1
+setuptools==83.0.0


### PR DESCRIPTION
## Summary

Fixes the failing `Security Checks / build (3.13, safety)` gate (tox `safety` env → `pip-audit -r requirements.txt`), which currently blocks every open PR:

- **setuptools 78.1.1 → 83.0.0** — PYSEC-2026-3447 / CVE-2026-59890 (GHSA-h35f-9h28-mq5c): `FileList` applies `MANIFEST.in` exclude/prune directives without Unicode normalization, so on macOS APFS/HFS+ an NFD filename can bypass an NFC exclusion rule and be packed into an sdist. Fixed in 83.0.0.
- **pyasn1 0.6.3 → 0.6.4** — PYSEC-2026-3455 / PYSEC-2026-3456 / PYSEC-2026-3457 (published after this repo's last CI runs): BER/CER/DER decoder resource-exhaustion issues. Fixed in 0.6.4. (`pyasn1` is consumed via `ldap3`.)

Bumping setuptools alone still fails the gate — the pyasn1 advisories landed after 2026-07-20, so both bumps are required for a green run.

## Verification

- `pip-audit -r requirements.txt` (pip-audit 2.10.1, same as CI) → exit 0, "No known vulnerabilities found"
- setuptools 83.0.0 `requires_python >=3.10` and pyasn1 0.6.4 `>=3.8` — both cover the supported 3.10–3.13 matrix
- No `pkg_resources` / `setuptools` / direct `pyasn1` imports in first-party code; `requirements.txt` is the only place either version is stated
- Fresh-venv install of the full requirements set + test suite run (details in review artifacts)
