### PR TITLE
ci: skip SonarQube scan on Dependabot PR runs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,7 +59,10 @@ jobs:
         run: tox
 
       - name: SonarQube Scan
-        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
+        # Dependabot-authored PR runs receive no repository secrets, so SONAR_TOKEN is
+        # empty and the scan can only fail; skip it there. The merged result is still
+        # scanned by the push-event run on master.
+        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]') }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e  # v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Gates the `SonarQube Scan` step in Code Quality so it is skipped on Dependabot-authored PR runs, where it can only fail.

## Problem

Every Dependabot PR now fails all four `build (3.x, ...style,coverage-ci)` legs at the SonarQube step with `Not authorized` / exit 3 — see #3402, where the test phase itself passed 562/562 on all four Python versions. The action's log shows `SONAR_TOKEN:` empty.

**Root cause:** GitHub supplies Dependabot-triggered workflow runs with secrets from the separate *Dependabot secrets* store, not the Actions store. That secret did not survive the repository transfer — Dependabot PR #3399 passed these same legs on 2026-07-08 with an unchanged workflow, and #3402 fails them today. The Actions-scope `SONAR_TOKEN` still works, so pushes and human PRs are unaffected.

## Fix

Add `github.actor != 'dependabot[bot]'` to the step's existing condition. Chosen over alternatives:

- A token-presence gate (`env.SONAR_TOKEN != ''`) would require lifting the secret to job-level env, widening the exposure that #3376 deliberately narrowed to step scope.
- Routing Dependabot PRs through the trusted `sonar-fork-pr.yml` path doesn't work — it hard-gates on `head_repository.fork == true` and Dependabot branches live in this repo.

Coverage is not lost: the merged result is still analyzed by the push-event run on master.

## Follow-up (out of scope)

Restoring analysis parity for Dependabot PRs requires adding `SONAR_TOKEN` to this repo's **Dependabot secrets** (admin / Infra). If that is done, this guard clause can be reverted. `sonar-project.properties` also still binds to the pre-transfer `mitre` SonarCloud organization, which maintainers may want to revisit.
